### PR TITLE
Api authentication with tokens

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -483,7 +483,7 @@ async function closeSessions() {
 	try {
 		buttonLoading(sessionButton, true, "Closing sessions..")
 		const molly_csrf = document.getElementById("molly-csrf").value;
-		const response = await fetch('/account/sessions/close', {
+		const response = await fetch('/api/account/sessions/close', {
 			method: 'POST',
 			body: JSON.stringify(
 				{
@@ -503,6 +503,35 @@ async function closeSessions() {
 	} catch (error) {
 		postAlert("bg-secondary-300", error);
 		buttonLoading(sessionButton, false, "Logout all other sessions")
+	}
+}
+
+async function closeSession(session_value) {
+	const sessionButton = document.getElementById(`session-button-${session_value}`);
+	try {
+		buttonLoading(sessionButton, true, "Closing session..")
+		const molly_csrf = document.getElementById("molly-csrf").value;
+		const response = await fetch('/api/account/session/close', {
+			method: 'POST',
+			body: JSON.stringify(
+				{
+					session_value,
+					molly_csrf,
+				}),
+			headers: { 'Content-Type': 'application/json' }
+		});
+
+		const data = await response.json();
+		if (response.status === 200) {
+			postAlert("bg-primary-300", data.data);
+			setTimeout(() => window.location.reload(), 1000);
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			buttonLoading(sessionButton, false, "Close session")
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+		buttonLoading(sessionButton, false, "Close session")
 	}
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -186,7 +186,7 @@ async function deployUnikernel() {
 		formData.append("arguments", arguments)
 		formData.append("molly_csrf", molly_csrf)
 		try {
-			const response = await fetch("/unikernel/create", {
+			const response = await fetch("/api/unikernel/create", {
 				method: 'POST',
 				body: formData
 			})
@@ -219,7 +219,7 @@ async function deployUnikernel() {
 async function restartUnikernel(name) {
 	try {
 		const molly_csrf = document.getElementById("molly-csrf").value;
-		const response = await fetch(`/unikernel/restart/${name}`, {
+		const response = await fetch(`/api/unikernel/restart/${name}`, {
 			method: 'POST',
 			body: JSON.stringify({ "name": name, "molly_csrf": molly_csrf }),
 			headers: { 'Content-Type': 'application/json' }
@@ -242,7 +242,7 @@ async function restartUnikernel(name) {
 async function destroyUnikernel(name) {
 	try {
 		const molly_csrf = document.getElementById("molly-csrf").value;
-		const response = await fetch(`/unikernel/destroy/${name}`, {
+		const response = await fetch(`/api/unikernel/destroy/${name}`, {
 			method: 'POST',
 			body: JSON.stringify({ "name": name, "molly_csrf": molly_csrf }),
 			headers: { 'Content-Type': 'application/json' }

--- a/error_page.ml
+++ b/error_page.ml
@@ -8,5 +8,7 @@ let error_layout (error : Utils.Status.t) =
           ~a:[ a_class [ "text-5xl text-secondary-500 font-semibold" ] ]
           [ txt (string_of_int error.code) ];
         p ~a:[ a_class [ "uppercase font-bold text-5xl" ] ] [ txt error.title ];
-        p ~a:[ a_class [ "capitalize text-xl my-6" ] ] [ txt error.data ];
+        p
+          ~a:[ a_class [ "text-xl my-6" ] ]
+          [ txt (Yojson.Basic.to_string error.data) ];
       ])

--- a/middleware.ml
+++ b/middleware.ml
@@ -101,7 +101,8 @@ let redirect_to_dashboard reqd ?(msg = "") () =
   Httpaf.Reqd.respond_with_string reqd response msg;
   Lwt.return_unit
 
-let http_response ~title ?(header_list = []) ?(data = "") reqd http_status =
+let http_response ~title ?(header_list = []) ?(data = `String "") reqd
+    http_status =
   let code = Httpaf.Status.to_code http_status
   and success = Httpaf.Status.is_successful http_status in
   let status = { Utils.Status.code; title; data; success } in
@@ -152,7 +153,9 @@ let is_user_admin_middleware api_meth user handler reqd =
   if user.User_model.super_user && user.active then handler reqd
   else
     redirect_to_error ~title:"Unauthorized"
-      ~data:"You don't have the necessary permissions to access this service."
+      ~data:
+        (`String
+          "You don't have the necessary permissions to access this service.")
       `Unauthorized 401 api_meth reqd ()
 
 let csrf_cookie_verification form_csrf reqd =
@@ -173,10 +176,12 @@ let csrf_verification user now form_csrf handler reqd =
       if User_model.is_valid_cookie csrf_token now then handler reqd
       else
         http_response ~title:"CSRF Token Mismatch"
-          ~data:"Invalid CSRF token error. Please refresh and try again." reqd
-          `Bad_request
+          ~data:
+            (`String "Invalid CSRF token error. Please refresh and try again.")
+          reqd `Bad_request
   | None ->
-      http_response ~data:"Missing CSRF token. Please refresh and try again."
+      http_response
+        ~data:(`String "Missing CSRF token. Please refresh and try again.")
         ~title:"Missing CSRF Token" reqd `Bad_request
 
 let api_authentication reqd =

--- a/middleware.ml
+++ b/middleware.ml
@@ -178,3 +178,10 @@ let csrf_verification user now form_csrf handler reqd =
   | None ->
       http_response ~data:"Missing CSRF token. Please refresh and try again."
         ~title:"Missing CSRF Token" reqd `Bad_request
+
+let api_authentication reqd =
+  match header "Authorization" reqd with
+  | Some auth when String.starts_with ~prefix:"Bearer " auth ->
+      let token = String.sub auth 7 (String.length auth - 7) in
+      Some token
+  | _ -> None

--- a/middleware.ml
+++ b/middleware.ml
@@ -139,24 +139,9 @@ let session_cookie_value reqd =
           m "auth-middleware: No molly-session in cookie header.");
       Error (`Msg "User not found")
 
-let auth_middleware user handler reqd =
-  if user.User_model.active then handler reqd
-  else
-    redirect_to_page ~path:"/sign-in" ~clear_session:true ~with_error:true
-      ~msg:"User account is deactivated." reqd ()
-
 let email_verified_middleware user handler reqd =
   if User_model.is_email_verified user then handler reqd
   else redirect_to_verify_email reqd ()
-
-let is_user_admin_middleware api_meth user handler reqd =
-  if user.User_model.super_user && user.active then handler reqd
-  else
-    redirect_to_error ~title:"Unauthorized"
-      ~data:
-        (`String
-          "You don't have the necessary permissions to access this service.")
-      `Unauthorized 401 api_meth reqd ()
 
 let csrf_cookie_verification form_csrf reqd =
   match cookie User_model.csrf_cookie reqd with

--- a/storage.ml
+++ b/storage.ml
@@ -164,6 +164,18 @@ module Make (BLOCK : Mirage_block.S) = struct
             | Some c -> Some (user, c)))
       None store.users
 
+  let find_by_api_token store token =
+    List.find_map
+      (fun (user : User_model.user) ->
+        match
+          List.find_opt
+            (fun (token_ : User_model.token) -> String.equal token token_.value)
+            user.tokens
+        with
+        | Some token_ -> Some (user, token_)
+        | None -> None)
+      store.users
+
   let count_users store = List.length store.users
 
   let find_email_verification_token store uuid =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1804,7 +1804,8 @@ struct
                   (delete_volume !albatross reqd))
         | "/api/volume/create" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true
+                  store reqd
                   (create_volume !albatross reqd))
         | "/api/volume/download" ->
             check_meth `POST (fun () ->
@@ -1813,7 +1814,8 @@ struct
                   (download_volume !albatross reqd))
         | "/api/volume/upload" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true
+                  store reqd
                   (upload_to_volume !albatross reqd))
         | "/tokens" ->
             check_meth `GET (fun () ->
@@ -1889,7 +1891,8 @@ struct
                   (unikernel_destroy !albatross reqd))
         | "/api/unikernel/restart" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true
+                  store reqd
                   (unikernel_restart !albatross reqd))
         | path when String.starts_with ~prefix:"/unikernel/console/" path ->
             check_meth `GET (fun () ->
@@ -1900,7 +1903,8 @@ struct
                   (unikernel_console !albatross unikernel_name reqd))
         | "/api/unikernel/create" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true
+                  store reqd
                   (unikernel_create !albatross reqd))
         | _ ->
             let error =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1889,7 +1889,7 @@ struct
                   (unikernel_destroy !albatross reqd))
         | "/api/unikernel/restart" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
                   (unikernel_restart !albatross reqd))
         | path when String.starts_with ~prefix:"/unikernel/console/" path ->
             check_meth `GET (fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -141,13 +141,13 @@ struct
     in
     go (Map.empty, []) m
 
-  let process_session_request ?(json_dict = []) ?form_csrf
-      ~email_verified f reqd user =
+  let process_session_request ?(json_dict = []) ?form_csrf ~email_verified f
+      reqd user =
     let current_time = Ptime.v (P.now_d_ps ()) in
     let middlewares ~form_csrf user =
       (if email_verified && false (* TODO *) then
-           [ Middleware.email_verified_middleware user ]
-         else [])
+         [ Middleware.email_verified_middleware user ]
+       else [])
       @ Option.fold ~none:[]
           ~some:(fun csrf ->
             [ Middleware.csrf_verification user current_time csrf ])
@@ -155,15 +155,17 @@ struct
     in
     Middleware.apply_middleware
       (middlewares ~form_csrf user)
-        (fun reqd -> f ~json_dict user) reqd
+      (fun reqd -> f ~json_dict user)
+      reqd
 
   let authenticate_user ~check_admin ~check_token store reqd =
     let ( let* ) = Result.bind in
     let current_time = Ptime.v (P.now_d_ps ()) in
     let user_is_active user =
-      if user.User_model.active then Ok () else Error "User account is deactivated"
+      if user.User_model.active then Ok ()
+      else Error "User account is deactivated"
     in
-    let user_is_admin user = 
+    let user_is_admin user =
       if (check_admin && user.User_model.super_user) || not check_admin then
         Ok ()
       else
@@ -173,8 +175,8 @@ struct
       match Middleware.session_cookie_value reqd with
       | Error (`Msg err) ->
           Error (`Cookie, "No molly-session in cookie header. %s" ^ err)
-      | Ok cookie_value ->
-         match Store.find_by_cookie store cookie_value with
+      | Ok cookie_value -> (
+          match Store.find_by_cookie store cookie_value with
           | None ->
               Error (`Cookie, "Failed to find user with cookie " ^ cookie_value)
           | Some (user, cookie) ->
@@ -186,80 +188,77 @@ struct
                 | Error msg -> Error (`Cookie, msg)
                 | Ok () -> Ok (`Cookie (user, cookie))
               else
-                Error (`Cookie, "Session value doesn't match user session " ^ cookie_value)
+                Error
+                  ( `Cookie,
+                    "Session value doesn't match user session " ^ cookie_value
+                  ))
     in
     let valid_token token_value =
       match Store.find_by_api_token store token_value with
       | Some (user, token) ->
-        if User_model.is_valid_token token current_time then
-          Ok (user, token)
-        else
-          Error (`Token, "Token value is not valid " ^ token_value)
-      | None ->
-        Error (`Token, "Failed to find user with token " ^ token_value)
+          if User_model.is_valid_token token current_time then Ok (user, token)
+          else Error (`Token, "Token value is not valid " ^ token_value)
+      | None -> Error (`Token, "Failed to find user with token " ^ token_value)
     in
     if check_token then
       match Middleware.api_authentication reqd with
       | Some token_value -> (
-        let* (user, token) = valid_token token_value in
-        match
-          let* () = user_is_active user in
-          user_is_admin user
-        with
-        | Ok () -> Ok (`Token (user, token))
-        | Error msg -> Error (`Token, msg))
+          let* user, token = valid_token token_value in
+          match
+            let* () = user_is_active user in
+            user_is_admin user
+          with
+          | Ok () -> Ok (`Token (user, token))
+          | Error msg -> Error (`Token, msg))
       | None -> check_cookie reqd
-    else
-      check_cookie reqd
- 
+    else check_cookie reqd
+
   let authenticate ?(email_verified = true) ?(check_admin = false)
       ?(api_meth = false) ?(check_csrf = false) ?(check_token = false) store
       reqd f =
     match authenticate_user ~check_admin ~check_token store reqd with
     | Error (`Cookie, msg) ->
-      Logs.err (fun m -> m "authenticate: %s" msg);
-      if api_meth then
-        Middleware.http_response reqd ~title:"Error"
-          ~data:(`String msg) `Bad_request
-      else
-        Middleware.redirect_to_page ~path:"/sign-in" ~clear_session:true
-          ~with_error:true ~msg reqd ()
+        Logs.err (fun m -> m "authenticate: %s" msg);
+        if api_meth then
+          Middleware.http_response reqd ~title:"Error" ~data:(`String msg)
+            `Bad_request
+        else
+          Middleware.redirect_to_page ~path:"/sign-in" ~clear_session:true
+            ~with_error:true ~msg reqd ()
     | Error (`Token, msg) ->
-      Logs.err (fun m -> m "authenticate: %s" msg);
-      Middleware.http_response reqd ~title:"Error"
-        ~data:(`String msg) `Bad_request
-    | Ok `Token (user, token) -> (
+        Logs.err (fun m -> m "authenticate: %s" msg);
+        Middleware.http_response reqd ~title:"Error" ~data:(`String msg)
+          `Bad_request
+    | Ok (`Token (user, token)) -> (
         Store.increment_token_usage store token user >>= function
-         | Error (`Msg err) ->
-           Middleware.http_response reqd ~title:"Error" ~data:(`String err)
-            `Internal_server_error
-         | Ok () ->
-          extract_json_body reqd >>= function
-          | Ok json_dict -> f ~json_dict user
-          | Error (`Msg msg) ->
-              Middleware.http_response reqd ~title:"Error"
-                ~data:(`String (String.escaped msg))
-                `Bad_request)
-    | Ok `Cookie (user, cookie) ->
-        Store.update_cookie_usage store cookie user reqd >>= function
-           | Error (`Msg err) ->
-              Logs.err (fun m -> m "Error with storage: %s" err);
+        | Error (`Msg err) ->
+            Middleware.http_response reqd ~title:"Error" ~data:(`String err)
+              `Internal_server_error
+        | Ok () -> (
+            extract_json_body reqd >>= function
+            | Ok json_dict -> f ~json_dict user
+            | Error (`Msg msg) ->
                 Middleware.http_response reqd ~title:"Error"
-                ~data:(`String (String.escaped err))
-                `Internal_server_error
-           | Ok () ->
-             if check_csrf then
-               extract_csrf_token reqd >>= function
-               | Ok (form_csrf, json_dict) ->
-                   process_session_request ~email_verified
-                     ~json_dict ~form_csrf f reqd user
-               | Error (`Msg msg) ->
-                   Middleware.http_response reqd ~title:"Error"
-                     ~data:(`String (String.escaped msg))
-                     `Bad_request
-             else
-               process_session_request ~email_verified
-                 f reqd user
+                  ~data:(`String (String.escaped msg))
+                  `Bad_request))
+    | Ok (`Cookie (user, cookie)) -> (
+        Store.update_cookie_usage store cookie user reqd >>= function
+        | Error (`Msg err) ->
+            Logs.err (fun m -> m "Error with storage: %s" err);
+            Middleware.http_response reqd ~title:"Error"
+              ~data:(`String (String.escaped err))
+              `Internal_server_error
+        | Ok () ->
+            if check_csrf then
+              extract_csrf_token reqd >>= function
+              | Ok (form_csrf, json_dict) ->
+                  process_session_request ~email_verified ~json_dict ~form_csrf
+                    f reqd user
+              | Error (`Msg msg) ->
+                  Middleware.http_response reqd ~title:"Error"
+                    ~data:(`String (String.escaped msg))
+                    `Bad_request
+            else process_session_request ~email_verified f reqd user)
 
   let reply reqd ?(content_type = "text/plain") ?(header_list = []) data status
       =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1885,7 +1885,7 @@ struct
                 authenticate store reqd (deploy_form store reqd))
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true store reqd
+                authenticate ~check_token:true ~api_meth:true store reqd
                   (unikernel_destroy !albatross reqd))
         | "/api/unikernel/restart" ->
             check_meth `POST (fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -102,6 +102,20 @@ struct
         Logs.warn (fun m -> m "JSON is not a dictionary: %s" data);
         Lwt.return (Error (`Msg "not a dictionary"))
 
+  let extract_json_body reqd =
+    decode_request_body reqd >>= fun data ->
+    match
+      try Ok (Yojson.Basic.from_string data)
+      with Yojson.Json_error s -> Error (`Msg s)
+    with
+    | Error (`Msg err) ->
+        Logs.warn (fun m -> m "Failed to parse JSON: %s" err);
+        Lwt.return (Error (`Msg err))
+    | Ok (`Assoc json_dict) -> Lwt.return (Ok json_dict)
+    | Ok _ ->
+        Logs.warn (fun m -> m "JSON is not a dictionary: %s" data);
+        Lwt.return (Error (`Msg "not a dictionary"))
+
   module Albatross = Albatross.Make (T) (P) (S)
 
   let to_map ~assoc m =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -841,7 +841,6 @@ struct
              `Unauthorized)
 
   let close_session store reqd ~json_dict (user : User_model.user) =
-    Logs.warn (fun m -> m "We got here");
     match Utils.Json.(get "session_value" json_dict) with
     | Some (`String session_value) -> (
         let now = Ptime.v (P.now_d_ps ()) in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1900,7 +1900,7 @@ struct
                   (unikernel_console !albatross unikernel_name reqd))
         | "/api/unikernel/create" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
                   (unikernel_create !albatross reqd))
         | _ ->
             let error =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1835,10 +1835,10 @@ struct
         | "/unikernel/deploy" ->
             check_meth `GET (fun () ->
                 authenticate store reqd (deploy_form store reqd))
-        | "api/unikernel/destroy" ->
+        | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate store reqd (unikernel_destroy !albatross reqd))
-        | "api/unikernel/restart" ->
+        | "/api/unikernel/restart" ->
             check_meth `POST (fun () ->
                 authenticate ~check_csrf:true store reqd
                   (unikernel_restart !albatross reqd))
@@ -1849,7 +1849,7 @@ struct
                 in
                 authenticate store reqd
                   (unikernel_console !albatross unikernel_name reqd))
-        | "api/unikernel/create" ->
+        | "/api/unikernel/create" ->
             check_meth `POST (fun () ->
                 authenticate ~check_csrf:true store reqd
                   (unikernel_create !albatross reqd))

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1813,7 +1813,7 @@ struct
                   (download_volume !albatross reqd))
         | "/api/volume/upload" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
                   (upload_to_volume !albatross reqd))
         | "/tokens" ->
             check_meth `GET (fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1804,7 +1804,7 @@ struct
                   (delete_volume !albatross reqd))
         | "/api/volume/create" ->
             check_meth `POST (fun () ->
-                authenticate ~check_token:true ~check_csrf:true store reqd
+                authenticate ~check_token:true ~check_csrf:true ~api_meth:true store reqd
                   (create_volume !albatross reqd))
         | "/api/volume/download" ->
             check_meth `POST (fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -155,7 +155,7 @@ struct
     in
     Middleware.apply_middleware
       (middlewares ~form_csrf user)
-      (fun reqd -> f ~json_dict user)
+      (fun _reqd -> f ~json_dict user)
       reqd
 
   let authenticate_user ~check_admin ~check_token store reqd =

--- a/user_account.ml
+++ b/user_account.ml
@@ -1,4 +1,4 @@
-let user_account_layout ~csrf (user : User_model.user) ~active_cookie_value
+let user_account_layout (user : User_model.user) ~active_cookie_value
     current_time =
   Tyxml_html.(
     section
@@ -304,21 +304,21 @@ let user_account_layout ~csrf (user : User_model.user) ~active_cookie_value
                                         (String.equal cookie.value
                                            active_cookie_value)
                                     then
-                                      a
-                                        ~a:
-                                          [
-                                            a_href
-                                              ("account/session/close/"
-                                             ^ cookie.value ^ "/" ^ csrf);
-                                            a_class
+                                      div
+                                        [
+                                          Utils.button_component
+                                            ~attribs:
                                               [
-                                                "hover:text-secondary-800 \
-                                                 text-secondary-500 \
-                                                 transition-colors \
-                                                 cursor-pointer";
-                                              ];
-                                          ]
-                                        [ txt "Close session" ]
+                                                a_id
+                                                  ("session-button-"
+                                                 ^ cookie.value);
+                                                a_onclick
+                                                  ("closeSession('"
+                                                 ^ cookie.value ^ "')");
+                                              ]
+                                            ~content:(txt "Close session")
+                                            ~btn_type:`Danger_outlined ();
+                                        ]
                                     else div []);
                                  ];
                              ])

--- a/user_model.ml
+++ b/user_model.ml
@@ -40,7 +40,7 @@ let week = 604800 (* a week = 7 days * 24 hours * 60 minutes * 60 seconds *)
 let session_cookie = "molly_session"
 let csrf_cookie = "molly_csrf"
 
-let cookie_to_json (cookie : cookie) : Yojson.Basic.t =
+let cookie_to_json (cookie : cookie) =
   `Assoc
     [
       ("name", `String cookie.name);
@@ -174,7 +174,7 @@ let cookie_of_json = function
           ("invalid json for cookie, expected a dict: "
          ^ Yojson.Basic.to_string js))
 
-let token_to_json t : Yojson.Basic.t =
+let token_to_json t =
   `Assoc
     [
       ("token_type", `String t.token_type);
@@ -277,7 +277,7 @@ let token_of_json = function
           ("invalid json for token: expected a dict: "
          ^ Yojson.Basic.to_string js))
 
-let user_to_json (u : user) : Yojson.Basic.t =
+let user_to_json (u : user) =
   `Assoc
     [
       ("name", `String u.name);

--- a/user_model.ml
+++ b/user_model.ml
@@ -764,6 +764,11 @@ let is_valid_cookie (cookie : cookie) now =
     ~check_time:cookie.created_at
   < cookie.expires_in
 
+let is_valid_token (token : token) now =
+  Utils.TimeHelper.diff_in_seconds ~current_time:now
+    ~check_time:token.created_at
+  < token.expires_in
+
 let is_email_verified user = Option.is_some user.email_verified
 let password_validation password = String.length password >= 8
 

--- a/utils.ml
+++ b/utils.ml
@@ -80,7 +80,7 @@ module Email = struct
 end
 
 module Status = struct
-  type t = { code : int; title : string; data : string; success : bool }
+  type t = { code : int; title : string; data : Yojson.Basic.t; success : bool }
 
   let to_json (status : t) : string =
     `Assoc
@@ -88,7 +88,7 @@ module Status = struct
         ("status", `Int status.code);
         ("title", `String status.title);
         ("success", `Bool status.success);
-        ("data", `String status.data);
+        ("data", status.data);
       ]
     |> Yojson.Basic.to_string
 end


### PR DESCRIPTION
closes #38 

This PR introduces many changes, including a refactoring of how we check for `csrf` tokens. 
In this PR:
- We can now have both session authentication and api token authentication (both stateful and stateless)
- Routes which change state are all converted to POST requests so that we can do the appropriate verifications.

The following endpoints can be accessed via the API
- [x] `/api/volume/delete`
- [x] `/api/volume/create`
- [x] `/api/volume/download`
- [x] `/api/volume/upload`
- [x] `/api/unikernel/destroy`
- [x] `/api/unikernel/restart`
- [x] `/api/unikernel/create`
