### PR TITLE
Initial draft to store users persistently using oneffs

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -17,6 +17,7 @@ let mollymawk =
       package "mirage-crypto-rng";
       package "uuidm";
       package "paf" ~sublibs:[ "mirage" ] ~min:"0.5.0";
+      package "oneffs" ;
     ]
   and runtime_args =
     [
@@ -26,7 +27,9 @@ let mollymawk =
   in
   main ~runtime_args ~packages "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> kv_ro @-> kv_ro
-   @-> job)
+   @-> block @-> job)
+
+let block = block_of_file "data"
 
 let () =
   register "mollymawk"
@@ -34,5 +37,5 @@ let () =
       mollymawk $ default_random $ default_posix_clock $ default_monotonic_clock
       $ default_time
       $ generic_stackv4v6 default_network
-      $ data $ assets;
+      $ data $ assets $ block;
     ]

--- a/config.ml
+++ b/config.ml
@@ -17,7 +17,7 @@ let mollymawk =
       package "mirage-crypto-rng";
       package "uuidm";
       package "paf" ~sublibs:[ "mirage" ] ~min:"0.5.0";
-      package "oneffs" ;
+      package "oneffs";
     ]
   and runtime_args =
     [

--- a/storage.ml
+++ b/storage.ml
@@ -1,7 +1,4 @@
-type t = {
-  version : int ;
-  users : User_model.user list ;
-}
+type t = { version : int; users : User_model.user list }
 
 let current_version = 1
 
@@ -11,33 +8,37 @@ let get key assoc =
   | Some (_, f) -> Some f
 
 let t_to_json t =
-  `Assoc [ ("version", `Int t.version ) ; ("users", `List (List.map User_model.user_to_json t.users)) ]
+  `Assoc
+    [
+      ("version", `Int t.version);
+      ("users", `List (List.map User_model.user_to_json t.users));
+    ]
 
 let t_of_json = function
-  | `Assoc xs ->
-    begin
+  | `Assoc xs -> (
       let ( let* ) = Result.bind in
-      match get "version" xs, get "users" xs with
-      | Some `Int v, Some `List xs ->
-        let* () =
-          if v = current_version then Ok () else
-            Error (`Msg "can't decode version")
-        in
-        let* users = List.fold_left (fun acc js ->
-            let* acc = acc in
-            let* user = User_model.user_of_json js in
-            Ok (user :: acc))
-            (Ok []) xs
-        in
-        Ok { version = v ; users }
-      | _ -> Error (`Msg "invalid data: no version and users field")
-    end
+      match (get "version" xs, get "users" xs) with
+      | Some (`Int v), Some (`List xs) ->
+          let* () =
+            if v = current_version then Ok ()
+            else Error (`Msg "can't decode version")
+          in
+          let* users =
+            List.fold_left
+              (fun acc js ->
+                let* acc = acc in
+                let* user = User_model.user_of_json js in
+                Ok (user :: acc))
+              (Ok []) xs
+          in
+          Ok { version = v; users }
+      | _ -> Error (`Msg "invalid data: no version and users field"))
   | _ -> Error (`Msg "invalid data: not an assoc")
 
 let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
 
 module Make (BLOCK : Mirage_block.S) = struct
-  module Stored_data = OneFFS.Make(BLOCK)
+  module Stored_data = OneFFS.Make (BLOCK)
 
   type store = t * BLOCK.t
 
@@ -48,22 +49,23 @@ module Make (BLOCK : Mirage_block.S) = struct
 
   let read_data disk =
     Stored_data.read disk >|= function
-    | Ok Some s ->
-      let ( let* ) = Result.bind in
-      let* json =
-        try Ok (Yojson.Basic.from_string s) with
-          Yojson.Json_error msg -> Error (`Msg ("Invalid json: " ^ msg))
-      in
-      let* t = t_of_json json in
-      Ok (disk, t)
-    | Ok None -> Ok (disk, { version = current_version ; users = [] })
+    | Ok (Some s) ->
+        let ( let* ) = Result.bind in
+        let* json =
+          try Ok (Yojson.Basic.from_string s)
+          with Yojson.Json_error msg -> Error (`Msg ("Invalid json: " ^ msg))
+        in
+        let* t = t_of_json json in
+        Ok (disk, t)
+    | Ok None -> Ok (disk, { version = current_version; users = [] })
     | Error e ->
-      error_msgf "error while reading storage: %a" Stored_data.pp_error e
+        error_msgf "error while reading storage: %a" Stored_data.pp_error e
 
   let add_user (disk, t) user =
     let t = { t with users = user :: t.users } in
     write_data (disk, t) >|= function
     | Ok () -> Ok (disk, t)
     | Error we ->
-      error_msgf "erro while writing storage: %a" Stored_data.pp_write_error we
+        error_msgf "erro while writing storage: %a" Stored_data.pp_write_error
+          we
 end

--- a/storage.ml
+++ b/storage.ml
@@ -1,0 +1,69 @@
+type t = {
+  version : int ;
+  users : User_model.user list ;
+}
+
+let current_version = 1
+
+let get key assoc =
+  match List.find_opt (fun (k, _) -> String.equal k key) assoc with
+  | None -> None
+  | Some (_, f) -> Some f
+
+let t_to_json t =
+  `Assoc [ ("version", `Int t.version ) ; ("users", `List (List.map User_model.user_to_json t.users)) ]
+
+let t_of_json = function
+  | `Assoc xs ->
+    begin
+      let ( let* ) = Result.bind in
+      match get "version" xs, get "users" xs with
+      | Some `Int v, Some `List xs ->
+        let* () =
+          if v = current_version then Ok () else
+            Error (`Msg "can't decode version")
+        in
+        let* users = List.fold_left (fun acc js ->
+            let* acc = acc in
+            let* user = User_model.user_of_json js in
+            Ok (user :: acc))
+            (Ok []) xs
+        in
+        Ok { version = v ; users }
+      | _ -> Error (`Msg "invalid data: no version and users field")
+    end
+  | _ -> Error (`Msg "invalid data: not an assoc")
+
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+module Make (BLOCK : Mirage_block.S) = struct
+  module Stored_data = OneFFS.Make(BLOCK)
+
+  type store = t * BLOCK.t
+
+  open Lwt.Infix
+
+  let write_data (disk, t) =
+    Stored_data.write disk (Yojson.Basic.to_string (t_to_json t))
+
+  let read_data disk =
+    Stored_data.read disk >|= function
+    | Ok Some s ->
+      let ( let* ) = Result.bind in
+      let* json =
+        try Ok (Yojson.Basic.from_string s) with
+          Yojson.Json_error msg -> Error (`Msg ("Invalid json: " ^ msg))
+      in
+      let* t = t_of_json json in
+      Ok (disk, t)
+    | Ok None -> Ok (disk, { version = current_version ; users = [] })
+    | Error e ->
+      error_msgf "error while reading storage: %a" Stored_data.pp_error e
+
+  let add_user (disk, t) user =
+    let t = { t with users = user :: t.users } in
+    write_data (disk, t) >|= function
+    | Ok () -> Ok (disk, t)
+    | Error we ->
+      error_msgf "erro while writing storage: %a" Stored_data.pp_write_error we
+end

--- a/storage.ml
+++ b/storage.ml
@@ -66,6 +66,6 @@ module Make (BLOCK : Mirage_block.S) = struct
     write_data (disk, t) >|= function
     | Ok () -> Ok (disk, t)
     | Error we ->
-        error_msgf "erro while writing storage: %a" Stored_data.pp_write_error
+        error_msgf "error while writing storage: %a" Stored_data.pp_write_error
           we
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -33,7 +33,8 @@ module Main
     (T : Mirage_time.S)
     (S : Tcpip.Stack.V4V6)
     (KV : Mirage_kv.RO)
-    (KV_ASSETS : Mirage_kv.RO) =
+    (KV_ASSETS : Mirage_kv.RO)
+    (BLOCK : Mirage_block.S) =
 struct
   module Paf = Paf_mirage.Make (S.TCP)
 
@@ -95,6 +96,8 @@ struct
     KV_ASSETS.get assets (Mirage_kv.Key.v "create_unikernel.html") >|= function
     | Error _e -> invalid_arg "Form could not be loaded"
     | Ok html -> html
+
+  module Store = Storage.Make(BLOCK)
 
   module TLS = Tls_mirage.Make (S.TCP)
 
@@ -322,7 +325,7 @@ struct
     in
     go (Map.empty, []) m
 
-  let request_handler stack credentials remote js_file css_file imgs html
+  let request_handler stack credentials remote js_file css_file imgs html store
       (_ipaddr, _port) reqd =
     Lwt.async (fun () ->
         let reply ?(content_type = "text/plain") data =
@@ -491,15 +494,21 @@ struct
                         let user =
                           User_model.create_user ~name ~email ~password
                         in
-                        let res =
-                          "{\"status\": 200, \"success\": true, \"message\": \
-                           {\"user\": "
-                          ^ Yojson.Basic.to_string
+                        Store.add_user !store user >>= function
+                        | Ok store' ->
+                          store := store';
+                          let res =
+                            "{\"status\": 200, \"success\": true, \"message\": \
+                             {\"user\": "
+                            ^ Yojson.Basic.to_string
                               (User_model.user_to_json user)
-                          ^ "}}"
-                        in
-                        Lwt.return (reply ~content_type:"application/json" res))
-                )
+                            ^ "}}"
+                          in
+                          Lwt.return (reply ~content_type:"application/json" res)
+                        | Error `Msg msg ->
+                          Lwt.return (reply ~content_type:"text/plain" "Error while writing to storage")
+
+                  ))
             | _ ->
                 let res =
                   "{\"status\": 400, \"success\": false, \"message\": \"Bad \
@@ -649,21 +658,26 @@ struct
           Fmt.(option ~none:(any "unknown") Httpaf.Request.pp_hum)
           request)
 
-  let start _ _ _ _ stack data assets host port =
+  let start _ _ _ _ stack data assets storage host port =
     js_contents assets >>= fun js_file ->
     css_contents assets >>= fun css_file ->
     images assets >>= fun imgs ->
     create_html_form assets >>= fun html ->
     retrieve_credentials data >>= fun credentials ->
-    let remote = (host, port) in
-    let port = 8080 in
-    Logs.info (fun m ->
-        m "Initialise an HTTP server (no HTTPS) on http://127.0.0.1:%u/" port);
-    let request_handler _flow =
-      request_handler stack credentials remote js_file css_file imgs html
-    in
-    Paf.init ~port:8080 (S.tcp stack) >>= fun service ->
-    let http = Paf.http_service ~error_handler request_handler in
-    let (`Initialized th) = Paf.serve http service in
-    th
+    Store.Stored_data.connect storage >>= fun stored_data ->
+    Store.read_data stored_data >>= function
+    | Error `Msg msg -> failwith msg
+    | Ok data ->
+      let store = ref data in
+      let remote = (host, port) in
+      let port = 8080 in
+      Logs.info (fun m ->
+          m "Initialise an HTTP server (no HTTPS) on http://127.0.0.1:%u/" port);
+      let request_handler _flow =
+        request_handler stack credentials remote js_file css_file imgs html store
+      in
+      Paf.init ~port:8080 (S.tcp stack) >>= fun service ->
+      let http = Paf.http_service ~error_handler request_handler in
+      let (`Initialized th) = Paf.serve http service in
+      th
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -506,10 +506,13 @@ struct
                             Lwt.return
                               (reply ~content_type:"application/json" res)
                         | Error (`Msg msg) ->
-                   let res =
-                  "{\"status\": 400, \"success\": false, \"message\": \"Something went wrong. Wait a few seconds and try again.\"}"
-                in
-                Lwt.return (reply ~content_type:"application/json" res))))
+                            let res =
+                              "{\"status\": 400, \"success\": false, \
+                               \"message\": \"Something went wrong. Wait a few \
+                               seconds and try again.\"}"
+                            in
+                            Lwt.return
+                              (reply ~content_type:"application/json" res))))
             | _ ->
                 let res =
                   "{\"status\": 400, \"success\": false, \"message\": \"Bad \

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -506,9 +506,10 @@ struct
                             Lwt.return
                               (reply ~content_type:"application/json" res)
                         | Error (`Msg msg) ->
-                            Lwt.return
-                              (reply ~content_type:"text/plain"
-                                 "Error while writing to storage"))))
+                   let res =
+                  "{\"status\": 400, \"success\": false, \"message\": \"Something went wrong. Wait a few seconds and try again.\"}"
+                in
+                Lwt.return (reply ~content_type:"application/json" res))))
             | _ ->
                 let res =
                   "{\"status\": 400, \"success\": false, \"message\": \"Bad \


### PR DESCRIPTION
//cc @PizieDust

The assumption is: we can retain the stuff in memory. We write to disk on change (at the moment, whenever a new user is created). We keep a reference to the latest store in unikernel.ml (request_handler) - thus we can extract data from `!store`.

We read the store only once at startup (since later we know about each change and don't need to read again).

Obviously we can have more data (and more types) in there ;)