### PR TITLE
Swap around host device and net name

### DIFF
--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -222,7 +222,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                     text-primary-600 uppercase";
                                                  ];
                                              ]
-                                           [ txt "Host device" ];
+                                           [ txt "Unikernel block device" ];
                                          th
                                            ~a:
                                              [
@@ -233,7 +233,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                     text-primary-600 uppercase";
                                                  ];
                                              ]
-                                           [ txt "Name" ];
+                                           [ txt "Host device" ];
                                          th
                                            ~a:
                                              [
@@ -273,7 +273,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                ];
                                            ]
                                          [
-                                           txt (Option.value device ~default:"");
+                                           txt (Option.value device ~default:name);
                                          ];
                                        td
                                          ~a:
@@ -325,7 +325,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                     text-primary-600 uppercase";
                                                  ];
                                              ]
-                                           [ txt "Host device" ];
+                                           [ txt "Unikernel network device" ];
                                          th
                                            ~a:
                                              [
@@ -336,7 +336,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                     text-primary-600 uppercase";
                                                  ];
                                              ]
-                                           [ txt "Name" ];
+                                           [ txt "Host device" ];
                                          th
                                            ~a:
                                              [
@@ -365,8 +365,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                ];
                                            ]
                                          [
-                                           txt
-                                             (Option.value device ~default:name);
+                                           txt name;
                                          ];
                                        td
                                          ~a:
@@ -378,7 +377,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                   text-gray-800";
                                                ];
                                            ]
-                                         [ txt name ];
+                                         [ txt (Option.value device ~default:name); ]
                                        td
                                          ~a:
                                            [

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -364,7 +364,10 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                   text-gray-800";
                                                ];
                                            ]
-                                         [ txt name ];
+                                         [
+                                           txt
+                                             (Option.value device ~default:name);
+                                         ];
                                        td
                                          ~a:
                                            [
@@ -375,10 +378,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                   text-gray-800";
                                                ];
                                            ]
-                                         [
-                                           txt
-                                             (Option.value device ~default:name);
-                                         ];
+                                         [ txt name ];
                                        td
                                          ~a:
                                            [

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -273,7 +273,8 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                ];
                                            ]
                                          [
-                                           txt (Option.value device ~default:name);
+                                           txt
+                                             (Option.value device ~default:name);
                                          ];
                                        td
                                          ~a:
@@ -364,9 +365,7 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                   text-gray-800";
                                                ];
                                            ]
-                                         [
-                                           txt name;
-                                         ];
+                                         [ txt name ];
                                        td
                                          ~a:
                                            [
@@ -377,8 +376,11 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                                   text-gray-800";
                                                ];
                                            ]
-                                         [ txt (Option.value device ~default:name); ]
-                                       td
+                                         [
+                                           txt
+                                             (Option.value device ~default:name);
+                                         ]
+                                         td
                                          ~a:
                                            [
                                              a_class

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -379,8 +379,8 @@ let unikernel_single_layout ~csrf unikernel now console_output =
                                          [
                                            txt
                                              (Option.value device ~default:name);
-                                         ]
-                                         td
+                                         ];
+                                       td
                                          ~a:
                                            [
                                              a_class


### PR DESCRIPTION
The data was swapped according to the table header. That is, the network name internal to the unikernel was displayed under the title "Host Device" while the host bridge name was displayed under "Name".