### PR TITLE
Fix restart

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -242,7 +242,7 @@ async function deployUnikernel() {
 async function restartUnikernel(name) {
 	try {
 		const molly_csrf = document.getElementById("molly-csrf").value;
-		const response = await fetch(`/api/unikernel/restart/${name}`, {
+		const response = await fetch(`/api/unikernel/restart`, {
 			method: 'POST',
 			body: JSON.stringify({ "name": name, "molly_csrf": molly_csrf }),
 			headers: { 'Content-Type': 'application/json' }
@@ -255,7 +255,7 @@ async function restartUnikernel(name) {
 				window.location.href = "/dashboard";
 			}, 2000);
 		} else {
-			postAlert("bg-secondary-300", `${name} has been restarted succesfully.`);
+			postAlert("bg-secondary-300", `Error. Restarting ${name} returned ${data.data}.`);
 		}
 	} catch (error) {
 		postAlert("bg-secondary-300", error);


### PR DESCRIPTION
fixes https://github.com/robur-coop/mollymawk/issues/101

There was a minor error in the `POST` url. Previously we used an implementation with `GET` which required us to pass the unikernel name in the url, but now with a `POST` implementation, we no longer have to pass the name in the url. 

Restart functionality currently fails due to a non-mollymawk issue which is currently reported at https://github.com/robur-coop/albatross/issues/209