### PR TITLE
Csrf tokens

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -83,6 +83,7 @@ async function saveConfig() {
 	const pkeyInput = document.getElementById("private-key").value;
 	const formAlert = document.getElementById("form-alert");
 	const formButton = document.getElementById('config-button');
+	const molly_csrf = document.getElementById("molly-csrf").value.trim();
 	formButton.classList.add("disabled");
 	formButton.innerHTML = `<i class="fa-solid fa-spinner animate-spin"></i>`
 	if (ipInput === '' || portInput === '' || certificateInput === '' || pkeyInput === '') {
@@ -96,7 +97,13 @@ async function saveConfig() {
 				headers: {
 					"Content-Type": "application/json",
 				},
-				body: JSON.stringify({ "server_ip": ipInput, "server_port": Number(portInput), "certificate": certificateInput, "private_key": pkeyInput })
+				body: JSON.stringify({
+					"server_ip": ipInput,
+					"server_port": Number(portInput),
+					"certificate": certificateInput,
+					"private_key": pkeyInput,
+					"molly_csrf": molly_csrf
+				})
 			})
 			const data = await response.json();
 			if (data.status === 200) {
@@ -146,6 +153,7 @@ async function deployUnikernel() {
 	const name = document.getElementById("unikernel-name").value.trim();
 	const arguments = document.getElementById("unikernel-arguments").value.trim();
 	const binary = document.getElementById("unikernel-binary").files[0];
+	const molly_csrf = document.getElementById("molly-csrf").value.trim();
 	const formAlert = document.getElementById("form-alert");
 	if (!name || !binary) {
 		formAlert.classList.remove("hidden", "text-primary-500");
@@ -158,6 +166,7 @@ async function deployUnikernel() {
 		formData.append("name", name);
 		formData.append("binary", binary)
 		formData.append("arguments", arguments)
+		formData.append("molly_csrf", molly_csrf)
 		try {
 			const response = await fetch("/unikernel/create", {
 				method: 'POST',
@@ -191,10 +200,13 @@ async function deployUnikernel() {
 
 async function destroyUnikernel(name) {
 	try {
+		const molly_csrf = document.getElementById("molly-csrf").value.trim();
 		const response = await fetch(`/unikernel/destroy/${name}`, {
-			method: 'GET',
-			mode: "no-cors"
+			method: 'POST',
+			body: JSON.stringify({ "name": name, "molly_csrf": molly_csrf }),
+			headers: { 'Content-Type': 'application/json' }
 		})
+
 		const data = await response.json();
 		if (data.status === 200) {
 			postAlert("bg-primary-300", `Successful: ${data.data}`);
@@ -225,9 +237,10 @@ function buttonLoading(btn, load, text) {
 
 async function toggleUserStatus(uuid, endpoint) {
 	try {
+		const molly_csrf = document.getElementById("molly-csrf").value.trim();
 		const response = await fetch(endpoint, {
 			method: 'POST',
-			body: JSON.stringify({ uuid: uuid }),
+			body: JSON.stringify({ uuid, molly_csrf }),
 			headers: { 'Content-Type': 'application/json' }
 		});
 
@@ -282,6 +295,7 @@ async function updatePolicy() {
 	const formAlert = document.getElementById("form-alert");
 	const user_id = document.getElementById("user_id").innerText;
 	const policyButton = document.getElementById("set-policy-btn");
+	const molly_csrf = document.getElementById("molly-csrf").value.trim();
 	try {
 		buttonLoading(policyButton, true, "Processing...")
 		const response = await fetch("/api/admin/u/policy/update", {
@@ -296,7 +310,8 @@ async function updatePolicy() {
 					"block": Number(storage_size),
 					"cpuids": cpuids,
 					"bridges": bridges,
-					"user_uuid": user_id
+					"user_uuid": user_id,
+					"molly_csrf": molly_csrf
 				})
 		})
 		const data = await response.json();

--- a/assets/main.js
+++ b/assets/main.js
@@ -85,7 +85,8 @@ async function saveConfig() {
 	const formButton = document.getElementById('config-button');
 	const molly_csrf = document.getElementById("molly-csrf").value.trim();
 	formButton.classList.add("disabled");
-	formButton.innerHTML = `<i class="fa-solid fa-spinner animate-spin"></i>`
+	formButton.innerHTML = `Processing <i class="fa-solid fa-spinner animate-spin text-primary-800"></i>`
+	formButton.disabled = true;
 	if (ipInput === '' || portInput === '' || certificateInput === '' || pkeyInput === '') {
 		formAlert.classList.remove("hidden");
 		formAlert.classList.add("text-secondary-500");
@@ -126,6 +127,7 @@ async function saveConfig() {
 		}
 	}
 	formButton.innerHTML = "Update"
+	formButton.disabled = false;
 }
 
 function closeBanner() {

--- a/middleware.ml
+++ b/middleware.ml
@@ -1,7 +1,13 @@
 type handler = Httpaf.Reqd.t -> unit Lwt.t
 type middleware = handler -> handler
 
-let has_session_cookie (reqd : Httpaf.Reqd.t) =
+let get_csrf now =
+  User_model.(
+    generate_cookie ~name:"molly_csrf"
+      ~uuid:(Uuidm.to_string (generate_uuid ()))
+      ~created_at:now ~expires_in:3600)
+
+let has_cookie cookie_name (reqd : Httpaf.Reqd.t) =
   let headers = (Httpaf.Reqd.request reqd).headers in
   match Httpaf.Headers.get headers "Cookie" with
   | Some cookies ->
@@ -10,7 +16,7 @@ let has_session_cookie (reqd : Httpaf.Reqd.t) =
         (fun cookie ->
           let parts = String.trim cookie |> String.split_on_char '=' in
           match parts with
-          | [ name; _ ] -> String.equal name "molly_session"
+          | [ name; _ ] -> String.equal name cookie_name
           | _ -> false)
         cookie_list
   | _ -> None
@@ -92,6 +98,14 @@ let redirect_to_dashboard reqd ?(msg = "") () =
   Httpaf.Reqd.respond_with_string reqd response msg;
   Lwt.return_unit
 
+let redirect_to_same_page reqd ?(msg = "") () =
+  let request = Httpaf.Reqd.request reqd in
+  let current_path = request.target in
+  let headers = Httpaf.Headers.of_list [ ("location", current_path) ] in
+  let response = Httpaf.Response.create ~headers `Found in
+  Httpaf.Reqd.respond_with_string reqd response msg;
+  Lwt.return_unit
+
 let cookie_value_from_auth_cookie cookie =
   match String.split_on_char '=' (String.trim cookie) with
   | _ :: s :: _ -> Ok (String.trim s)
@@ -108,7 +122,7 @@ let user_from_auth_cookie cookie users =
       Error (`Msg s)
 
 let user_of_cookie users now reqd =
-  match has_session_cookie reqd with
+  match has_cookie "molly_session" reqd with
   | Some auth_cookie -> (
       match user_from_auth_cookie auth_cookie users with
       | Ok user -> (
@@ -161,3 +175,39 @@ let is_user_admin_middleware api_meth now users handler reqd =
             "You don't have the necessary permissions to access this service."
           `Unauthorized user 401 api_meth reqd ()
   | Error (`Msg msg) -> redirect_to_login ~msg reqd ()
+
+let csrf_match ~input_csrf ~check_csrf = String.equal input_csrf check_csrf
+
+let csrf_cookie_verification form_csrf reqd =
+  match has_cookie "molly_csrf" reqd with
+  | Some cookie ->
+      csrf_match
+        ~input_csrf:(Utils.Json.clean_string form_csrf)
+        ~check_csrf:cookie
+  | None -> false
+
+let csrf_form_verification users now form_csrf handler reqd =
+  match user_of_cookie users now reqd with
+  | Ok user -> (
+      let user_csrf_token =
+        List.find_opt
+          (fun (cookie : User_model.cookie) ->
+            String.equal cookie.name "molly_csrf")
+          user.User_model.cookies
+      in
+      match user_csrf_token with
+      | Some csrf_token ->
+          if
+            User_model.is_valid_cookie csrf_token now
+            && csrf_match ~check_csrf:csrf_token.value
+                 ~input_csrf:(Utils.Json.clean_string form_csrf)
+          then handler reqd
+          else
+            redirect_to_same_page reqd
+              ~msg:"CSRF token mismatch error. Please referesh and try again."
+              ()
+      | None ->
+          redirect_to_same_page
+            ~msg:"CSRF token mismatch error. Please referesh and try again."
+            reqd ())
+  | Error (`Msg err) -> redirect_to_login ~msg:err reqd ()

--- a/middleware.ml
+++ b/middleware.ml
@@ -223,6 +223,6 @@ let csrf_verification users now form_csrf handler reqd =
               reqd `Bad_request
       | None ->
           http_response
-            ~data:"CSRF token mismatch error. Please referesh and try again."
-            ~title:"CSRF Token Mismatch" reqd `Bad_request)
+            ~data:"Missing CSRF token. Please referesh and try again."
+            ~title:"Missing CSRF Token" reqd `Bad_request)
   | Error (`Msg err) -> redirect_to_login ~msg:err reqd ()

--- a/middleware.ml
+++ b/middleware.ml
@@ -199,7 +199,9 @@ let csrf_cookie_verification form_csrf reqd =
       | Error (`Msg err) ->
           Logs.err (fun m -> m "Error with csrf cookie %s" err);
           false)
-  | None -> false
+  | None -> 
+    Logs.err (fun m -> m "Couldn't find csrf cookie.");
+    false
 
 let csrf_verification users now form_csrf handler reqd =
   match user_of_cookie users now reqd with

--- a/middleware.ml
+++ b/middleware.ml
@@ -196,7 +196,7 @@ let csrf_cookie_verification form_csrf reqd =
       match cookie_value_from_cookie cookie with
       | Ok token -> csrf_match ~input_csrf:form_csrf ~check_csrf:token
       | Error (`Msg err) ->
-          Logs.err (fun m -> m "Error with csrf cookie %s" err);
+          Logs.err (fun m -> m "Error retrieving csrf value from cookie %s" err);
           false)
   | None -> 
     Logs.err (fun m -> m "Couldn't find csrf cookie.");

--- a/middleware.ml
+++ b/middleware.ml
@@ -198,9 +198,9 @@ let csrf_cookie_verification form_csrf reqd =
       | Error (`Msg err) ->
           Logs.err (fun m -> m "Error retrieving csrf value from cookie %s" err);
           false)
-  | None -> 
-    Logs.err (fun m -> m "Couldn't find csrf cookie.");
-    false
+  | None ->
+      Logs.err (fun m -> m "Couldn't find csrf cookie.");
+      false
 
 let csrf_verification users now form_csrf handler reqd =
   match user_of_cookie users now reqd with

--- a/middleware.ml
+++ b/middleware.ml
@@ -15,7 +15,6 @@ let has_cookie cookie_name (reqd : Httpaf.Reqd.t) =
       List.find_opt
         (fun cookie ->
           let parts = String.trim cookie |> String.split_on_char '=' in
-
           match parts with
           | [ name; _ ] -> String.equal name cookie_name
           | _ -> false)

--- a/middleware.ml
+++ b/middleware.ml
@@ -186,7 +186,7 @@ let csrf_cookie_verification form_csrf reqd =
         ~check_csrf:cookie
   | None -> false
 
-let csrf_form_verification users now form_csrf handler reqd =
+let csrf_verification users now form_csrf handler reqd =
   match user_of_cookie users now reqd with
   | Ok user -> (
       let user_csrf_token =

--- a/middleware.ml
+++ b/middleware.ml
@@ -17,8 +17,7 @@ let has_cookie cookie_name (reqd : Httpaf.Reqd.t) =
           let parts = String.trim cookie |> String.split_on_char '=' in
 
           match parts with
-          | [ name; _ ] ->
-              String.equal name cookie_name
+          | [ name; _ ] -> String.equal name cookie_name
           | _ -> false)
         cookie_list
   | _ -> None

--- a/settings_page.ml
+++ b/settings_page.ml
@@ -1,4 +1,4 @@
-let settings_layout (configuration : Configuration.t) =
+let settings_layout (configuration : Configuration.t) csrf =
   let ip = Ipaddr.to_string configuration.server_ip in
   let port = string_of_int configuration.server_port in
   let certificate = X509.Certificate.encode_pem configuration.certificate in
@@ -11,6 +11,7 @@ let settings_layout (configuration : Configuration.t) =
         div
           ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
           [
+            Utils.csrf_form_input csrf;
             div
               [
                 p

--- a/settings_page.ml
+++ b/settings_page.ml
@@ -1,4 +1,4 @@
-let settings_layout (configuration : Configuration.t) csrf =
+let settings_layout ~csrf (configuration : Configuration.t) =
   let ip = Ipaddr.to_string configuration.server_ip in
   let port = string_of_int configuration.server_port in
   let certificate = X509.Certificate.encode_pem configuration.certificate in

--- a/sign_up.ml
+++ b/sign_up.ml
@@ -1,6 +1,6 @@
 open Tyxml
 
-let register_page ~icon () =
+let register_page csrf ~icon () =
   let page =
     Html.(
       html
@@ -38,6 +38,7 @@ let register_page ~icon () =
                          ];
                      ]
                    [
+                     Utils.csrf_form_input csrf;
                      div
                        ~a:[ a_class [ "w-full max-w-lg mt-16 pb-16 mx-auto" ] ]
                        [
@@ -255,7 +256,8 @@ let register_page ~icon () =
                 document.getElementById('register-button')\n\
                \                registerButton.addEventListener('click', async \
                 function() {\n\
-               \                    const name = \
+                const form_csrf = document.getElementById('molly-csrf').value\n\
+               \               const name = \
                 document.getElementById('name').value\n\
                \                    const email = \
                 document.getElementById('email').value\n\
@@ -304,7 +306,7 @@ let register_page ~icon () =
                 'application/json',\n\
                \                            },\n\
                \                            body: JSON.stringify({ name, \
-                email, password })\n\
+                email, password, form_csrf })\n\
                \                        })\n\
                \                        const data = await response.json();\n\
                \                        if (data.status === 200) {\n\

--- a/sign_up.ml
+++ b/sign_up.ml
@@ -1,6 +1,6 @@
 open Tyxml
 
-let register_page csrf ~icon () =
+let register_page ~csrf ~icon =
   let page =
     Html.(
       html

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -174,7 +174,7 @@ struct
     | Ok None | Error (`Msg _) ->
         Lwt.return
           (reply reqd ~content_type:"text/html"
-             (Sign_up.register_page csrf.value ~icon:"/images/robur.png" ())
+             (Sign_up.register_page ~csrf:csrf.value ~icon:"/images/robur.png")
              ~header_list:
                [ ("Set-Cookie", csrf_cookie); ("X-MOLLY-CSRF", csrf.value) ]
              `OK)
@@ -380,7 +380,7 @@ struct
         Logs.info (fun m -> m "Verification link is: %s" verification_link);
         Lwt.return
           (reply reqd ~content_type:"text/html"
-             (Verify_email.verify_page user csrf ~icon:"/images/robur.png" ())
+             (Verify_email.verify_page user ~csrf ~icon:"/images/robur.png")
              ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
              `OK)
     | Error err ->
@@ -537,8 +537,8 @@ struct
           (reply reqd ~content_type:"text/html"
              (Dashboard.dashboard_layout user ~page_title:"Settings | Mollymawk"
                 ~content:
-                  (Settings_page.settings_layout
-                     (snd !store).Storage.configuration csrf)
+                  (Settings_page.settings_layout ~csrf
+                     (snd !store).Storage.configuration)
                 ~icon:"/images/robur.png" ())
              ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
              `OK)
@@ -579,7 +579,7 @@ struct
           (reply reqd ~content_type:"text/html"
              (Dashboard.dashboard_layout user
                 ~page_title:"Deploy a Unikernel | Mollymawk"
-                ~content:(Unikernel_create.unikernel_create_layout csrf)
+                ~content:(Unikernel_create.unikernel_create_layout ~csrf)
                 ~icon:"/images/robur.png" ())
              ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
              `OK)
@@ -643,8 +643,8 @@ struct
             (reply reqd ~content_type:"text/html"
                (Dashboard.dashboard_layout user
                   ~content:
-                    (Unikernel_single.unikernel_single_layout
-                       (List.hd unikernels) now console_output csrf)
+                    (Unikernel_single.unikernel_single_layout ~csrf
+                       (List.hd unikernels) now console_output)
                   ~icon:"/images/robur.png" ())
                ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
                `OK)
@@ -851,8 +851,8 @@ struct
                  (Dashboard.dashboard_layout user
                     ~page_title:(String.capitalize_ascii u.name ^ " | Mollymawk")
                     ~content:
-                      (User_single.user_single_layout u unikernels policy now
-                         csrf)
+                      (User_single.user_single_layout ~csrf u unikernels policy
+                         now)
                     ~icon:"/images/robur.png" ())
                  ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
                  `OK)
@@ -900,8 +900,8 @@ struct
                         ~page_title:
                           (String.capitalize_ascii u.name ^ " | Mollymawk")
                         ~content:
-                          (Update_policy.update_policy_layout u ~user_policy
-                             ~unallocated_resources csrf)
+                          (Update_policy.update_policy_layout ~csrf u
+                             ~user_policy ~unallocated_resources)
                         ~icon:"/images/robur.png" ())
                      ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
                      `OK)

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -153,8 +153,7 @@ struct
       @ (if email_verified && false (* TODO *) then
            [ Middleware.email_verified_middleware now users ]
          else [])
-      @ (if check_csrf then
-           [ Middleware.csrf_form_verification users now form_csrf ]
+      @ (if check_csrf then [ Middleware.csrf_verification users now form_csrf ]
          else [])
       @ [ Middleware.auth_middleware now users ]
     in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -103,11 +103,10 @@ struct
 
   let extract_csrf_token reqd =
     decode_request_body reqd >>= fun data ->
-    let json =
+    match
       try Ok (Yojson.Basic.from_string data)
       with Yojson.Json_error s -> Error (`Msg s)
-    in
-    match json with
+    with
     | Error (`Msg err) ->
         Logs.warn (fun m -> m "Failed to parse JSON: %s" err);
         Lwt.return (String.empty, `Null)

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1180,7 +1180,7 @@ struct
         | "/unikernel/deploy" ->
             check_meth `GET (fun () ->
                 authenticate !store reqd (deploy_form store reqd))
-        | "/unikernel/destory" ->
+        | "/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 extract_csrf_token reqd >>= fun (form_csrf, json) ->
                 authenticate !store reqd ~check_csrf:true ~form_csrf

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -1,4 +1,4 @@
-let unikernel_create_layout =
+let unikernel_create_layout csrf =
   Tyxml_html.(
     section
       ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
@@ -14,6 +14,7 @@ let unikernel_create_layout =
         div
           ~a:[ a_class [ "space-y-6 mt-8 p-6 max-w-5xl mx-auto" ] ]
           [
+            Utils.csrf_form_input csrf;
             p ~a:[ a_id "form-alert"; a_class [ "my-4 hidden" ] ] [];
             div
               [

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -1,4 +1,4 @@
-let unikernel_create_layout csrf =
+let unikernel_create_layout ~csrf =
   Tyxml_html.(
     section
       ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -1,4 +1,4 @@
-let unikernel_single_layout unikernel now console_output csrf =
+let unikernel_single_layout ~csrf unikernel now console_output =
   let u_name, data = unikernel in
   Tyxml_html.(
     section

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -1,4 +1,4 @@
-let unikernel_single_layout unikernel now console_output =
+let unikernel_single_layout unikernel now console_output csrf =
   let u_name, data = unikernel in
   Tyxml_html.(
     section
@@ -40,6 +40,7 @@ let unikernel_single_layout unikernel now console_output =
                       ];
                     div
                       [
+                        Utils.csrf_form_input csrf;
                         button
                           ~a:
                             [

--- a/update_policy.ml
+++ b/update_policy.ml
@@ -1,9 +1,10 @@
 let update_policy_layout (user : User_model.user) ~user_policy
-    ~unallocated_resources =
+    ~unallocated_resources csrf =
   Tyxml_html.(
     section
       ~a:[ a_id "policy-form" ]
       [
+        Utils.csrf_form_input csrf;
         h2
           ~a:[ a_class [ "font-semibold text-2xl" ] ]
           [ txt ("Set Policy for " ^ user.name) ];

--- a/update_policy.ml
+++ b/update_policy.ml
@@ -1,5 +1,5 @@
-let update_policy_layout (user : User_model.user) ~user_policy
-    ~unallocated_resources csrf =
+let update_policy_layout ~csrf (user : User_model.user) ~user_policy
+    ~unallocated_resources =
   Tyxml_html.(
     section
       ~a:[ a_id "policy-form" ]

--- a/user_single.ml
+++ b/user_single.ml
@@ -1,4 +1,5 @@
-let user_single_layout (user : User_model.user) unikernels policy current_time =
+let user_single_layout (user : User_model.user) unikernels policy current_time
+    csrf =
   Tyxml_html.(
     section
       ~a:[ a_class [ "p-4 bg-gray-50 my-1" ] ]
@@ -9,6 +10,7 @@ let user_single_layout (user : User_model.user) unikernels policy current_time =
         section
           ~a:[ a_class [ "my-5" ] ]
           [
+            Utils.csrf_form_input csrf;
             ul
               ~a:
                 [

--- a/user_single.ml
+++ b/user_single.ml
@@ -1,5 +1,5 @@
-let user_single_layout (user : User_model.user) unikernels policy current_time
-    csrf =
+let user_single_layout ~csrf (user : User_model.user) unikernels policy
+    current_time =
   Tyxml_html.(
     section
       ~a:[ a_class [ "p-4 bg-gray-50 my-1" ] ]

--- a/utils.ml
+++ b/utils.ml
@@ -93,6 +93,18 @@ module Status = struct
     |> Yojson.Safe.to_string
 end
 
+let csrf_form_input csrf =
+  Tyxml_html.(
+    input
+      ~a:
+        [
+          a_input_type `Hidden;
+          a_id "molly-csrf";
+          a_name "molly-csrf-input";
+          a_value csrf;
+        ]
+      ())
+
 let display_banner = function
   | Some message ->
       Tyxml_html.(

--- a/verify_email.ml
+++ b/verify_email.ml
@@ -1,6 +1,6 @@
 open Tyxml
 
-let verify_page ~icon ~(user : User_model.user) () =
+let verify_page ~icon (user : User_model.user) csrf () =
   let page =
     Html.(
       html
@@ -51,6 +51,7 @@ let verify_page ~icon ~(user : User_model.user) () =
                      div
                        ~a:[ a_class [ "my-5" ] ]
                        [
+                         Utils.csrf_form_input csrf;
                          h1
                            ~a:[ a_class [ "text-3xl font-bold" ] ]
                            [ txt "Please verify your email" ];

--- a/verify_email.ml
+++ b/verify_email.ml
@@ -1,6 +1,6 @@
 open Tyxml
 
-let verify_page ~icon (user : User_model.user) csrf () =
+let verify_page ~csrf ~icon (user : User_model.user) =
   let page =
     Html.(
       html


### PR DESCRIPTION
closes #40 
This PR adds functionality for CSRF token.

When a user is authenticated, we use a [Double Synchronizer Pattern](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern) which keeps the token on the server and transmit a copy as hidden field to the form. 

When a user is not authenticated, we use a [Naive Double Submit Cookie Pattern](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#naive-double-submit-cookie-pattern-discouraged) which sends the token in a cookie and also a hidden field on the form.

We also add a custom header `X-MOLLY-CSRF`. Will experiment with this to see if it's better for unauthenticated users than cookies.