### PR TITLE
etter filtering and table sorting

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -32,23 +32,18 @@ function getUnikernelName(url) {
 }
 
 function filterData() {
-	var input, filter, table, tr, td, i, txtValue;
-	input = document.getElementById("searchQuery");
-	filter = input.value.toUpperCase();
-	table = document.getElementById("data-table");
-	tr = table.getElementsByTagName("tr");
-	for (i = 0; i < tr.length; i++) {
-		td = tr[i].getElementsByTagName("td")[0];
-		if (td) {
-			txtValue = td.textContent || td.innerText;
-			if (txtValue.toUpperCase().indexOf(filter) > -1) {
-				tr[i].style.display = "";
-			} else {
-				tr[i].style.display = "none";
-			}
-		}
-	}
+    const input = document.getElementById("searchQuery").value.toUpperCase();
+    const table = document.getElementById("data-table");
+    const rows = Array.from(table.querySelectorAll("tbody tr"));
+
+    rows.forEach(row => {
+        const cells = Array.from(row.getElementsByTagName("td"));
+        const match = cells.some(td => td.textContent.toUpperCase().includes(input));
+        row.style.display = match ? "" : "none";
+    });
 }
+
+
 
 function openConfigForm(ip, port, certificate, p_key) {
 	const formSection = document.getElementById("config-form");
@@ -339,3 +334,64 @@ async function updatePolicy() {
 		buttonLoading(policyButton, false, "Set Policy")
 	}
 }
+
+function sort_data() {
+	return {
+		sortBy: "",
+		sortAsc: false,
+		sortByColumn($event) {
+			if (this.sortBy === $event.target.innerText) {
+				this.sortAsc = !this.sortAsc;
+			} else {
+				this.sortBy = $event.target.innerText;
+				this.sortAsc = true;
+			}
+
+			const tableBody = this.getTableBody();
+			if (!tableBody) {
+				console.error("Table body not found");
+				return;
+			}
+
+			let rows = this.getTableRows()
+				.sort(
+					this.sortCallback(
+						Array.from($event.target.parentNode.children).indexOf(
+							$event.target
+						)
+					)
+				)
+				.forEach((tr) => {
+					tableBody.appendChild(tr);
+				});
+		},
+		getTableRows() {
+			const tableBody = this.getTableBody();
+			if (tableBody) {
+				return Array.from(tableBody.querySelectorAll("tr"));
+			}
+			return [];
+		},
+		getCellValue(row, index) {
+			return row.children[index].innerText;
+		},
+		sortCallback(index) {
+			return (a, b) =>
+				((row1, row2) => {
+					return row1 !== "" &&
+						row2 !== "" &&
+						!isNaN(row1) &&
+						!isNaN(row2)
+						? row1 - row2
+						: row1.toString().localeCompare(row2);
+				})(
+					this.getCellValue(this.sortAsc ? a : b, index),
+					this.getCellValue(this.sortAsc ? b : a, index)
+				);
+		},
+		getTableBody() {
+			return document.querySelector("#data-table tbody");
+		}
+	};
+}
+

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -170,7 +170,7 @@ struct
     let csrf = Middleware.get_csrf now () in
     let csrf_cookie = csrf.name ^ "=" ^ csrf.value ^ ";Path=/;HttpOnly=true" in
     match Middleware.session_cookie_value reqd with
-    | Ok (Some x) -> Middleware.redirect_to_dashboard reqd ()
+    | Ok (Some _x) -> Middleware.redirect_to_dashboard reqd ()
     | Ok None | Error (`Msg _) ->
         Lwt.return
           (reply reqd ~content_type:"text/html"

--- a/unikernel_index.ml
+++ b/unikernel_index.ml
@@ -48,7 +48,11 @@ let unikernel_index_layout unikernels current_time =
                     [ a_class [ "p-1.5 min-w-full inline-block align-middle" ] ]
                   [
                     div
-                      ~a:[ a_class [ "overflow-hidden" ] ]
+                      ~a:
+                        [
+                          Unsafe.string_attrib "x-data" "sort_data()";
+                          a_class [ "overflow-hidden" ];
+                        ]
                       [
                         table
                           ~a:
@@ -68,36 +72,125 @@ let unikernel_index_layout unikernels current_time =
                                      th
                                        ~a:
                                          [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
                                            a_class
                                              [
                                                "px-6 py-3 text-start text-xs \
                                                 font-bold text-primary-600 \
-                                                uppercase";
+                                                uppercase cursor-pointer \
+                                                select-none";
                                              ];
                                          ]
-                                       [ txt "Name" ];
+                                       [
+                                         txt "Name";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
                                      th
                                        ~a:
                                          [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
                                            a_class
                                              [
                                                "px-6 py-3 text-start text-xs \
                                                 font-bold text-primary-600 \
-                                                uppercase";
+                                                uppercase cursor-pointer \
+                                                select-none";
                                              ];
                                          ]
                                        [ txt "Type" ];
                                      th
                                        ~a:
                                          [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
                                            a_class
                                              [
                                                "px-6 py-3 text-start text-xs \
                                                 font-bold text-primary-600 \
-                                                uppercase";
+                                                uppercase cursor-pointer \
+                                                select-none";
                                              ];
                                          ]
-                                       [ txt "CPU" ];
+                                       [
+                                         txt "CPU";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Memory";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Created";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
                                      th
                                        ~a:
                                          [
@@ -105,29 +198,8 @@ let unikernel_index_layout unikernels current_time =
                                              [
                                                "px-6 py-3 text-start text-xs \
                                                 font-bold text-primary-600 \
-                                                uppercase";
-                                             ];
-                                         ]
-                                       [ txt "Memory" ];
-                                     th
-                                       ~a:
-                                         [
-                                           a_class
-                                             [
-                                               "px-6 py-3 text-start text-xs \
-                                                font-bold text-primary-600 \
-                                                uppercase";
-                                             ];
-                                         ]
-                                       [ txt "Created" ];
-                                     th
-                                       ~a:
-                                         [
-                                           a_class
-                                             [
-                                               "px-6 py-3 text-start text-xs \
-                                                font-bold text-primary-600 \
-                                                uppercase";
+                                                uppercase cursor-pointer \
+                                                select-none";
                                              ];
                                          ]
                                        [ txt "Action" ];


### PR DESCRIPTION
closes #75 
cc / @hannesm 
You can now click on the table headers to sort by that columns data. 

also the search box now filters across the entire table and not just the names. :) 
If you type 10, it should probably display the unikernels with a CPUID of 10. Basically it filters from data across the entire table.