### PR TITLE
Rollback functionality of Unikernels

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -982,6 +982,45 @@ async function updateUnikernel(job, latest_build, current_build, unikernel_name)
 	}
 }
 
+async function rollbackUnikernel(unikernel_name) {
+	const rollbackButton = document.getElementById("unikernel-rollback");
+	const molly_csrf = document.getElementById("molly-csrf").value;
+	const formAlert = document.getElementById("form-alert");
+	try {
+		buttonLoading(rollbackButton, true, "Rolling back...")
+		const response = await fetch("/api/unikernel/rollback", {
+			method: 'POST',
+			headers: {
+				"Content-Type": "application/json",
+				"Accept": "application/json",
+			},
+			body: JSON.stringify(
+				{
+					"unikernel_name": unikernel_name,
+					"molly_csrf": molly_csrf
+				})
+		})
+		const data = await response.json();
+		if (data.status === 200) {
+			postAlert("bg-primary-300", "Unikernel rollback succesful");
+			setTimeout(() => window.location.reload(), 1000);
+			buttonLoading(rollbackButton, false, "Rollback")
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			formAlert.classList.remove("hidden", "text-primary-500");
+			formAlert.classList.add("text-secondary-500");
+			formAlert.textContent = data.data
+			buttonLoading(rollbackButton, false, "Rollback")
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = data.data
+		buttonLoading(rollbackButton, false, "Rollback")
+	}
+}
+
 function isValidName(s) {
 	const length = s.length;
 	if (length === 0 || length >= 64) return false;

--- a/assets/main.js
+++ b/assets/main.js
@@ -932,7 +932,7 @@ async function updateToken(value) {
 	}
 }
 
-async function updateUnikernel(job, build, unikernel_name) {
+async function updateUnikernel(job, latest_build, current_build, unikernel_name) {
 	const updateButton = document.getElementById("update-unikernel-button");
 	const unikernelArguments = document.getElementById("unikernel-arguments").value;
 	const argumentsToggle = document.getElementById("arguments-toggle").checked;
@@ -954,7 +954,8 @@ async function updateUnikernel(job, build, unikernel_name) {
 			body: JSON.stringify(
 				{
 					"job": job,
-					"build": build,
+					"latest_build": latest_build,
+					"current_build": current_build,
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
 					"molly_csrf": molly_csrf

--- a/storage.ml
+++ b/storage.ml
@@ -215,7 +215,7 @@ module Make (BLOCK : Mirage_block.S) = struct
   let update_user_unikernel_updates store
       (new_update : User_model.unikernel_update) (user : User_model.user) =
     let is_unique (u : User_model.unikernel_update) =
-      u.name <> new_update.name
+      not (String.equal u.name new_update.name)
     in
     let updated_list =
       new_update :: List.filter is_unique user.unikernel_updates

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1019,11 +1019,22 @@ struct
         let now = Ptime.v (P.now_d_ps ()) in
         generate_csrf_token store user now reqd >>= function
         | Ok csrf ->
+            let last_update_time =
+              match
+                List.find_opt
+                  (fun (u : User_model.unikernel_update) ->
+                    String.equal u.name name)
+                  user.unikernel_updates
+              with
+              | Some unikernel_update -> Some unikernel_update.timestamp
+              | None -> None
+            in
             reply reqd ~content_type:"text/html"
               (Dashboard.dashboard_layout ~csrf user
                  ~content:
                    (Unikernel_single.unikernel_single_layout
-                      ~unikernel_name:name unikernel now console_output)
+                      ~unikernel_name:name unikernel ~last_update_time
+                      ~current_time:now console_output)
                  ~icon:"/images/robur.png" ())
               ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
               `OK

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1259,7 +1259,7 @@ struct
         job;
         uuid = currently_running_unikernel;
         config = unikernel_cfg;
-        timestamp = Ptime.v (P.now_d_ps ());
+        timestamp = Mirage_ptime.now ();
       }
     in
     Store.update_user_unikernel_updates store unikernel_update user >>= function
@@ -1280,7 +1280,7 @@ struct
                  (change_string change_kind ^ " storing update information for "
                 ^ unikernel_name ^ " failed with: " ^ err ^ " for data: " ^ data
                  ),
-               (`Internal_server_error : Httpaf.Status.t) ))
+               (`Internal_server_error : H1.Status.t) ))
     | Ok () -> (
         Builder_web.send_request http_client
           ("/job/" ^ job ^ "/build/" ^ to_be_updated_unikernel ^ "/main-binary")
@@ -1501,9 +1501,8 @@ struct
       json_dict reqd =
     match Utils.Json.get "unikernel_name" json_dict with
     | Some (`String unikernel_name) ->
-        process_rollback ~unikernel_name
-          (Ptime.v (P.now_d_ps ()))
-          albatross store http_client reqd user
+        process_rollback ~unikernel_name (Mirage_ptime.now ()) albatross store
+          http_client reqd user
     | _ ->
         Middleware.http_response reqd ~title:"Error"
           ~data:(`String "Couldn't find unikernel name in json") `Bad_request

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1488,6 +1488,15 @@ struct
           ~data:(`String "Couldn't find job or build in json. Received ")
           `Bad_request
 
+  let unikernel_rollback albatross store http_client (user : User_model.user)
+      json_dict reqd =
+    match Utils.Json.get "unikernel_name" json_dict with
+    | Some (`String unikernel_name) ->
+        process_rollback ~unikernel_name albatross store http_client reqd user
+    | _ ->
+        Middleware.http_response reqd ~title:"Error"
+          ~data:(`String "Couldn't find unikernel name in json") `Bad_request
+
   let unikernel_destroy albatross (user : User_model.user) json_dict reqd =
     (* TODO use uuid in the future *)
     match Utils.Json.get "name" json_dict with
@@ -2286,6 +2295,11 @@ struct
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (extract_json_csrf_token
                      (unikernel_update !albatross store http_client)))
+        | "/api/unikernel/rollback" ->
+            check_meth `POST (fun () ->
+                authenticate ~check_token:true ~api_meth:true store reqd
+                  (extract_json_csrf_token
+                     (unikernel_rollback !albatross store http_client)))
         | _ ->
             let error =
               {

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1318,7 +1318,7 @@ struct
                        `Bad_request ))
             | Ok () -> Lwt.return (Ok (unikernel_image, unikernel_cfg))))
 
-  let unikernel_rollback ~unikernel_name albatross store http_client reqd
+  let process_rollback ~unikernel_name albatross store http_client reqd
       (user : User_model.user) =
     match
       List.find_opt

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -85,6 +85,7 @@ let unikernel_single_layout ~unikernel_name unikernel current_time
                           ];
                       ];
                   ];
+                p ~a:[ a_id "form-alert"; a_class [ "my-3" ] ] [];
                 div
                   ~a:[ a_class [ "grid grid-cols-3 gap-3 text-white my-3" ] ]
                   [

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -76,7 +76,7 @@ let unikernel_single_layout ~unikernel_name ?(last_update_time = None)
                         | Some check_time
                           when Utils.TimeHelper.diff_in_seconds ~current_time
                                  ~check_time
-                               < 600 ->
+                               < Utils.rollback_seconds_limit ->
                             div
                               [
                                 Utils.button_component

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -1,5 +1,5 @@
-let unikernel_single_layout ~unikernel_name unikernel current_time
-    console_output =
+let unikernel_single_layout ~unikernel_name ?(last_update_time = None)
+    ~current_time unikernel console_output =
   let u_name, data = unikernel in
   Tyxml_html.(
     section
@@ -71,19 +71,26 @@ let unikernel_single_layout ~unikernel_name unikernel current_time
                                 ]
                               [ txt "Update" ];
                           ];
-                        div
-                          [
-                            Utils.button_component
-                              ~attribs:
-                                [
-                                  a_id "unikernel-rollback";
-                                  a_onclick
-                                    ("rollbackUnikernel('" ^ unikernel_name
-                                   ^ "')");
-                                ]
-                              ~content:(txt "Rollback")
-                              ~btn_type:`Primary_outlined ();
-                          ];
+                        (* check that the last update happened less than 10 minutes ago (600 seconds)*)
+                        (match last_update_time with
+                        | Some check_time
+                          when Utils.TimeHelper.diff_in_seconds ~current_time
+                                 ~check_time
+                               < 600 ->
+                            div
+                              [
+                                Utils.button_component
+                                  ~attribs:
+                                    [
+                                      a_id "unikernel-rollback";
+                                      a_onclick
+                                        ("rollbackUnikernel('" ^ unikernel_name
+                                       ^ "')");
+                                    ]
+                                  ~content:(txt "Rollback")
+                                  ~btn_type:`Primary_outlined ();
+                              ]
+                        | _ -> div []);
                         div
                           [
                             Utils.button_component

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -76,6 +76,19 @@ let unikernel_single_layout ~unikernel_name unikernel current_time
                             Utils.button_component
                               ~attribs:
                                 [
+                                  a_id "unikernel-rollback";
+                                  a_onclick
+                                    ("rollbackUnikernel('" ^ unikernel_name
+                                   ^ "')");
+                                ]
+                              ~content:(txt "Rollback")
+                              ~btn_type:`Primary_outlined ();
+                          ];
+                        div
+                          [
+                            Utils.button_component
+                              ~attribs:
+                                [
                                   a_onclick
                                     ("destroyUnikernel('" ^ unikernel_name
                                    ^ "')");

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -1,6 +1,6 @@
-let arg_modal ~unikernel_name
-    (unikernel : Vmm_core.Name.t * Vmm_core.Unikernel.info)
-    (build : Builder_web.build) =
+let arg_modal ~unikernel_name ~(latest_build : Builder_web.build)
+    ~(current_build : Builder_web.build)
+    (unikernel : Vmm_core.Name.t * Vmm_core.Unikernel.info) =
   Tyxml_html.(
     section
       [
@@ -129,8 +129,9 @@ let arg_modal ~unikernel_name
                 [
                   a_id "update-unikernel-button";
                   a_onclick
-                    ("updateUnikernel('" ^ build.job ^ "','" ^ build.uuid
-                   ^ "','" ^ unikernel_name ^ "')");
+                    ("updateUnikernel('" ^ latest_build.job ^ "','"
+                   ^ latest_build.uuid ^ "','" ^ current_build.uuid ^ "','"
+                   ^ unikernel_name ^ "')");
                 ]
               ~content:(txt "Proceed to update") ~btn_type:`Primary_full ();
           ];
@@ -455,8 +456,9 @@ let unikernel_update_layout ~unikernel_name unikernel current_time
                          ~modal_title:"Unikernel Configuration"
                          ~button_content:(txt "Update to Latest")
                          ~content:
-                           (arg_modal ~unikernel_name unikernel
-                              build_comparison.right)
+                           (arg_modal ~unikernel_name
+                              ~latest_build:build_comparison.right
+                              ~current_build:build_comparison.left unikernel)
                          ()
                      else
                        p
@@ -583,7 +585,8 @@ let unikernel_update_layout ~unikernel_name unikernel current_time
            Modal_dialog.modal_dialog ~modal_title:"Unikernel Configuration"
              ~button_content:(txt "Update to Latest")
              ~content:
-               (arg_modal ~unikernel_name unikernel build_comparison.right)
+               (arg_modal ~unikernel_name ~latest_build:build_comparison.right
+                  ~current_build:build_comparison.left unikernel)
              ()
          else
            p

--- a/user_model.ml
+++ b/user_model.ml
@@ -73,10 +73,12 @@ let unikernel_update_of_json = function
       | ( Some (`String name),
           Some (`String job),
           Some (`String uuid),
-          Some (`String config),
+          Some config,
           Some (`String timestamp_str) ) ->
           let* timestamp = Utils.TimeHelper.ptime_of_string timestamp_str in
-          let* config = Albatross_json.config_of_json config in
+          let* config =
+            Albatross_json.config_of_json (Yojson.Basic.to_string config)
+          in
           Ok { name; job; uuid; config; timestamp }
       | _ ->
           Error

--- a/user_model.ml
+++ b/user_model.ml
@@ -55,6 +55,7 @@ let unikernel_update_to_json (u : unikernel_update) : Yojson.Basic.t =
       ("name", `String u.name);
       ("job", `String u.job);
       ("uuid", `String u.uuid);
+      ("config", Albatross_json.config_to_json u.config);
       ("timestamp", `String (Utils.TimeHelper.string_of_ptime u.timestamp));
     ]
 

--- a/utils.ml
+++ b/utils.ml
@@ -175,3 +175,6 @@ let display_banner = function
 let bytes_to_megabytes bytes =
   let megabytes = float_of_int bytes /. (1024.0 *. 1024.0) in
   Printf.sprintf "%.2f MB" megabytes
+
+(*10 minutes for a rollback to be valid*)
+let rollback_seconds_limit = 600


### PR DESCRIPTION
This PR implements Rollback functionality for unikernel updates.
The methodology is that, if we try to update a unikernel, we store some metadata about the running unikernel to disk and then attempt the update. If this fails, we call the rollback function with the previous running build.