### PR TITLE
Perform Liveliness checks

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -938,11 +938,54 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 	const argumentsToggle = document.getElementById("arguments-toggle").checked;
 	const molly_csrf = document.getElementById("molly-csrf").value;
 	const formAlert = document.getElementById("unikernel-arguments-alert");
+	const liveliness_toggle = document.getElementById("liveliness-toggle").checked;
+	const http_toggle = document.getElementById("http-toggle").checked;
+	const dns_toggle = document.getElementById("dns-toggle").checked;
+	const tcp_toggle = document.getElementById("tcp-toggle").checked;
+	const tcp_address = document.getElementById("tcp-address").value.trim();
+	const dns_address = document.getElementById("dns-name").value.trim();
+	const http_address = document.getElementById("http-address").value.trim();
+
 	if (argumentsToggle && !unikernelArguments) {
-		postAlert("bg-secondary-300", "You must give arguments for this build else switch 'Update the configuration for this build' off");
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "You must give arguments for this build else switch 'Update the configuration for this build' off"
 		buttonLoading(updateButton, false, "Proceed to update")
 		return;
 	}
+
+	if (liveliness_toggle && !(http_toggle || dns_toggle || tcp_toggle)) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Error: If liveliness is enabled, at least one of HTTP, DNS, or TCP must be activated."
+		buttonLoading(updateButton, false, "Proceed to update")
+		return;
+	}
+
+	if (tcp_toggle && !tcp_address) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Error: TCP is enabled, but no TCP address is provided."
+		buttonLoading(updateButton, false, "Proceed to update")
+		return;
+	}
+
+	if (dns_toggle && !dns_address) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Error: DNS is enabled, but no DNS name is provided."
+		buttonLoading(updateButton, false, "Proceed to update")
+		return;
+	}
+
+	if (http_toggle && !http_address) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Error: HTTP is enabled, but no HTTP address is provided."
+		buttonLoading(updateButton, false, "Proceed to update")
+		return;
+	}
+
 	try {
 		buttonLoading(updateButton, true, "Updating...")
 		const response = await fetch("/api/unikernel/update", {
@@ -958,6 +1001,9 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"currently_running_unikernel": currently_running_unikernel,
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
+					"http_liveliness_address": http_address ?? null,
+					"tcp_liveliness_address": tcp_address ?? null,
+					"dns_liveliness_address": dns_address ?? null,
 					"molly_csrf": molly_csrf
 				})
 		})

--- a/assets/main.js
+++ b/assets/main.js
@@ -992,11 +992,11 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"currently_running_unikernel": currently_running_unikernel,
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
-					"http_liveliness_address": http_address ? http_address : null,
-					"dns_liveliness": {
+					"http_liveliness_address": http_toggle ? (http_address ? http_address : null) : null,
+					"dns_liveliness": dns_toggle ? ({
 						"dns_address": dns_address ? dns_address : null,
 						"dns_name": dns_name ? dns_name : null
-					},
+					}) : null,
 					"molly_csrf": molly_csrf
 				})
 		})

--- a/assets/main.js
+++ b/assets/main.js
@@ -992,8 +992,11 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"currently_running_unikernel": currently_running_unikernel,
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
-					"http_liveliness_address": http_address ?? null,
-					"dns_liveliness": { "dns_address": dns_address ?? null, "dns_name": dns_name ?? null },
+					"http_liveliness_address": http_address ? http_address : null,
+					"dns_liveliness": {
+						"dns_address": dns_address ? dns_address : null,
+						"dns_name": dns_name ? dns_name : null
+					},
 					"molly_csrf": molly_csrf
 				})
 		})

--- a/assets/main.js
+++ b/assets/main.js
@@ -941,7 +941,8 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 	const liveliness_toggle = document.getElementById("liveliness-toggle").checked;
 	const http_toggle = document.getElementById("http-toggle").checked;
 	const dns_toggle = document.getElementById("dns-toggle").checked;
-	const dns_address = document.getElementById("dns-name").value.trim();
+	const dns_address = document.getElementById("dns-address").value.trim();
+	const dns_name = document.getElementById("dns-name").value.trim();
 	const http_address = document.getElementById("http-address").value.trim();
 
 	if (argumentsToggle && !unikernelArguments) {
@@ -960,10 +961,10 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 		return;
 	}
 
-	if (dns_toggle && !dns_address) {
+	if (dns_toggle && !(dns_address && dns_name)) {
 		formAlert.classList.remove("hidden", "text-primary-500");
 		formAlert.classList.add("text-secondary-500");
-		formAlert.textContent = "Error: DNS is enabled, but no DNS name is provided."
+		formAlert.textContent = "Error: DNS is enabled, but DNS name and DNS address is not provided."
 		buttonLoading(updateButton, false, "Proceed to update")
 		return;
 	}
@@ -993,6 +994,7 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
 					"http_liveliness_address": http_address ?? null,
 					"dns_liveliness_address": dns_address ?? null,
+					"dns_liveliness_name": dns_name ?? null,
 					"molly_csrf": molly_csrf
 				})
 		})

--- a/assets/main.js
+++ b/assets/main.js
@@ -932,7 +932,7 @@ async function updateToken(value) {
 	}
 }
 
-async function updateUnikernel(job, latest_build, current_build, unikernel_name) {
+async function updateUnikernel(job, to_be_updated_unikernel, currently_running_unikernel, unikernel_name) {
 	const updateButton = document.getElementById("update-unikernel-button");
 	const unikernelArguments = document.getElementById("unikernel-arguments").value;
 	const argumentsToggle = document.getElementById("arguments-toggle").checked;
@@ -954,8 +954,8 @@ async function updateUnikernel(job, latest_build, current_build, unikernel_name)
 			body: JSON.stringify(
 				{
 					"job": job,
-					"latest_build": latest_build,
-					"current_build": current_build,
+					"to_be_updated_unikernel": to_be_updated_unikernel,
+					"currently_running_unikernel": currently_running_unikernel,
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
 					"molly_csrf": molly_csrf

--- a/assets/main.js
+++ b/assets/main.js
@@ -941,8 +941,6 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 	const liveliness_toggle = document.getElementById("liveliness-toggle").checked;
 	const http_toggle = document.getElementById("http-toggle").checked;
 	const dns_toggle = document.getElementById("dns-toggle").checked;
-	const tcp_toggle = document.getElementById("tcp-toggle").checked;
-	const tcp_address = document.getElementById("tcp-address").value.trim();
 	const dns_address = document.getElementById("dns-name").value.trim();
 	const http_address = document.getElementById("http-address").value.trim();
 
@@ -954,18 +952,10 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 		return;
 	}
 
-	if (liveliness_toggle && !(http_toggle || dns_toggle || tcp_toggle)) {
+	if (liveliness_toggle && !(http_toggle || dns_toggle)) {
 		formAlert.classList.remove("hidden", "text-primary-500");
 		formAlert.classList.add("text-secondary-500");
-		formAlert.textContent = "Error: If liveliness is enabled, at least one of HTTP, DNS, or TCP must be activated."
-		buttonLoading(updateButton, false, "Proceed to update")
-		return;
-	}
-
-	if (tcp_toggle && !tcp_address) {
-		formAlert.classList.remove("hidden", "text-primary-500");
-		formAlert.classList.add("text-secondary-500");
-		formAlert.textContent = "Error: TCP is enabled, but no TCP address is provided."
+		formAlert.textContent = "Error: If liveliness is enabled, at least one of HTTP or DNS must be activated."
 		buttonLoading(updateButton, false, "Proceed to update")
 		return;
 	}
@@ -1002,7 +992,6 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
 					"http_liveliness_address": http_address ?? null,
-					"tcp_liveliness_address": tcp_address ?? null,
 					"dns_liveliness_address": dns_address ?? null,
 					"molly_csrf": molly_csrf
 				})

--- a/assets/main.js
+++ b/assets/main.js
@@ -993,8 +993,7 @@ async function updateUnikernel(job, to_be_updated_unikernel, currently_running_u
 					"unikernel_name": unikernel_name,
 					"unikernel_arguments": argumentsToggle ? JSON.parse(unikernelArguments) : null,
 					"http_liveliness_address": http_address ?? null,
-					"dns_liveliness_address": dns_address ?? null,
-					"dns_liveliness_name": dns_name ?? null,
+					"dns_liveliness": { "dns_address": dns_address ?? null, "dns_name": dns_name ?? null },
 					"molly_csrf": molly_csrf
 				})
 		})

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -1,5 +1,3 @@
-open Lwt.Infix
-
 let ( let* ) = Result.bind
 let base_url = "https://builds.robur.coop"
 
@@ -305,25 +303,3 @@ let compare_of_json = function
         (`Msg
            ("invalid json for builder_web diff, expected a dict: "
           ^ Yojson.Basic.to_string js))
-
-let send_request http_client path =
-  let url = base_url ^ path in
-  let body = "" in
-  let body_f _ acc chunk = Lwt.return (acc ^ chunk) in
-  Http_mirage_client.request http_client ~follow_redirect:true
-    ~headers:[ ("Accept", "application/json") ]
-    url body_f body
-  >>= function
-  | Error (`Msg err) -> Lwt.return (Error (`Msg err))
-  | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
-  | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
-  | Ok (resp, body) -> (
-      match resp.Http_mirage_client.status with
-      | `OK -> Lwt.return (Ok body)
-      | _ ->
-          Lwt.return
-            (Error
-               (`Msg
-                  ("accessing " ^ url ^ " resulted in an error: "
-                  ^ Http_mirage_client.Status.to_string resp.status
-                  ^ " " ^ resp.reason))))

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -5,7 +5,7 @@ let ( let* ) = Result.bind
 type checks = [ `HTTP of string | `DNS of string * string ]
 
 let http_timeout = 15 (* 15seconds timeout for http requests *)
-let dns_timeout = 5 (* 5 seconds timeout for http requests *)
+let dns_timeout = 5 (* 5 seconds timeout for dns requests *)
 
 module Make (S : Tcpip.Stack.V4V6) = struct
   module HE = Happy_eyeballs_mirage.Make (S)

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -4,7 +4,7 @@ let ( let* ) = Result.bind
 
 type checks = [ `HTTP of string | `DNS of string * string ]
 
-let http_timeout = 15 (* 15seconds timeout for http requests *)
+let http_timeout = 15 (* 15 seconds timeout for http requests *)
 let dns_timeout = 5 (* 5 seconds timeout for dns requests *)
 
 module Make (S : Tcpip.Stack.V4V6) = struct

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -5,7 +5,7 @@ let ( let* ) = Result.bind
 type checks = [ `HTTP of string | `TCP of string | `DNS of string ]
 
 let check_http http_client base_url =
-  Utils.send_request http_client ~base_url >>= function
+  Utils.send_http_request http_client ~base_url >>= function
   | Error (`Msg err) ->
       Logs.err (fun m ->
           m "http-liveliness-check: Error response of %s with error: %s"

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -87,13 +87,6 @@ module Make (S : Tcpip.Stack.V4V6) = struct
         in
         Error (`Msg err_msg)
 
-  let perform_checks_with_timeout ~timeout stack http_client checks =
-    Lwt.pick
-      [
-        (perform_checks stack http_client checks >|= fun r -> `Result r);
-        (Mirage_sleep.ns (Duration.of_sec timeout) >|= fun () -> `Timeout);
-      ]
-
   let prepare_liveliness_parameters ~http_liveliness_address ~dns_liveliness =
     let* http_liveliness_address =
       Utils.Json.string_or_none "http_liveliness_address"

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -70,19 +70,18 @@ module Make (S : Tcpip.Stack.V4V6) = struct
         in
         Error (`Msg err_msg)
 
-  let liveliness_checks ~http_liveliness_address ~dns_liveliness_address
-      ~dns_liveliness_name stack http_client =
+  let liveliness_checks ~http_liveliness_address ~dns_liveliness stack
+      http_client =
     Lwt.return
       (let* http_liveliness_address =
          Utils.Json.string_or_none "http_liveliness_address"
            http_liveliness_address
        in
        let* dns_liveliness_address =
-         Utils.Json.string_or_none "dns_liveliness_address"
-           dns_liveliness_address
+         Utils.Json.string_or_none "dns_address" dns_liveliness
        in
        let* dns_liveliness_name =
-         Utils.Json.string_or_none "dns_liveliness_name" dns_liveliness_name
+         Utils.Json.string_or_none "dns_name" dns_liveliness
        in
        let validated_checks =
          List.filter_map
@@ -113,7 +112,7 @@ module Make (S : Tcpip.Stack.V4V6) = struct
             Error (`Msg err))
 
   let interval_liveliness_checks ~unikernel_name ~http_liveliness_address
-      ~dns_liveliness_address ~dns_liveliness_name stack http_client =
+      ~dns_liveliness stack http_client =
     let rec aux_check failed_checks delay_intervals =
       match delay_intervals with
       | [] ->
@@ -133,8 +132,8 @@ module Make (S : Tcpip.Stack.V4V6) = struct
           Logs.info (fun m ->
               m "Performing liveliness check of %s after %d second delay."
                 unikernel_name delay);
-          liveliness_checks ~http_liveliness_address ~dns_liveliness_address
-            ~dns_liveliness_name stack http_client
+          liveliness_checks ~http_liveliness_address ~dns_liveliness stack
+            http_client
           >>= function
           | Error (`Msg err) -> aux_check (err :: failed_checks) rest
           | Ok () -> aux_check failed_checks rest)

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -4,118 +4,138 @@ let ( let* ) = Result.bind
 
 type checks = [ `HTTP of string | `DNS of string * string ]
 
-let check_http http_client base_url =
-  Utils.send_http_request http_client ~base_url >>= function
-  | Error (`Msg err) ->
-      Logs.err (fun m ->
-          m "http-liveliness-check: Error response of %s with error: %s"
-            base_url err);
-      Lwt.return
-        (Error
-           (`Msg
-              (base_url
-             ^ " :an error occured while performing a liveliness check on the \
-                http endpoint with error: " ^ err)))
-  | Ok _response -> Ok () |> Lwt.return
+module Make (S : Tcpip.Stack.V4V6) = struct
+  module HE = Happy_eyeballs_mirage.Make (S)
+  module Dns = Dns_client_mirage.Make (S) (HE)
 
-let check_type http_client = function
-  | `HTTP address -> check_http http_client address
-  | `DNS (address, domain_name) ->
-      Error
-        (`Msg
-           (domain_name
-          ^ ": Can't handle DNS liveliness checks at the moment with address "
-          ^ address))
-      |> Lwt.return
+  let check_dns stack dns_server domain_name =
+    HE.connect_device stack >>= fun he ->
+    Dns.connect
+      ~nameservers:[ "tcp:" ^ dns_server; "udp:" ^ dns_server ]
+      (stack, he)
+    >>= fun dns_client ->
+    Dns.gethostbyname dns_client
+      (Domain_name.of_string_exn domain_name |> Domain_name.host_exn)
+    >|= function
+    | Error (`Msg err) ->
+        Logs.err (fun m ->
+            m "dns-liveliness-check: Error response of %s with error: %s"
+              domain_name err);
+        Error
+          (`Msg
+             (domain_name
+            ^ " :an error occured while performing a liveliness check on the \
+               DNS endpoint with error: " ^ err))
+    | Ok _response -> Ok ()
 
-let rec perform_checks http_client failed = function
-  | [] -> (
-      match failed with
-      | [] -> Lwt.return (Ok ())
-      | _ ->
-          let err_msg =
-            "Liveliness checks failed for: "
-            ^ String.concat ", " (List.rev failed)
-          in
-          Lwt.return (Error (`Msg err_msg)))
-  | check :: rest -> (
-      check_type http_client check >>= function
-      | Ok _ -> perform_checks http_client failed rest
-      | Error (`Msg err) ->
-          let failed_desc =
-            match check with
-            | `HTTP url -> "HTTP (" ^ url ^ "): " ^ err
-            | `DNS (address, domain_name) ->
-                "DNS (" ^ domain_name ^ ", " ^ address ^ "): " ^ err
-          in
-          perform_checks http_client (failed_desc :: failed) rest)
+  let check_http http_client base_url =
+    Utils.send_http_request http_client ~base_url >>= function
+    | Error (`Msg err) ->
+        Logs.err (fun m ->
+            m "http-liveliness-check: Error response of %s with error: %s"
+              base_url err);
+        Lwt.return
+          (Error
+             (`Msg
+                (base_url
+               ^ " :an error occured while performing a liveliness check on \
+                  the http endpoint with error: " ^ err)))
+    | Ok _response -> Ok () |> Lwt.return
 
-let liveliness_checks ~http_liveliness_address ~dns_liveliness_address
-    ~dns_liveliness_name http_client =
-  Lwt.return
-    (let* http_liveliness_address =
-       Utils.Json.string_or_none "http_liveliness_address"
-         http_liveliness_address
-     in
-     let* dns_liveliness_address =
-       Utils.Json.string_or_none "dns_liveliness_address" dns_liveliness_address
-     in
-     let* dns_liveliness_name =
-       Utils.Json.string_or_none "dns_liveliness_name" dns_liveliness_name
-     in
-     let validated_checks =
-       List.filter_map
-         (fun kind ->
-           match kind with
-           | `HTTP addr -> (
-               match addr with Some addr -> Some (`HTTP addr) | None -> None)
-           | `DNS (address, domain_name) -> (
-               match (address, domain_name) with
-               | Some address, Some domain_name ->
-                   Some (`DNS (address, domain_name))
-               | _ -> None))
-         [
-           `HTTP http_liveliness_address;
-           `DNS (dns_liveliness_address, dns_liveliness_name);
-         ]
-     in
-     Ok validated_checks)
-  >>= function
-  | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
-  | Ok checks -> (
-      perform_checks http_client [] checks >>= function
-      | Ok () ->
-          Logs.info (fun m -> m "All liveliness checks passed.");
-          Lwt.return (Ok ())
-      | Error (`Msg err) ->
-          Logs.err (fun m -> m "liveliness-checks-failed with error %s" err);
-          Lwt.return (Error (`Msg err)))
+  let check_type stack http_client = function
+    | `HTTP address -> check_http http_client address
+    | `DNS (address, domain_name) -> check_dns stack address domain_name
 
-let interval_liveliness_checks ~unikernel_name ~http_liveliness_address
-    ~dns_liveliness_address ~dns_liveliness_name http_client =
-  let rec aux_check failed_checks delay_intervals =
-    match delay_intervals with
-    | [] ->
-        (match failed_checks with
-        | [] -> Ok ()
+  let rec perform_checks stack http_client failed = function
+    | [] -> (
+        match failed with
+        | [] -> Lwt.return (Ok ())
         | _ ->
             let err_msg =
-              "Liveliness checks failed with error(s): "
-              ^ String.concat ", " (List.rev failed_checks)
+              "Liveliness checks failed for: "
+              ^ String.concat ", " (List.rev failed)
             in
-            Logs.info (fun m ->
-                m "liveliness-checks for %s: %s" unikernel_name err_msg);
-            Error (`Msg err_msg))
-        |> Lwt.return
-    | delay :: rest -> (
-        Mirage_sleep.ns (Duration.of_sec delay) >>= fun () ->
-        Logs.info (fun m ->
-            m "Performing liveliness check of %s after %d second delay."
-              unikernel_name delay);
-        liveliness_checks ~http_liveliness_address ~dns_liveliness_address
-          ~dns_liveliness_name http_client
-        >>= function
-        | Error (`Msg err) -> aux_check (err :: failed_checks) rest
-        | Ok () -> aux_check failed_checks rest)
-  in
-  aux_check [] [ 1; 2; 5; 9; 14; 20; 27; 35; 44; 54 ]
+            Lwt.return (Error (`Msg err_msg)))
+    | check :: rest -> (
+        check_type stack http_client check >>= function
+        | Ok _ -> perform_checks stack http_client failed rest
+        | Error (`Msg err) ->
+            let failed_desc =
+              match check with
+              | `HTTP url -> "HTTP (" ^ url ^ "): " ^ err
+              | `DNS (address, domain_name) ->
+                  "DNS (" ^ domain_name ^ ", " ^ address ^ "): " ^ err
+            in
+            perform_checks stack http_client (failed_desc :: failed) rest)
+
+  let liveliness_checks ~http_liveliness_address ~dns_liveliness_address
+      ~dns_liveliness_name stack http_client =
+    Lwt.return
+      (let* http_liveliness_address =
+         Utils.Json.string_or_none "http_liveliness_address"
+           http_liveliness_address
+       in
+       let* dns_liveliness_address =
+         Utils.Json.string_or_none "dns_liveliness_address"
+           dns_liveliness_address
+       in
+       let* dns_liveliness_name =
+         Utils.Json.string_or_none "dns_liveliness_name" dns_liveliness_name
+       in
+       let validated_checks =
+         List.filter_map
+           (fun kind ->
+             match kind with
+             | `HTTP addr -> (
+                 match addr with Some addr -> Some (`HTTP addr) | None -> None)
+             | `DNS (address, domain_name) -> (
+                 match (address, domain_name) with
+                 | Some address, Some domain_name ->
+                     Some (`DNS (address, domain_name))
+                 | _ -> None))
+           [
+             `HTTP http_liveliness_address;
+             `DNS (dns_liveliness_address, dns_liveliness_name);
+           ]
+       in
+       Ok validated_checks)
+    >>= function
+    | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
+    | Ok checks -> (
+        perform_checks stack http_client [] checks >>= function
+        | Ok () ->
+            Logs.info (fun m -> m "All liveliness checks passed.");
+            Lwt.return (Ok ())
+        | Error (`Msg err) ->
+            Logs.err (fun m -> m "liveliness-checks-failed with error %s" err);
+            Lwt.return (Error (`Msg err)))
+
+  let interval_liveliness_checks ~unikernel_name ~http_liveliness_address
+      ~dns_liveliness_address ~dns_liveliness_name stack http_client =
+    let rec aux_check failed_checks delay_intervals =
+      match delay_intervals with
+      | [] ->
+          (match failed_checks with
+          | [] -> Ok ()
+          | _ ->
+              let err_msg =
+                "Liveliness checks failed with error(s): "
+                ^ String.concat ", " (List.rev failed_checks)
+              in
+              Logs.info (fun m ->
+                  m "liveliness-checks for %s: %s" unikernel_name err_msg);
+              Error (`Msg err_msg))
+          |> Lwt.return
+      | delay :: rest -> (
+          Mirage_sleep.ns (Duration.of_sec delay) >>= fun () ->
+          Logs.info (fun m ->
+              m "Performing liveliness check of %s after %d second delay."
+                unikernel_name delay);
+          liveliness_checks ~http_liveliness_address ~dns_liveliness_address
+            ~dns_liveliness_name stack http_client
+          >>= function
+          | Error (`Msg err) -> aux_check (err :: failed_checks) rest
+          | Ok () -> aux_check failed_checks rest)
+    in
+    aux_check [] [ 1; 2; 5; 9; 14; 20; 27; 35; 44; 54 ]
+end

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -1,0 +1,89 @@
+open Lwt.Infix
+
+let ( let* ) = Result.bind
+
+type checks = [ `HTTP of string | `TCP of string | `DNS of string ]
+
+let check_http http_client base_url =
+  Utils.send_request http_client ~base_url >>= function
+  | Error (`Msg err) ->
+      Logs.err (fun m ->
+          m "http-liveliness-check: Error response of %s with error: %s"
+            base_url err);
+      Lwt.return
+        (Error
+           (`Msg
+              (base_url
+             ^ " :an error occured while performing a liveliness check on the \
+                http endpoint with error: " ^ err)))
+  | Ok _response -> Ok () |> Lwt.return
+
+let check_type http_client = function
+  | `HTTP address -> check_http http_client address
+  | `TCP address ->
+      Error
+        (`Msg (address ^ ": Can't handle TCP liveliness checks at the moment"))
+      |> Lwt.return
+  | `DNS address ->
+      Error
+        (`Msg (address ^ ": Can't handle DNS liveliness checks at the moment"))
+      |> Lwt.return
+
+let rec perform_checks http_client failed = function
+  | [] -> (
+      match failed with
+      | [] -> Lwt.return (Ok ())
+      | _ ->
+          let err_msg =
+            "Liveliness checks failed for: "
+            ^ String.concat ", " (List.rev failed)
+          in
+          Lwt.return (Error (`Msg err_msg)))
+  | check :: rest -> (
+      check_type http_client check >>= function
+      | Ok _ -> perform_checks http_client failed rest
+      | Error (`Msg err) ->
+          let failed_desc =
+            match check with
+            | `HTTP url -> "HTTP (" ^ url ^ "): " ^ err
+            | `TCP addr -> "TCP (" ^ addr ^ "): " ^ err
+            | `DNS domain -> "DNS (" ^ domain ^ "): " ^ err
+          in
+          perform_checks http_client (failed_desc :: failed) rest)
+
+let liveliness_checks ~http_liveliness_address ~dns_liveliness_address
+    ~tcp_liveliness_address http_client =
+  Lwt.return
+    (let* http_liveliness_address =
+       Utils.Json.string_or_none "http_liveliness_address"
+         http_liveliness_address
+     in
+     let* tcp_liveliness_address =
+       Utils.Json.string_or_none "tcp_liveliness_address" tcp_liveliness_address
+     in
+     let* dns_liveliness_address =
+       Utils.Json.string_or_none "dns_liveliness_address" dns_liveliness_address
+     in
+     let validated_checks =
+       List.filter_map
+         (fun (constructor, value) ->
+           match value with
+           | Some addr -> Some (constructor addr)
+           | None -> None)
+         [
+           ((fun addr -> `HTTP addr), http_liveliness_address);
+           ((fun addr -> `TCP addr), tcp_liveliness_address);
+           ((fun addr -> `DNS addr), dns_liveliness_address);
+         ]
+     in
+     Ok validated_checks)
+  >>= function
+  | Error (`Msg msg) -> Lwt.return (Error (`Msg msg))
+  | Ok checks -> (
+      perform_checks http_client [] checks >>= function
+      | Ok () ->
+          Logs.info (fun m -> m "All liveliness checks passed.");
+          Lwt.return (Ok ())
+      | Error (`Msg err) ->
+          Logs.err (fun m -> m "liveliness-checks-failed with error %s" err);
+          Lwt.return (Error (`Msg err)))

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -4,8 +4,7 @@ let ( let* ) = Result.bind
 
 type checks = [ `HTTP of string | `DNS of string * string ]
 
-let http_timeout = 15 (* 15 seconds timeout for http requests *)
-let dns_timeout = 5 (* 5 seconds timeout for dns requests *)
+let timeout = 5 (* 5 seconds timeout for one check *)
 
 module Make (S : Tcpip.Stack.V4V6) = struct
   module HE = Happy_eyeballs_mirage.Make (S)

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -173,6 +173,6 @@ module Make (S : Tcpip.Stack.V4V6) = struct
               | Error (`Msg err) -> aux_check (err :: failed_checks) rest
               | Ok () -> Ok () |> Lwt.return)
         in
-        aux_check [] [ 1; 2; 5; 9; 14; 20; 27; 35; 44; 54 ]
+        aux_check [] [ 1; 1; 1; 2; 3; 3; 4; 5 ]
     | Error (`Msg err) -> Error (`Msg err) |> Lwt.return
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1383,9 +1383,8 @@ struct
           `Internal_server_error
 
   let process_unikernel_update ~unikernel_name ~job ~to_be_updated_unikernel
-      ~currently_running_unikernel ~http_liveliness_address
-      ~dns_liveliness_address ~dns_liveliness_name stack cfg user store
-      http_client albatross reqd =
+      ~currently_running_unikernel ~http_liveliness_address ~dns_liveliness
+      stack cfg user store http_client albatross reqd =
     process_change ~unikernel_name ~job ~to_be_updated_unikernel
       ~currently_running_unikernel cfg user store http_client `Update
     >>= function
@@ -1395,8 +1394,7 @@ struct
         >>= function
         | Ok _res -> (
             Liveliness.interval_liveliness_checks ~unikernel_name
-              ~http_liveliness_address ~dns_liveliness_address
-              ~dns_liveliness_name stack http_client
+              ~http_liveliness_address ~dns_liveliness stack http_client
             >>= function
             | Error (`Msg err) ->
                 Logs.err (fun m ->
@@ -1447,8 +1445,7 @@ struct
           get "currently_running_unikernel" json_dict,
           get "unikernel_name" json_dict,
           get "http_liveliness_address" json_dict,
-          get "dns_liveliness_address" json_dict,
-          get "dns_liveliness_name" json_dict,
+          get "dns_liveliness" json_dict,
           get "unikernel_arguments" json_dict )
     with
     | ( Some (`String job),
@@ -1456,11 +1453,10 @@ struct
         Some (`String currently_running_unikernel),
         Some (`String unikernel_name),
         http_liveliness_address,
-        dns_liveliness_address,
-        dns_liveliness_name,
+        dns_liveliness,
         configuration ) -> (
-        Liveliness.liveliness_checks ~http_liveliness_address
-          ~dns_liveliness_address ~dns_liveliness_name stack http_client
+        Liveliness.liveliness_checks ~http_liveliness_address ~dns_liveliness
+          stack http_client
         >>= function
         | Ok () -> (
             match config_or_none "unikernel_arguments" configuration with
@@ -1492,9 +1488,8 @@ struct
                     | Ok cfg ->
                         process_unikernel_update ~unikernel_name ~job
                           ~to_be_updated_unikernel ~currently_running_unikernel
-                          ~http_liveliness_address ~dns_liveliness_address
-                          ~dns_liveliness_name stack cfg user store http_client
-                          albatross reqd
+                          ~http_liveliness_address ~dns_liveliness stack cfg
+                          user store http_client albatross reqd
                     | Error (`Msg err) ->
                         Logs.warn (fun m -> m "Couldn't decode data %s" err);
                         Middleware.http_response reqd ~title:"Error"
@@ -1503,9 +1498,8 @@ struct
             | Ok (Some cfg) ->
                 process_unikernel_update ~unikernel_name ~job
                   ~to_be_updated_unikernel ~currently_running_unikernel
-                  ~http_liveliness_address ~dns_liveliness_address
-                  ~dns_liveliness_name stack cfg user store http_client
-                  albatross reqd)
+                  ~http_liveliness_address ~dns_liveliness stack cfg user store
+                  http_client albatross reqd)
         | Error (`Msg err) ->
             Logs.info (fun m ->
                 m

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1402,7 +1402,6 @@ struct
           get "currently_running_unikernel" json_dict,
           get "unikernel_name" json_dict,
           get "http_liveliness_address" json_dict,
-          get "tcp_liveliness_address" json_dict,
           get "dns_liveliness_address" json_dict,
           get "unikernel_arguments" json_dict )
     with
@@ -1411,7 +1410,6 @@ struct
         Some (`String currently_running_unikernel),
         Some (`String unikernel_name),
         http_liveliness_address,
-        tcp_liveliness_address,
         dns_liveliness_address,
         configuration ) -> (
         match config_or_none "unikernel_arguments" configuration with
@@ -1484,18 +1482,15 @@ struct
                   unikernel_cfg user albatross
                 >>= function
                 | Ok _res -> (
-                    Mirage_sleep.ns
-                      (Duration.of_sec Utils.liveliness_wait_period)
-                    >>= fun () ->
-                    Liveliness_checks.liveliness_checks ~http_liveliness_address
-                      ~tcp_liveliness_address ~dns_liveliness_address
+                    Liveliness_checks.interval_liveliness_checks ~unikernel_name
+                      ~http_liveliness_address ~dns_liveliness_address
                       http_client
                     >>= function
                     | Error (`Msg err) ->
                         Logs.err (fun m ->
                             m
                               "liveliness-checks for %s and build %s failed \
-                               with error %s. now performing a rollback"
+                               with error(s) %s. now performing a rollback"
                               unikernel_name to_be_updated_unikernel err);
                         process_rollback ~unikernel_name (Mirage_ptime.now ())
                           albatross store http_client reqd user

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1045,7 +1045,7 @@ struct
           ~title:"Albatross Error" ~api_meth:false `Internal_server_error reqd
           ()
     | Ok (unikernel_name, unikernel) -> (
-        Utils.send_request http_client ~base_url:Builder_web.base_url
+        Utils.send_http_request http_client ~base_url:Builder_web.base_url
           ~path:("/hash?sha256=" ^ Ohex.encode unikernel.digest)
         >>= function
         | Error (`Msg err) ->
@@ -1080,7 +1080,8 @@ struct
                   ~title:(name ^ " update Error") ~api_meth:false
                   `Internal_server_error reqd ()
             | Ok current_job_data -> (
-                Utils.send_request http_client ~base_url:Builder_web.base_url
+                Utils.send_http_request http_client
+                  ~base_url:Builder_web.base_url
                   ~path:("/job/" ^ current_job_data.job ^ "/build/latest")
                 >>= function
                 | Error (`Msg err) ->
@@ -1137,7 +1138,7 @@ struct
                              ^ " found on builds.robur.coop")
                             ())
                         else
-                          Utils.send_request http_client
+                          Utils.send_http_request http_client
                             ~base_url:Builder_web.base_url
                             ~path:
                               ("/compare/" ^ current_job_data.uuid ^ "/"
@@ -1284,7 +1285,7 @@ struct
                  ),
                (`Internal_server_error : H1.Status.t) ))
     | Ok () -> (
-        Utils.send_request http_client ~base_url:Builder_web.base_url
+        Utils.send_http_request http_client ~base_url:Builder_web.base_url
           ~path:
             ("/job/" ^ job ^ "/build/" ^ to_be_updated_unikernel
            ^ "/main-binary")

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1045,8 +1045,8 @@ struct
           ~title:"Albatross Error" ~api_meth:false `Internal_server_error reqd
           ()
     | Ok (unikernel_name, unikernel) -> (
-        Builder_web.send_request http_client
-          ("/hash?sha256=" ^ Ohex.encode unikernel.digest)
+        Utils.send_request http_client ~base_url:Builder_web.base_url
+          ~path:("/hash?sha256=" ^ Ohex.encode unikernel.digest)
         >>= function
         | Error (`Msg err) ->
             Logs.err (fun m ->
@@ -1080,8 +1080,8 @@ struct
                   ~title:(name ^ " update Error") ~api_meth:false
                   `Internal_server_error reqd ()
             | Ok current_job_data -> (
-                Builder_web.send_request http_client
-                  ("/job/" ^ current_job_data.job ^ "/build/latest")
+                Utils.send_request http_client ~base_url:Builder_web.base_url
+                  ~path:("/job/" ^ current_job_data.job ^ "/build/latest")
                 >>= function
                 | Error (`Msg err) ->
                     Logs.err (fun m ->
@@ -1137,7 +1137,9 @@ struct
                              ^ " found on builds.robur.coop")
                             ())
                         else
-                          Builder_web.send_request http_client
+                          Utils.send_request http_client
+                            ~base_url:Builder_web.base_url
+                            ~path:
                             ("/compare/" ^ current_job_data.uuid ^ "/"
                            ^ latest_job_data.uuid ^ "")
                           >>= function
@@ -1282,8 +1284,10 @@ struct
                  ),
                (`Internal_server_error : H1.Status.t) ))
     | Ok () -> (
-        Builder_web.send_request http_client
-          ("/job/" ^ job ^ "/build/" ^ to_be_updated_unikernel ^ "/main-binary")
+        Utils.send_request http_client ~base_url:Builder_web.base_url
+          ~path:
+            ("/job/" ^ job ^ "/build/" ^ to_be_updated_unikernel
+           ^ "/main-binary")
         >>= function
         | Error (`Msg err) ->
             Logs.err (fun m ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1403,6 +1403,7 @@ struct
           get "unikernel_name" json_dict,
           get "http_liveliness_address" json_dict,
           get "dns_liveliness_address" json_dict,
+          get "dns_liveliness_name" json_dict,
           get "unikernel_arguments" json_dict )
     with
     | ( Some (`String job),
@@ -1411,6 +1412,7 @@ struct
         Some (`String unikernel_name),
         http_liveliness_address,
         dns_liveliness_address,
+        dns_liveliness_name,
         configuration ) -> (
         match config_or_none "unikernel_arguments" configuration with
         | Error (`Msg err) ->
@@ -1421,7 +1423,7 @@ struct
               `Bad_request
         | Ok None -> (
             Liveliness_checks.liveliness_checks ~http_liveliness_address
-              ~dns_liveliness_address http_client
+              ~dns_liveliness_address ~dns_liveliness_name http_client
             >>= function
             | Ok () -> (
                 user_unikernel albatross ~user_name:user.name ~unikernel_name
@@ -1493,7 +1495,7 @@ struct
                   `Bad_request)
         | Ok (Some cfg) -> (
             Liveliness_checks.liveliness_checks ~http_liveliness_address
-              ~dns_liveliness_address http_client
+              ~dns_liveliness_address ~dns_liveliness_name http_client
             >>= function
             | Ok () -> (
                 process_change ~unikernel_name ~job ~to_be_updated_unikernel
@@ -1507,7 +1509,8 @@ struct
                     | Ok _res -> (
                         Liveliness_checks.interval_liveliness_checks
                           ~unikernel_name ~http_liveliness_address
-                          ~dns_liveliness_address http_client
+                          ~dns_liveliness_address ~dns_liveliness_name
+                          http_client
                         >>= function
                         | Error (`Msg err) ->
                             Logs.err (fun m ->

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -1,5 +1,5 @@
-let arg_modal ~unikernel_name ~(latest_build : Builder_web.build)
-    ~(current_build : Builder_web.build)
+let arg_modal ~unikernel_name ~(to_be_updated_unikernel : Builder_web.build)
+    ~(currently_running_unikernel : Builder_web.build)
     (unikernel : Vmm_core.Name.t * Vmm_core.Unikernel.info) =
   Tyxml_html.(
     section
@@ -55,9 +55,10 @@ let arg_modal ~unikernel_name ~(latest_build : Builder_web.build)
                 [
                   a_id "update-unikernel-button";
                   a_onclick
-                    ("updateUnikernel('" ^ latest_build.job ^ "','"
-                   ^ latest_build.uuid ^ "','" ^ current_build.uuid ^ "','"
-                   ^ unikernel_name ^ "')");
+                    ("updateUnikernel('" ^ to_be_updated_unikernel.job ^ "','"
+                   ^ to_be_updated_unikernel.uuid ^ "','"
+                   ^ currently_running_unikernel.uuid ^ "','" ^ unikernel_name
+                   ^ "')");
                 ]
               ~content:(txt "Proceed to update") ~btn_type:`Primary_full ();
           ];
@@ -383,8 +384,9 @@ let unikernel_update_layout ~unikernel_name unikernel current_time
                          ~button_content:(txt "Update to Latest")
                          ~content:
                            (arg_modal ~unikernel_name
-                              ~latest_build:build_comparison.right
-                              ~current_build:build_comparison.left unikernel)
+                              ~to_be_updated_unikernel:build_comparison.right
+                              ~currently_running_unikernel:build_comparison.left
+                              unikernel)
                          ()
                      else
                        p
@@ -511,8 +513,9 @@ let unikernel_update_layout ~unikernel_name unikernel current_time
            Modal_dialog.modal_dialog ~modal_title:"Unikernel Configuration"
              ~button_content:(txt "Update to Latest")
              ~content:
-               (arg_modal ~unikernel_name ~latest_build:build_comparison.right
-                  ~current_build:build_comparison.left unikernel)
+               (arg_modal ~unikernel_name
+                  ~to_be_updated_unikernel:build_comparison.right
+                  ~currently_running_unikernel:build_comparison.left unikernel)
              ()
          else
            p

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -77,6 +77,45 @@ let arg_modal ~unikernel_name ~(to_be_updated_unikernel : Builder_web.build)
                                         a_autocomplete `On;
                                         a_input_type `Text;
                                         a_name "dns_name";
+                                        a_id "dns-name";
+                                        a_placeholder "e.g robur.coop";
+                                        a_class
+                                          [
+                                            "ring-primary-100 mt-1.5 \
+                                             transition appearance-none block \
+                                             w-full px-3 py-3 rounded-xl \
+                                             shadow-sm border \
+                                             hover:border-primary-200\n\
+                                            \                                           \
+                                             focus:border-primary-300 \
+                                             bg-primary-50 bg-opacity-0 \
+                                             hover:bg-opacity-50 \
+                                             focus:bg-opacity-50 \
+                                             ring-primary-200 \
+                                             focus:ring-primary-200\n\
+                                            \                                           \
+                                             focus:ring-[1px] \
+                                             focus:outline-none";
+                                          ];
+                                      ]
+                                    ();
+                                  label
+                                    ~a:
+                                      [
+                                        a_class [ "block text-sm font-medium" ];
+                                        a_label_for "dns_name";
+                                      ]
+                                    [
+                                      txt
+                                        "Domain IP address for liveliness check";
+                                    ];
+                                  input
+                                    ~a:
+                                      [
+                                        a_autocomplete `On;
+                                        a_input_type `Text;
+                                        a_name "dns_address";
+                                        a_placeholder "e.g 127.0.0.1";
                                         a_id "dns-address";
                                         a_class
                                           [

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -8,6 +8,144 @@ let arg_modal ~unikernel_name ~(to_be_updated_unikernel : Builder_web.build)
         div
           ~a:[ a_class [ "my-4" ] ]
           [
+            Utils.switch_button ~switch_id:"liveliness-toggle"
+              ~switch_label:"Perform a liveliness check after updating"
+              (div
+                 ~a:[ a_class [ "px-4" ] ]
+                 [
+                   div
+                     [
+                       Utils.switch_button ~switch_id:"http-toggle"
+                         ~switch_label:"HTTP check"
+                         (div
+                            [
+                              div
+                                [
+                                  label
+                                    ~a:
+                                      [
+                                        a_class [ "block text-sm font-medium" ];
+                                        a_label_for "http_address";
+                                      ]
+                                    [ txt "HTTP address for liveliness check" ];
+                                  input
+                                    ~a:
+                                      [
+                                        a_autocomplete `On;
+                                        a_input_type `Text;
+                                        a_name "http_address";
+                                        a_id "http-address";
+                                        a_class
+                                          [
+                                            "ring-primary-100 mt-1.5 \
+                                             transition appearance-none block \
+                                             w-full px-3 py-3 rounded-xl \
+                                             shadow-sm border \
+                                             hover:border-primary-200\n\
+                                            \                                           \
+                                             focus:border-primary-300 \
+                                             bg-primary-50 bg-opacity-0 \
+                                             hover:bg-opacity-50 \
+                                             focus:bg-opacity-50 \
+                                             ring-primary-200 \
+                                             focus:ring-primary-200\n\
+                                            \                                           \
+                                             focus:ring-[1px] \
+                                             focus:outline-none";
+                                          ];
+                                      ]
+                                    ();
+                                ];
+                            ]);
+                       hr ();
+                       Utils.switch_button ~switch_id:"dns-toggle"
+                         ~switch_label:"DNS check"
+                         (div
+                            [
+                              div
+                                [
+                                  label
+                                    ~a:
+                                      [
+                                        a_class [ "block text-sm font-medium" ];
+                                        a_label_for "dns_name";
+                                      ]
+                                    [ txt "Domain name for liveliness check" ];
+                                  input
+                                    ~a:
+                                      [
+                                        a_autocomplete `On;
+                                        a_input_type `Text;
+                                        a_name "dns_name";
+                                        a_id "dns-address";
+                                        a_class
+                                          [
+                                            "ring-primary-100 mt-1.5 \
+                                             transition appearance-none block \
+                                             w-full px-3 py-3 rounded-xl \
+                                             shadow-sm border \
+                                             hover:border-primary-200\n\
+                                            \                                           \
+                                             focus:border-primary-300 \
+                                             bg-primary-50 bg-opacity-0 \
+                                             hover:bg-opacity-50 \
+                                             focus:bg-opacity-50 \
+                                             ring-primary-200 \
+                                             focus:ring-primary-200\n\
+                                            \                                           \
+                                             focus:ring-[1px] \
+                                             focus:outline-none";
+                                          ];
+                                      ]
+                                    ();
+                                ];
+                            ]);
+                       hr ();
+                       Utils.switch_button ~switch_id:"tcp-toggle"
+                         ~switch_label:"TCP check"
+                         (div
+                            [
+                              div
+                                [
+                                  label
+                                    ~a:
+                                      [
+                                        a_class [ "block text-sm font-medium" ];
+                                        a_label_for "http_link";
+                                      ]
+                                    [ txt "TCP address for liveliness check" ];
+                                  input
+                                    ~a:
+                                      [
+                                        a_autocomplete `On;
+                                        a_input_type `Text;
+                                        a_name "tcp_address";
+                                        a_id "tcp-address";
+                                        a_class
+                                          [
+                                            "ring-primary-100 mt-1.5 \
+                                             transition appearance-none block \
+                                             w-full px-3 py-3 rounded-xl \
+                                             shadow-sm border \
+                                             hover:border-primary-200\n\
+                                            \                                           \
+                                             focus:border-primary-300 \
+                                             bg-primary-50 bg-opacity-0 \
+                                             hover:bg-opacity-50 \
+                                             focus:bg-opacity-50 \
+                                             ring-primary-200 \
+                                             focus:ring-primary-200\n\
+                                            \                                           \
+                                             focus:ring-[1px] \
+                                             focus:outline-none";
+                                          ];
+                                      ]
+                                    ();
+                                ];
+                            ]);
+                     ];
+                 ]);
+            hr ();
             Utils.switch_button ~switch_id:"arguments-toggle"
               ~switch_label:"Update the configuration for this build"
               (div

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -35,6 +35,7 @@ let arg_modal ~unikernel_name ~(to_be_updated_unikernel : Builder_web.build)
                                         a_input_type `Text;
                                         a_name "http_address";
                                         a_id "http-address";
+                                        a_placeholder "https://example.com";
                                         a_class
                                           [
                                             "ring-primary-100 mt-1.5 \

--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -100,49 +100,6 @@ let arg_modal ~unikernel_name ~(to_be_updated_unikernel : Builder_web.build)
                                     ();
                                 ];
                             ]);
-                       hr ();
-                       Utils.switch_button ~switch_id:"tcp-toggle"
-                         ~switch_label:"TCP check"
-                         (div
-                            [
-                              div
-                                [
-                                  label
-                                    ~a:
-                                      [
-                                        a_class [ "block text-sm font-medium" ];
-                                        a_label_for "http_link";
-                                      ]
-                                    [ txt "TCP address for liveliness check" ];
-                                  input
-                                    ~a:
-                                      [
-                                        a_autocomplete `On;
-                                        a_input_type `Text;
-                                        a_name "tcp_address";
-                                        a_id "tcp-address";
-                                        a_class
-                                          [
-                                            "ring-primary-100 mt-1.5 \
-                                             transition appearance-none block \
-                                             w-full px-3 py-3 rounded-xl \
-                                             shadow-sm border \
-                                             hover:border-primary-200\n\
-                                            \                                           \
-                                             focus:border-primary-300 \
-                                             bg-primary-50 bg-opacity-0 \
-                                             hover:bg-opacity-50 \
-                                             focus:bg-opacity-50 \
-                                             ring-primary-200 \
-                                             focus:ring-primary-200\n\
-                                            \                                           \
-                                             focus:ring-[1px] \
-                                             focus:outline-none";
-                                          ];
-                                      ]
-                                    ();
-                                ];
-                            ]);
                      ];
                  ]);
             hr ();

--- a/utils.ml
+++ b/utils.ml
@@ -266,7 +266,7 @@ let send_http_request ?(path = "") ~base_url http_client =
   | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
   | Ok (resp, body) -> (
       match resp.Http_mirage_client.status with
-      | `Code 200 -> Lwt.return (Ok body)
+      | `OK | `Created | `Accepted -> Lwt.return (Ok body)
       | _ ->
           Lwt.return
             (Error

--- a/utils.ml
+++ b/utils.ml
@@ -1,3 +1,7 @@
+open Lwt.Infix
+
+let ( let* ) = Result.bind
+
 module Json = struct
   let get key assoc =
     Option.map snd (List.find_opt (fun (k, _) -> String.equal k key) assoc)
@@ -248,3 +252,25 @@ let switch_button ~switch_id ~switch_label html_content =
           ~a:[ Unsafe.string_attrib "x-show" "toggle"; a_class [ "my-4" ] ]
           [ html_content ];
       ])
+
+let send_request ?(path = "") ~base_url http_client =
+  let url = base_url ^ path in
+  let body = "" in
+  let body_f _ acc chunk = Lwt.return (acc ^ chunk) in
+  Http_mirage_client.request http_client ~follow_redirect:true
+    ~headers:[ ("Accept", "application/json") ]
+    url body_f body
+  >>= function
+  | Error (`Msg err) -> Lwt.return (Error (`Msg err))
+  | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
+  | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
+  | Ok (resp, body) -> (
+      match resp.Http_mirage_client.status with
+      | `OK -> Lwt.return (Ok body)
+      | _ ->
+          Lwt.return
+            (Error
+               (`Msg
+                  ("accessing " ^ url ^ " resulted in an error: "
+                  ^ Http_mirage_client.Status.to_string resp.status
+                  ^ " " ^ resp.reason))))

--- a/utils.ml
+++ b/utils.ml
@@ -265,9 +265,9 @@ let send_http_request ?(path = "") ~base_url http_client =
   | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
   | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
   | Ok (resp, body) -> (
-      match resp.Http_mirage_client.status with
-      | `OK | `Created | `Accepted -> Lwt.return (Ok body)
-      | _ ->
+      if Http_mirage_client.Status.is_successful resp.Http_mirage_client.status then
+        Lwt.return (Ok body)
+      else
           Lwt.return
             (Error
                (`Msg

--- a/utils.ml
+++ b/utils.ml
@@ -264,13 +264,13 @@ let send_http_request ?(path = "") ~base_url http_client =
   | Error (`Msg err) -> Lwt.return (Error (`Msg err))
   | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
   | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
-  | Ok (resp, body) -> (
-      if Http_mirage_client.Status.is_successful resp.Http_mirage_client.status then
-        Lwt.return (Ok body)
+  | Ok (resp, body) ->
+      if Http_mirage_client.Status.is_successful resp.Http_mirage_client.status
+      then Lwt.return (Ok body)
       else
-          Lwt.return
-            (Error
-               (`Msg
-                  ("accessing " ^ url ^ " resulted in an error: "
-                  ^ Http_mirage_client.Status.to_string resp.status
-                  ^ " " ^ resp.reason))))
+        Lwt.return
+          (Error
+             (`Msg
+                ("accessing " ^ url ^ " resulted in an error: "
+                ^ Http_mirage_client.Status.to_string resp.status
+                ^ " " ^ resp.reason)))

--- a/utils.ml
+++ b/utils.ml
@@ -256,7 +256,7 @@ let switch_button ~switch_id ~switch_label html_content =
           [ html_content ];
       ])
 
-let send_request ?(path = "") ~base_url http_client =
+let send_http_request ?(path = "") ~base_url http_client =
   let url = base_url ^ path in
   let body = "" in
   let body_f _ acc chunk = Lwt.return (acc ^ chunk) in

--- a/utils.ml
+++ b/utils.ml
@@ -183,6 +183,9 @@ let bytes_to_megabytes bytes =
 (*10 minutes for a rollback to be valid*)
 let rollback_seconds_limit = 600
 
+(* 60 seconds wait time to start a liveliness check*)
+let liveliness_wait_period = 60
+
 let switch_button ~switch_id ~switch_label html_content =
   Tyxml_html.(
     div

--- a/utils.ml
+++ b/utils.ml
@@ -266,7 +266,7 @@ let send_http_request ?(path = "") ~base_url http_client =
   | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
   | Ok (resp, body) -> (
       match resp.Http_mirage_client.status with
-      | `OK -> Lwt.return (Ok body)
+      | `Code 200 -> Lwt.return (Ok body)
       | _ ->
           Lwt.return
             (Error

--- a/utils.ml
+++ b/utils.ml
@@ -183,9 +183,6 @@ let bytes_to_megabytes bytes =
 (*10 minutes for a rollback to be valid*)
 let rollback_seconds_limit = 600
 
-(* 60 seconds wait time to start a liveliness check*)
-let liveliness_wait_period = 60
-
 let switch_button ~switch_id ~switch_label html_content =
   Tyxml_html.(
     div


### PR DESCRIPTION
This PR adds new functionality for performing liveliness checks with automatic rollback functionality.

## How it works
During an update, the user selects which type of liveliness check they want (HTTP, DNS or TCP) and provides an address. This address is then checked that it returns a positive response and then the update is performed, else a rollback is performed. 

At the moment, HTTP and DNS checks have been implemented.