### PR TITLE
Token Management

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -265,13 +265,9 @@ async function destroyUnikernel(name) {
 function buttonLoading(btn, load, text) {
 	if (load) {
 		btn.disabled = true;
-		btn.classList.remove("bg-primary-500", "text-gray-50");
-		btn.classList.add("bg-primary-50", "text-primary-950");
 		btn.innerHTML = `<i class="fa-solid fa-spinner animate-spin mr-2"></i> ${text}`;
 	} else {
 		btn.disabled = false;
-		btn.classList.remove("bg-primary-50", "text-primary-950");
-		btn.classList.add("bg-primary-500", "text-gray-50");
 		btn.innerHTML = text;
 	}
 }
@@ -741,6 +737,139 @@ async function uploadToVolume(block_name) {
 	} catch (error) {
 		postAlert("bg-secondary-300", error);
 		buttonLoading(uploadButton, false, "Upload data")
+	}
+}
+
+
+async function createToken() {
+	const tokenButton = document.getElementById('create-token-button');
+	const token_name = document.getElementById("token_name").value;
+	const token_expiry = document.getElementById("token_expiry").value;
+	const molly_csrf = document.getElementById("molly-csrf").value;
+	const formAlert = document.getElementById("tokens-form-alert");
+
+	if (!token_name || token_name == "") {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please enter a name"
+		buttonLoading(tokenButton, false, "Create Token")
+		return;
+	}
+	if (!token_expiry || token_expiry == "") {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please select a validity period"
+		buttonLoading(tokenButton, false, "Create Token")
+		return;
+	}
+	try {
+		buttonLoading(tokenButton, true, "Creating...")
+		const response = await fetch("/api/tokens/create", {
+			method: 'POST',
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(
+				{
+					"token_name": token_name,
+					"token_expiry": Number(token_expiry),
+					"molly_csrf": molly_csrf
+				})
+		})
+		const data = await response.json();
+		if (data.status === 200) {
+			postAlert("bg-primary-300", "Token created succesfully");
+			setTimeout(() => window.location.reload(), 1000);
+			buttonLoading(tokenButton, false, "Create Token")
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			buttonLoading(tokenButton, false, "Create Token")
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+		buttonLoading(tokenButton, false, "Create Token")
+	}
+}
+
+async function deleteToken(value) {
+	const tokenButton = document.getElementById(`delete-token-button-${value}`);
+	const molly_csrf = document.getElementById("molly-csrf").value;
+	try {
+		buttonLoading(tokenButton, true, "Deleting...")
+		const response = await fetch("/api/tokens/delete", {
+			method: 'POST',
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(
+				{
+					"token_value": value,
+					"molly_csrf": molly_csrf
+				})
+		})
+		const data = await response.json();
+		if (data.status === 200) {
+			postAlert("bg-primary-300", "Token deleted succesfully");
+			setTimeout(() => window.location.reload(), 1000);
+			buttonLoading(tokenButton, false, "Delete")
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			buttonLoading(tokenButton, false, "Delete")
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+		buttonLoading(tokenButton, false, "Delete")
+	}
+}
+
+async function updateToken(value) {
+	const tokenButton = document.getElementById("update-token-button");
+	const token_name = document.getElementById("token_name").value;
+	const token_expiry = document.getElementById("token_expiry").value;
+	const molly_csrf = document.getElementById("molly-csrf").value;
+	const formAlert = document.getElementById("tokens-form-alert");
+
+	if (!token_name || token_name == "") {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please enter a name"
+		buttonLoading(tokenButton, false, "Update Token")
+		return;
+	}
+	if (!token_expiry || token_expiry == "") {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please select a validity period"
+		buttonLoading(tokenButton, false, "Update Token")
+		return;
+	}
+	try {
+		buttonLoading(tokenButton, true, "Updating...")
+		const response = await fetch("/api/tokens/update", {
+			method: 'POST',
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(
+				{
+					"token_value": value,
+					"token_name": token_name,
+					"token_expiry": Number(token_expiry),
+					"molly_csrf": molly_csrf
+				})
+		})
+		const data = await response.json();
+		if (data.status === 200) {
+			postAlert("bg-primary-300", "Token updated succesfully");
+			setTimeout(() => window.location.reload(), 1000);
+			buttonLoading(tokenButton, false, "Update Token")
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			buttonLoading(tokenButton, false, "Update Token")
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", data.data);
+		buttonLoading(tokenButton, false, "Update Token")
 	}
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -824,10 +824,10 @@ async function deleteToken(value) {
 
 async function updateToken(value) {
 	const tokenButton = document.getElementById("update-token-button");
-	const token_name = document.getElementById("token_name").value;
-	const token_expiry = document.getElementById("token_expiry").value;
+	const token_name = document.getElementById("token_u_name").value;
+	const token_expiry = document.getElementById("token_u_expiry").value;
 	const molly_csrf = document.getElementById("molly-csrf").value;
-	const formAlert = document.getElementById("tokens-form-alert");
+	const formAlert = document.getElementById("tokens-update-form-alert");
 
 	if (!token_name || token_name == "") {
 		formAlert.classList.remove("hidden", "text-primary-500");

--- a/storage.ml
+++ b/storage.ml
@@ -1,12 +1,13 @@
 open Utils.Json
 
-let current_version = 5
+let current_version = 6
 (* version history:
    1 was initial (fields until email_verification_uuid)
    2 added active
    3 added super_user (but did not serialise it)
    4 properly serialised super_user
    5 cookie has two new fields last_access and user_agent
+   6 tokens has 3 new fields: name, last_access and usage_count
 *)
 
 let t_to_json users configuration =
@@ -25,6 +26,7 @@ let t_of_json json =
       | Some (`Int v), Some (`List users), Some configuration ->
           let* () =
             if v = current_version then Ok ()
+            else if v = 5 then Ok ()
             else if v = 4 then Ok ()
             else if v = 3 then Ok ()
             else if v = 2 then Ok ()
@@ -42,8 +44,8 @@ let t_of_json json =
                 let* user =
                   if v = 1 then User_model.user_v1_of_json js
                   else if v = 2 || v = 3 then User_model.user_v2_of_json js
-                  else if v = 4 then
-                    User_model.(user_of_json cookie_v1_of_json) js
+                  else if v = 4 || v = 5 then
+                    User_model.(user_v3_of_json cookie_v1_of_json) js
                   else User_model.(user_of_json cookie_of_json) js
                 in
                 Ok (user :: acc))

--- a/tokens_index.ml
+++ b/tokens_index.ml
@@ -1,0 +1,356 @@
+let tokens_index_layout tokens current_time =
+  Tyxml_html.(
+    section
+      ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
+      [
+        div
+          ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
+          [
+            div
+              [
+                p
+                  ~a:[ a_class [ "font-bold text-gray-700" ] ]
+                  [
+                    txt ("API Keys (" ^ string_of_int (List.length tokens) ^ ")");
+                  ];
+              ];
+            div
+              [
+                Modal_dialog.modal_dialog ~modal_title:"Create API Key"
+                  ~button_content:(txt "New API Key")
+                  ~content:Tokens_ui.create_token ();
+              ];
+          ];
+        hr ~a:[ a_class [ "border border-primary-500 my-5" ] ] ();
+        div
+          [
+            input
+              ~a:
+                [
+                  a_onkeyup "filterData()";
+                  a_placeholder "search";
+                  a_id "searchQuery";
+                  a_name "searchQuery";
+                  a_input_type `Text;
+                  a_class
+                    [
+                      "rounded py-2 px-3 border border-primary-200 \
+                       focus:border-primary-500 outline-0";
+                    ];
+                ]
+              ();
+          ];
+        div
+          ~a:[ a_class [ "flex flex-col" ] ]
+          [
+            div
+              ~a:[ a_class [ "-m-1.5 overflow-x-auto" ] ]
+              [
+                div
+                  ~a:
+                    [ a_class [ "p-1.5 min-w-full inline-block align-middle" ] ]
+                  [
+                    div
+                      ~a:
+                        [
+                          Unsafe.string_attrib "x-data" "sort_data()";
+                          a_class [ "overflow-hidden" ];
+                        ]
+                      [
+                        table
+                          ~a:
+                            [
+                              a_id "data-table";
+                              a_class
+                                [
+                                  "table-auto min-w-full divide-y \
+                                   divide-gray-200";
+                                ];
+                            ]
+                          ~thead:
+                            (thead
+                               [
+                                 tr
+                                   [
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Name";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [ txt "Type" ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Key";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Created";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Expires";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           Unsafe.string_attrib "x-on:click"
+                                             "sortByColumn";
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [
+                                         txt "Last used";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
+                                     th
+                                       ~a:
+                                         [
+                                           a_class
+                                             [
+                                               "px-6 py-3 text-start text-xs \
+                                                font-bold text-primary-600 \
+                                                uppercase cursor-pointer \
+                                                select-none";
+                                             ];
+                                         ]
+                                       [ txt "Action" ];
+                                   ];
+                               ])
+                          (List.map
+                             (fun (token : User_model.token) ->
+                               tr
+                                 ~a:[ a_class [ "border-b border-gray-200" ] ]
+                                 [
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [ txt token.name ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [ txt token.token_type ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [ txt token.value ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [
+                                       txt
+                                         (Utils.TimeHelper.string_of_ptime
+                                            token.created_at);
+                                     ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [ txt (string_of_int token.expires_in) ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800";
+                                           ];
+                                       ]
+                                     [
+                                       txt
+                                         (Utils.TimeHelper.time_ago
+                                            ~current_time
+                                            ~check_time:token.last_access);
+                                     ];
+                                   td
+                                     ~a:
+                                       [
+                                         a_class
+                                           [
+                                             "px-6 py-4 whitespace-nowrap \
+                                              text-sm font-medium \
+                                              text-gray-800f flex \
+                                              justify-between gap-4";
+                                           ];
+                                       ]
+                                     [
+                                       Modal_dialog.modal_dialog
+                                         ~modal_title:"Edit API Key"
+                                         ~button_content:(txt "Edit Key")
+                                         ~button_type:`Primary_outlined
+                                         ~content:(Tokens_ui.edit_token token)
+                                         ();
+                                       Utils.button_component
+                                         ~attribs:
+                                           [
+                                             a_id
+                                               ("delete-token-button-"
+                                              ^ token.value);
+                                             a_onclick
+                                               ("deleteToken('" ^ token.value
+                                              ^ "')");
+                                           ]
+                                         ~extra_css:"w-full"
+                                         ~content:(txt "Delete")
+                                         ~btn_type:`Danger_outlined ();
+                                     ];
+                                 ])
+                             tokens);
+                      ];
+                  ];
+              ];
+          ];
+      ])

--- a/tokens_index.ml
+++ b/tokens_index.ml
@@ -298,7 +298,17 @@ let tokens_index_layout tokens current_time =
                                               text-gray-800";
                                            ];
                                        ]
-                                     [ txt (string_of_int token.expires_in) ];
+                                     [
+                                       (match
+                                          Utils.TimeHelper.future_time
+                                            token.created_at token.expires_in
+                                        with
+                                       | Some ptime ->
+                                           txt
+                                             (Utils.TimeHelper.string_of_ptime
+                                                ptime)
+                                       | None -> txt "-");
+                                     ];
                                    td
                                      ~a:
                                        [

--- a/tokens_index.ml
+++ b/tokens_index.ml
@@ -112,7 +112,20 @@ let tokens_index_layout tokens current_time =
                                                 select-none";
                                              ];
                                          ]
-                                       [ txt "Type" ];
+                                       [
+                                         txt "Key";
+                                         span
+                                           ~a:[ a_class [ "px-2" ] ]
+                                           [
+                                             i
+                                               ~a:
+                                                 [
+                                                   a_class
+                                                     [ "fa-solid fa-sort" ];
+                                                 ]
+                                               [];
+                                           ];
+                                       ];
                                      th
                                        ~a:
                                          [
@@ -127,7 +140,7 @@ let tokens_index_layout tokens current_time =
                                              ];
                                          ]
                                        [
-                                         txt "Key";
+                                         txt "Usage";
                                          span
                                            ~a:[ a_class [ "px-2" ] ]
                                            [
@@ -261,7 +274,9 @@ let tokens_index_layout tokens current_time =
                                               text-gray-800";
                                            ];
                                        ]
-                                     [ txt token.token_type ];
+                                     [
+                                       txt (token.token_type ^ " " ^ token.value);
+                                     ];
                                    td
                                      ~a:
                                        [
@@ -272,7 +287,7 @@ let tokens_index_layout tokens current_time =
                                               text-gray-800";
                                            ];
                                        ]
-                                     [ txt token.value ];
+                                     [ txt (string_of_int token.usage_count) ];
                                    td
                                      ~a:
                                        [

--- a/tokens_ui.ml
+++ b/tokens_ui.ml
@@ -86,7 +86,7 @@ let edit_token (token : User_model.token) =
         div
           ~a:[ a_class [ "my-6" ] ]
           [
-            p ~a:[ a_id "tokens-form-alert"; a_class [ "my-4 hidden" ] ] [];
+            p ~a:[ a_id "tokens-update-form-alert"; a_class [ "my-4 hidden" ] ] [];
             label
               ~a:[ a_class [ "block text-sm font-medium" ]; a_label_for "name" ]
               [ txt "Name" ];
@@ -96,7 +96,7 @@ let edit_token (token : User_model.token) =
                   a_autocomplete `On;
                   a_input_type `Text;
                   a_name "token_name";
-                  a_id "token_name";
+                  a_id "token_u_name";
                   a_value token.name;
                   a_class
                     [
@@ -127,7 +127,7 @@ let edit_token (token : User_model.token) =
               ~a:
                 [
                   a_name "token_expiry";
-                  a_id "token_expiry";
+                  a_id "token_u_expiry";
                   a_class
                     [
                       "ring-primary-100 mt-1.5 transition block w-full px-3 \

--- a/tokens_ui.ml
+++ b/tokens_ui.ml
@@ -1,0 +1,194 @@
+let create_token =
+  Tyxml_html.(
+    section
+      ~a:[ a_id "token-create"; a_class [ "w-full mx-auto" ] ]
+      [
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            p ~a:[ a_id "tokens-form-alert"; a_class [ "my-4 hidden" ] ] [];
+            label
+              ~a:[ a_class [ "block text-sm font-medium" ]; a_label_for "name" ]
+              [ txt "Name" ];
+            input
+              ~a:
+                [
+                  a_autocomplete `On;
+                  a_input_type `Text;
+                  a_name "token_name";
+                  a_id "token_name";
+                  a_class
+                    [
+                      "ring-primary-100 mt-1.5 transition appearance-none \
+                       block w-full px-3 py-3 rounded-xl shadow-sm border \
+                       hover:border-primary-200\n\
+                      \                                           \
+                       focus:border-primary-300 bg-primary-50 bg-opacity-0 \
+                       hover:bg-opacity-50 focus:bg-opacity-50 \
+                       ring-primary-200 focus:ring-primary-200\n\
+                      \                                           \
+                       focus:ring-[1px] focus:outline-none";
+                    ];
+                ]
+              ();
+          ];
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            label
+              ~a:
+                [
+                  a_class [ "block text-sm font-medium" ];
+                  a_label_for "validity";
+                ]
+              [ txt "Valid for" ];
+            select
+              ~a:
+                [
+                  a_name "token_expiry";
+                  a_id "token_expiry";
+                  a_class
+                    [
+                      "ring-primary-100 mt-1.5 transition block w-full px-3 \
+                       py-3 rounded-xl shadow-sm border \
+                       hover:border-primary-200\n\
+                      \                                           \
+                       focus:border-primary-300 bg-primary-50 bg-opacity-0 \
+                       hover:bg-opacity-50 focus:bg-opacity-50 \
+                       ring-primary-200 focus:ring-primary-200\n\
+                      \                                           \
+                       focus:ring-[1px] focus:outline-none";
+                    ];
+                ]
+              [
+                option ~a:[ a_value "2419200" ] (txt "1 month");
+                option ~a:[ a_value "7257600" ] (txt "3 months");
+                option ~a:[ a_value "14515200" ] (txt "6 months");
+                option ~a:[ a_value "29030400" ] (txt "1 year");
+                option ~a:[ a_value "58060800" ] (txt "2 years");
+              ];
+          ];
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            Utils.button_component
+              ~attribs:[ a_id "create-token-button"; a_onclick "createToken()" ]
+              ~extra_css:"w-full" ~content:(txt "Create Token")
+              ~btn_type:`Primary_full ();
+          ];
+      ])
+
+let edit_token (token : User_model.token) =
+  Tyxml_html.(
+    section
+      ~a:[ a_id "token-update"; a_class [ "w-full mx-auto" ] ]
+      [
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            p ~a:[ a_id "tokens-form-alert"; a_class [ "my-4 hidden" ] ] [];
+            label
+              ~a:[ a_class [ "block text-sm font-medium" ]; a_label_for "name" ]
+              [ txt "Name" ];
+            input
+              ~a:
+                [
+                  a_autocomplete `On;
+                  a_input_type `Text;
+                  a_name "token_name";
+                  a_id "token_name";
+                  a_value token.name;
+                  a_class
+                    [
+                      "ring-primary-100 mt-1.5 transition appearance-none \
+                       block w-full px-3 py-3 rounded-xl shadow-sm border \
+                       hover:border-primary-200\n\
+                      \                                           \
+                       focus:border-primary-300 bg-primary-50 bg-opacity-0 \
+                       hover:bg-opacity-50 focus:bg-opacity-50 \
+                       ring-primary-200 focus:ring-primary-200\n\
+                      \                                           \
+                       focus:ring-[1px] focus:outline-none";
+                    ];
+                ]
+              ();
+          ];
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            label
+              ~a:
+                [
+                  a_class [ "block text-sm font-medium" ];
+                  a_label_for "validity";
+                ]
+              [ txt "Valid for" ];
+            select
+              ~a:
+                [
+                  a_name "token_expiry";
+                  a_id "token_expiry";
+                  a_class
+                    [
+                      "ring-primary-100 mt-1.5 transition block w-full px-3 \
+                       py-3 rounded-xl shadow-sm border \
+                       hover:border-primary-200\n\
+                      \                                           \
+                       focus:border-primary-300 bg-primary-50 bg-opacity-0 \
+                       hover:bg-opacity-50 focus:bg-opacity-50 \
+                       ring-primary-200 focus:ring-primary-200\n\
+                      \                                           \
+                       focus:ring-[1px] focus:outline-none";
+                    ];
+                ]
+              [
+                option
+                  ~a:
+                    ([ a_value "2419200" ]
+                    @
+                    if token.expires_in = 2419200 then [ a_selected () ] else []
+                    )
+                  (txt "1 month");
+                option
+                  ~a:
+                    ([ a_value "7257600" ]
+                    @
+                    if token.expires_in = 7257600 then [ a_selected () ] else []
+                    )
+                  (txt "3 months");
+                option
+                  ~a:
+                    ([ a_value "14515200" ]
+                    @
+                    if token.expires_in = 14515200 then [ a_selected () ]
+                    else [])
+                  (txt "6 months");
+                option
+                  ~a:
+                    ([ a_value "29030400" ]
+                    @
+                    if token.expires_in = 29030400 then [ a_selected () ]
+                    else [])
+                  (txt "1 year");
+                option
+                  ~a:
+                    ([ a_value "58060800" ]
+                    @
+                    if token.expires_in = 58060800 then [ a_selected () ]
+                    else [])
+                  (txt "2 years");
+              ];
+          ];
+        div
+          ~a:[ a_class [ "my-6" ] ]
+          [
+            Utils.button_component
+              ~attribs:
+                [
+                  a_id "update-token-button";
+                  a_onclick ("updateToken('" ^ token.value ^ "')");
+                ]
+              ~extra_css:"w-full" ~content:(txt "Update Token")
+              ~btn_type:`Primary_full ();
+          ];
+      ])

--- a/tokens_ui.ml
+++ b/tokens_ui.ml
@@ -86,7 +86,9 @@ let edit_token (token : User_model.token) =
         div
           ~a:[ a_class [ "my-6" ] ]
           [
-            p ~a:[ a_id "tokens-update-form-alert"; a_class [ "my-4 hidden" ] ] [];
+            p
+              ~a:[ a_id "tokens-update-form-alert"; a_class [ "my-4 hidden" ] ]
+              [];
             label
               ~a:[ a_class [ "block text-sm font-medium" ]; a_label_for "name" ]
               [ txt "Name" ];

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1733,7 +1733,7 @@ struct
                 extract_csrf_token reqd >>= function
                 | Ok (form_csrf, json_dict) ->
                     authenticate ~form_csrf ~api_meth:true store reqd
-                      (delete_token json_dict store reqd)
+                      (update_token json_dict store reqd)
                 | Error (`Msg msg) ->
                     Middleware.http_response reqd ~title:"Error"
                       ~data:(String.escaped msg) `Bad_request)

--- a/user_model.ml
+++ b/user_model.ml
@@ -4,7 +4,8 @@ type token = {
   name : string;
   token_type : string;
   value : string;
-  expires_in : int; (* the number of seconds until this token is invalid, starts counting from created_at*)
+  expires_in : int;
+      (* the number of seconds until this token is invalid, starts counting from created_at*)
   created_at : Ptime.t;
   last_access : Ptime.t;
   usage_count : int;

--- a/user_model.ml
+++ b/user_model.ml
@@ -4,11 +4,10 @@ type token = {
   name : string;
   token_type : string;
   value : string;
-  expires_in : int;
+  expires_in : int; (* the number of seconds until this token is invalid, starts counting from created_at*)
   created_at : Ptime.t;
   last_access : Ptime.t;
   usage_count : int;
-      (* In seconds, so after 1 hour would be 3600 seconds of inactivity *)
 }
 
 type cookie = {

--- a/utils.ml
+++ b/utils.ml
@@ -14,7 +14,7 @@ module TimeHelper = struct
             (Format.asprintf "invalid created_at format: %a"
                Ptime.pp_rfc3339_error err))
 
-  let string_of_ptime (t : Ptime.t) : string = Ptime.to_rfc3339 t ~frac_s:0
+  let string_of_ptime (t : Ptime.t) : string = Ptime.to_rfc3339 ~space:true t ~frac_s:0
 
   (* calculate the diff between two timestamps *)
   let diff_in_seconds ~current_time ~check_time =
@@ -41,6 +41,12 @@ module TimeHelper = struct
         | Error _ -> Error (`Msg "invalid date string"))
     | `Null -> Ok None
     | _ -> Error (`Msg "invalid json for Ptime.t option")
+
+  let future_time ptime seconds =
+    let created_span = Ptime.to_span ptime in
+    let expiry = Ptime.Span.of_int_s seconds in
+    let future_span = Ptime.Span.add created_span expiry in
+    Ptime.of_span future_span
 
   let time_ago ~current_time ~check_time =
     let diff = diff_in_seconds ~current_time ~check_time in

--- a/utils.ml
+++ b/utils.ml
@@ -14,7 +14,8 @@ module TimeHelper = struct
             (Format.asprintf "invalid created_at format: %a"
                Ptime.pp_rfc3339_error err))
 
-  let string_of_ptime (t : Ptime.t) : string = Ptime.to_rfc3339 ~space:true t ~frac_s:0
+  let string_of_ptime (t : Ptime.t) : string =
+    Ptime.to_rfc3339 ~space:true t ~frac_s:0
 
   (* calculate the diff between two timestamps *)
   let diff_in_seconds ~current_time ~check_time =


### PR DESCRIPTION
related to #38 
This PR begins the work for allowing accessing mollymawk solely via it's API.

API tokens are no longer created when a user creates an account. 
The user can manually create an API token from their dashboard. 

The API tokens now have new fields:
- `name` : to help the user differentiate between different keys e.g (GitHub, GitLab)
- `last_access`: when last was the specific key used to query mollymawk
- `usage_count`: how many times this key has been used