### PR TITLE
Use setup-ocamlv3 in ocamlformat workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 


### PR DESCRIPTION
- This updates our ocamlformat workflow to use `setup-ocamlv3`
- We have some issues with the `darcs` package which causes the ci workflow to fail.  Specifically, the error is
