### PR TITLE
Better create form fixed

### DIFF
--- a/account_usage.ml
+++ b/account_usage.ml
@@ -1,71 +1,11 @@
 let account_usage_layout policy unikernels blocks =
-  let deployed_unikernels = List.length unikernels in
-  let total_volume_used =
-    List.fold_left (fun total_size (_, size, _) -> total_size + size) 0 blocks
-  in
-  let total_free_space =
-    Option.value ~default:0 policy.Vmm_core.Policy.block - total_volume_used
-  in
-  let total_memory_used =
-    List.fold_left
-      (fun total_memory (_, unikernel) ->
-        total_memory + unikernel.Vmm_core.Unikernel.memory)
-      0 unikernels
-  in
-  let count_cpuid_usage =
-    let cpuid_count = Hashtbl.create (List.length unikernels) in
-    (* count usage of each cpuid in unikernels *)
-    List.iter
-      (fun (_, unikernel) ->
-        let cpuid = unikernel.Vmm_core.Unikernel.cpuid in
-        let count =
-          Hashtbl.find_opt cpuid_count cpuid |> Option.value ~default:0
-        in
-        Hashtbl.replace cpuid_count cpuid (count + 1))
-      unikernels;
-    (* Prepare list of all cpuids from policy *)
-    let policy_cpuids = Vmm_core.IS.elements policy.cpuids in
-    (* Generate the list with all policy.cpuids and their respective counts *)
-    List.map
-      (fun cpuid ->
-        let count =
-          Hashtbl.find_opt cpuid_count cpuid |> Option.value ~default:0
-        in
-        (cpuid, count))
-      policy_cpuids
-  in
-  let count_bridge_usage =
-    let bridge_count =
-      Hashtbl.create (Vmm_core.String_set.cardinal policy.bridges)
-    in
-    (* Initialize all policy bridges with a count of 0 *)
-    Vmm_core.String_set.iter
-      (fun bridge -> Hashtbl.replace bridge_count bridge 0)
-      policy.bridges;
-
-    (* Count each bridge usage from unikernel.bridges, but only if it's in policy.bridges *)
-    List.iter
-      (fun (_, unikernel) ->
-        List.iter
-          (fun { Vmm_core.Unikernel.host_device; _ } ->
-            (* Only count if the bridge is in policy.bridges *)
-            if Vmm_core.String_set.mem host_device policy.bridges then
-              let count =
-                Hashtbl.find_opt bridge_count host_device
-                |> Option.value ~default:0
-              in
-              Hashtbl.replace bridge_count host_device (count + 1))
-          unikernel.Vmm_core.Unikernel.bridges)
-      unikernels;
-
-    (* Convert the hash table to a sorted list of (bridge_name, count) *)
-    let bridge_usage_list =
-      Hashtbl.fold
-        (fun bridge count acc -> (bridge, count) :: acc)
-        bridge_count []
-    in
-    (* Sort the list by bridge name *)
-    List.sort (fun (b1, _) (b2, _) -> String.compare b1 b2) bridge_usage_list
+  let ( deployed_unikernels,
+        total_volume_used,
+        total_free_space,
+        total_memory_used,
+        count_cpuid_usage,
+        count_bridge_usage ) =
+    Utils.user_policy_usage policy unikernels blocks
   in
   Tyxml_html.(
     section

--- a/account_usage.ml
+++ b/account_usage.ml
@@ -1,12 +1,5 @@
 let account_usage_layout policy unikernels blocks =
-  let ( deployed_unikernels,
-        total_volume_used,
-        total_free_space,
-        total_memory_used,
-        count_cpuid_usage,
-        count_bridge_usage ) =
-    Utils.user_policy_usage policy unikernels blocks
-  in
+  let user_policy_usage = Utils.user_policy_usage policy unikernels blocks in
   Tyxml_html.(
     section
       ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
@@ -33,16 +26,20 @@ let account_usage_layout policy unikernels blocks =
                          \                  type: 'pie',\n\
                          \                  data: {\n\
                          \                    labels: ['Available ("
-                        ^ string_of_int (policy.unikernels - deployed_unikernels)
+                        ^ string_of_int
+                            (policy.unikernels
+                           - user_policy_usage.deployed_unikernels)
                         ^ ")','Running ("
-                        ^ string_of_int deployed_unikernels
+                        ^ string_of_int user_policy_usage.deployed_unikernels
                         ^ ")'],\n\
                           \                    datasets: [{\n\
                           \                      label: 'Allocated',\n\
                           \                      data: ["
-                        ^ string_of_int (policy.unikernels - deployed_unikernels)
+                        ^ string_of_int
+                            (policy.unikernels
+                           - user_policy_usage.deployed_unikernels)
                         ^ ", "
-                        ^ string_of_int deployed_unikernels
+                        ^ string_of_int user_policy_usage.deployed_unikernels
                         ^ "],\n\
                           \                      backgroundColor: ['rgb(156, \
                            156, 156)','rgb(54, 156, 140)'],\n\
@@ -72,16 +69,16 @@ let account_usage_layout policy unikernels blocks =
                          \                  type: 'pie',\n\
                          \                  data: {\n\
                          \                    labels: ['Free ("
-                        ^ string_of_int total_free_space
+                        ^ string_of_int user_policy_usage.total_free_space
                         ^ "MB)','Used ("
-                        ^ string_of_int total_volume_used
+                        ^ string_of_int user_policy_usage.total_volume_used
                         ^ "MB)'],\n\
                           \                    datasets: [{\n\
                           \                      label: 'Size',\n\
                           \                      data: ["
-                        ^ string_of_int total_free_space
+                        ^ string_of_int user_policy_usage.total_free_space
                         ^ ", "
-                        ^ string_of_int total_volume_used
+                        ^ string_of_int user_policy_usage.total_volume_used
                         ^ "],\n\
                           \                      backgroundColor: ['rgb(156, \
                            156, 156)','rgb(54, 156, 140)'],\n\
@@ -111,16 +108,18 @@ let account_usage_layout policy unikernels blocks =
                          \                  type: 'pie',\n\
                          \                  data: {\n\
                          \                    labels: ['Free ("
-                        ^ string_of_int (policy.memory - total_memory_used)
+                        ^ string_of_int
+                            (policy.memory - user_policy_usage.total_memory_used)
                         ^ "MB)','Assigned ("
-                        ^ string_of_int total_memory_used
+                        ^ string_of_int user_policy_usage.total_memory_used
                         ^ "MB)'],\n\
                           \                    datasets: [{\n\
                           \                      label: 'Allocated',\n\
                           \                      data: ["
-                        ^ string_of_int (policy.memory - total_memory_used)
+                        ^ string_of_int
+                            (policy.memory - user_policy_usage.total_memory_used)
                         ^ ", "
-                        ^ string_of_int total_memory_used
+                        ^ string_of_int user_policy_usage.total_memory_used
                         ^ "],\n\
                           \                      backgroundColor: ['rgb(156, \
                            156, 156)','rgb(54, 156, 140)'],\n\
@@ -171,7 +170,7 @@ let account_usage_layout policy unikernels blocks =
                             (List.map
                                (fun (_, count) ->
                                  "\"" ^ string_of_int count ^ "\"")
-                               count_cpuid_usage)
+                               user_policy_usage.cpu_usage_count)
                         ^ "\n\
                           \                                ],\n\
                           \                                backgroundColor: \
@@ -255,7 +254,7 @@ let account_usage_layout policy unikernels blocks =
                             (List.map
                                (fun (_, count) ->
                                  "\"" ^ string_of_int count ^ "\"")
-                               count_bridge_usage)
+                               user_policy_usage.bridge_usage_count)
                         ^ "\n\
                           \          ],\n\
                           \          backgroundColor: ['rgb(54, 156, 140)'],\n\

--- a/assets/main.js
+++ b/assets/main.js
@@ -254,7 +254,8 @@ async function deployUnikernel() {
 		return;
 	}
 
-	const arguments = document.getElementById("unikernel-arguments").value;
+	const argumentsString = document.getElementById("unikernel-arguments").value.trim();
+	const argumentsList = argumentsString ? argumentsString.split(/\s+/) : [];
 	const binary = document.getElementById("unikernel-binary").files[0];
 	const molly_csrf = document.getElementById("molly-csrf").value;
 
@@ -270,20 +271,18 @@ async function deployUnikernel() {
 
 	let formData = new FormData();
 	const unikernel_config = {
-		name,
 		cpuid: Number(cpuid),
 		fail_behaviour: { "restart": fail_behaviour },
 		memory: Number(memory),
 		...networkData,
 		...blockData,
-		arguments
+		arguments: argumentsList
 	};
 
-	formData.append("unikernel_config", unikernel_config);
+	formData.append("unikernel_name", name,);
+	formData.append("unikernel_config", JSON.stringify(unikernel_config));
 	formData.append("binary", binary);
 	formData.append("molly_csrf", molly_csrf);
-
-	console.log(formData, unikernel_config);
 
 	try {
 		const response = await fetch("/api/unikernel/create", {

--- a/assets/main.js
+++ b/assets/main.js
@@ -243,6 +243,7 @@ async function deployUnikernel() {
 	const name = document.getElementById("unikernel-name").value;
 	const cpuid = document.getElementById("cpuid").value;
 	const fail_behaviour = document.getElementById("restart-on-fail").checked;
+	const force_create = document.getElementById("force-create").checked;
 	const memory = document.getElementById("unikernel-memory").innerText;
 
 	const networkData = gatherFieldsForDevices("network", "network_interfaces", formAlert);
@@ -259,10 +260,18 @@ async function deployUnikernel() {
 	const binary = document.getElementById("unikernel-binary").files[0];
 	const molly_csrf = document.getElementById("molly-csrf").value;
 
-	if (!isValidName(name) || !binary) {
+	if (!isValidName(name)) {
 		formAlert.classList.remove("hidden", "text-primary-500");
 		formAlert.classList.add("text-secondary-500");
-		formAlert.textContent = "Please fill in the required data";
+		formAlert.textContent = "Please fill in a valid name";
+		buttonLoading(deployButton, false, "Deploy");
+		return;
+	}
+
+	if (!binary) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please upload the unikernel image";
 		buttonLoading(deployButton, false, "Deploy");
 		return;
 	}
@@ -282,6 +291,7 @@ async function deployUnikernel() {
 	formData.append("unikernel_name", name,);
 	formData.append("unikernel_config", JSON.stringify(unikernel_config));
 	formData.append("binary", binary);
+	formData.append("unikernel_force_create", force_create);
 	formData.append("molly_csrf", molly_csrf);
 
 	try {

--- a/assets/main.js
+++ b/assets/main.js
@@ -272,7 +272,7 @@ async function deployUnikernel() {
 	let formData = new FormData();
 	const unikernel_config = {
 		cpuid: Number(cpuid),
-		fail_behaviour: { "restart": fail_behaviour },
+		fail_behaviour: fail_behaviour ? { "restart": fail_behaviour } : "quit",
 		memory: Number(memory),
 		...networkData,
 		...blockData,

--- a/assets/main.js
+++ b/assets/main.js
@@ -190,53 +190,128 @@ function postAlert(bg_color, content) {
 	}, 4000);
 }
 
+function gatherFieldsForDevices(fieldId, targetKey, formAlert) {
+	const result = [];
+	let index = 0;
+	let loop = true;
+
+	while (loop) {
+		const selectEl = document.getElementById(`${fieldId}-select-${index}`);
+		const inputEl = document.getElementById(`${fieldId}-input-${index}`);
+
+		// Case: One of them exists but the other doesn't
+		if ((selectEl && !inputEl) || (!selectEl && inputEl)) {
+			formAlert.classList.remove("hidden", "text-primary-500");
+			formAlert.classList.add("text-secondary-500");
+			formAlert.textContent = `Please fill in both the ${fieldId} device and its associated name.`;
+			postAlert("bg-secondary-300", `Please fill in both the ${fieldId} device and its associated name.`);
+			return null;
+		}
+
+		// Case: both don't exist => end loop
+		if (!selectEl && !inputEl) {
+			break;
+		}
+
+		// Otherwise, both exist -> proceed
+		const selectValue = selectEl.value.trim();
+		const inputValue = inputEl.value.trim();
+
+		// check for empty strings:
+		if (!selectValue || !inputValue) {
+			formAlert.classList.remove("hidden", "text-primary-500");
+			formAlert.classList.add("text-secondary-500");
+			formAlert.textContent = `Please fill in both the ${fieldId} device and its associated name.`;
+			postAlert("bg-secondary-300", `Please fill in both the ${fieldId} device and its associated name.`);
+			return null;
+		}
+
+		result.push({
+			name: inputValue,
+			host_device: selectValue,
+		});
+
+		index++;
+	}
+
+	return { [targetKey]: result };
+}
+
 async function deployUnikernel() {
+	const formAlert = document.getElementById("form-alert");
 	const deployButton = document.getElementById("deploy-button");
 	const name = document.getElementById("unikernel-name").value;
+	const cpuid = document.getElementById("cpuid").value;
+	const fail_behaviour = document.getElementById("restart-on-fail").checked;
+	const memory = document.getElementById("unikernel-memory").innerText;
+
+	const networkData = gatherFieldsForDevices("network", "network_interfaces", formAlert);
+	const blockData = gatherFieldsForDevices("block", "block_devices", formAlert);
+
+	// Abort immediately if a device field is invalid
+	if (networkData === null || blockData === null) {
+		buttonLoading(deployButton, false, "Deploy");
+		return;
+	}
+
 	const arguments = document.getElementById("unikernel-arguments").value;
 	const binary = document.getElementById("unikernel-binary").files[0];
 	const molly_csrf = document.getElementById("molly-csrf").value;
-	const formAlert = document.getElementById("form-alert");
+
 	if (!isValidName(name) || !binary) {
 		formAlert.classList.remove("hidden", "text-primary-500");
 		formAlert.classList.add("text-secondary-500");
-		formAlert.textContent = "Please fill in the required data"
-		buttonLoading(deployButton, false, "Deploy")
-	} else {
-		buttonLoading(deployButton, true, "Deploying...")
-		let formData = new FormData();
-		formData.append("name", name);
-		formData.append("arguments", arguments);
-		formData.append("binary", binary);
-		formData.append("molly_csrf", molly_csrf)
-		try {
-			const response = await fetch("/api/unikernel/create", {
-				method: 'POST',
-				body: formData
-			})
-			const data = await response.json();
-			if (data.status === 200 && data.success) {
-				formAlert.classList.remove("hidden", "text-secondary-500");
-				formAlert.classList.add("text-primary-500");
-				formAlert.textContent = "Succesfully updated";
-				postAlert("bg-primary-300", `${name} has been deployed succesfully.`);
-				setTimeout(function () {
-					window.location.href = "/dashboard";
-				}, 2000);
-			} else {
-				postAlert("bg-secondary-300", data.data);
-				formAlert.classList.remove("hidden", "text-primary-500");
-				formAlert.classList.add("text-secondary-500");
-				formAlert.textContent = data.data
-				buttonLoading(deployButton, false, "Deploy")
-			}
-		} catch (error) {
-			postAlert("bg-secondary-300", error);
-			formAlert.classList.remove("hidden");
+		formAlert.textContent = "Please fill in the required data";
+		buttonLoading(deployButton, false, "Deploy");
+		return;
+	}
+
+	buttonLoading(deployButton, true, "Deploying...");
+
+	let formData = new FormData();
+	const unikernel_config = {
+		name,
+		cpuid: Number(cpuid),
+		fail_behaviour: { "restart": fail_behaviour },
+		memory: Number(memory),
+		...networkData,
+		...blockData,
+		arguments
+	};
+
+	formData.append("unikernel_config", unikernel_config);
+	formData.append("binary", binary);
+	formData.append("molly_csrf", molly_csrf);
+
+	console.log(formData, unikernel_config);
+
+	try {
+		const response = await fetch("/api/unikernel/create", {
+			method: 'POST',
+			body: formData
+		})
+		const data = await response.json();
+		if (data.status === 200 && data.success) {
+			formAlert.classList.remove("hidden", "text-secondary-500");
+			formAlert.classList.add("text-primary-500");
+			formAlert.textContent = "Successfully updated";
+			postAlert("bg-primary-300", `${name} has been deployed successfully.`);
+			setTimeout(function () {
+				window.location.href = "/dashboard";
+			}, 2000);
+		} else {
+			postAlert("bg-secondary-300", data.data);
+			formAlert.classList.remove("hidden", "text-primary-500");
 			formAlert.classList.add("text-secondary-500");
-			formAlert.textContent = error
-			buttonLoading(deployButton, false, "Deploy")
+			formAlert.textContent = data.data;
+			buttonLoading(deployButton, false, "Deploy");
 		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+		formAlert.classList.remove("hidden");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = error;
+		buttonLoading(deployButton, false, "Deploy");
 	}
 }
 

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1588,16 +1588,17 @@ struct
 
   let unikernel_create albatross (user : User_model.user) m reqd =
     match
-      ( Map.find_opt "arguments" m,
-        Map.find_opt "name" m,
+      ( Map.find_opt "unikernel_name" m,
+        Map.find_opt "unikernel_config" m,
         Map.find_opt "binary" m )
     with
-    | Some (_, args), Some (_, name), Some (_, binary) -> (
-        match Albatross_json.config_of_json args with
+    | Some (_, unikernel_name), Some (_, unikernel_config), Some (_, binary)
+      -> (
+        match Albatross_json.config_of_json unikernel_config with
         | Ok cfg -> (
             let config = { cfg with image = binary } in
             (* TODO use uuid in the future *)
-            Albatross.query albatross ~domain:user.name ~name
+            Albatross.query albatross ~domain:user.name ~name:unikernel_name
               (`Unikernel_cmd (`Unikernel_create config))
             >>= function
             | Error err ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1624,7 +1624,8 @@ struct
         | Ok cfg -> (
             let config = { cfg with image = binary } in
             (* TODO use uuid in the future *)
-            if bool_of_string force_create then (
+            if bool_of_string_opt force_create |> Option.value ~default:false
+            then (
               force_create_unikernel ~unikernel_name ~unikernel_image:binary cfg
                 user albatross
               >>= function

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -252,6 +252,35 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                   ();
               ];
             div
+              ~a:[ a_class [ "" ] ]
+              [
+                label
+                  ~a:[ a_class [ "block font-medium" ] ]
+                  [ txt "Force create" ];
+                div
+                  ~a:[ a_class [ "" ] ]
+                  [
+                    Utils.switch_button ~initial_state:true
+                      ~switch_id:"force-create"
+                      ~switch_label:"Force create this unikernel"
+                      (div
+                         [
+                           label
+                             ~a:
+                               [
+                                 a_class [ "block text-sm font-medium" ];
+                                 a_label_for "restart_description";
+                               ]
+                             [
+                               txt
+                                 "If a unikernel exist with this same name, it \
+                                  will be destroyed first and this one \
+                                  created.";
+                             ];
+                         ]);
+                  ];
+              ];
+            div
               ~a:[ a_class [ "flex justify-items-center mx-auto w-60" ] ]
               [
                 Utils.button_component

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -80,7 +80,10 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                              (txt
                                 ("CPU " ^ string_of_int cpu_id ^ " (used by "
                                ^ string_of_int count ^ " unikernels)")))
-                         cpu_usage_count);
+                         (List.sort
+                            (fun (_, count1) (_, count2) ->
+                              Int.compare count1 count2)
+                            cpu_usage_count));
                   ];
                 div
                   ~a:[ a_class [ "" ] ]

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -1,4 +1,9 @@
-let unikernel_create_layout =
+let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
+    (blocks : (Vmm_core.Name.t * int * bool) list) =
+  let _, _, _, total_memory_used, count_cpuid_usage, _ =
+    Utils.user_policy_usage user_policy unikernels blocks
+  in
+  let memory_left = user_policy.memory - total_memory_used in
   Tyxml_html.(
     section
       ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
@@ -16,37 +21,184 @@ let unikernel_create_layout =
           [
             p ~a:[ a_id "form-alert"; a_class [ "my-4 hidden" ] ] [];
             div
+              ~a:[ a_class [ "grid grid-cols-2 gap-3" ] ]
               [
-                label
-                  ~a:[ a_class [ "block text-sm font-medium" ] ]
-                  [ txt "Name*" ];
-                input
+                div
+                  [
+                    label ~a:[ a_class [ "block font-medium" ] ] [ txt "Name*" ];
+                    input
+                      ~a:
+                        [
+                          a_input_type `Text;
+                          a_name "name";
+                          a_required ();
+                          a_id "unikernel-name";
+                          a_class
+                            [
+                              "ring-primary-100 mt-1.5 transition \
+                               appearance-none block w-full px-3 py-3 \
+                               rounded-xl shadow-sm border \
+                               hover:border-primary-200\n\
+                              \                                           \
+                               focus:border-primary-300 bg-primary-50 \
+                               bg-opacity-0 hover:bg-opacity-50 \
+                               focus:bg-opacity-50 ring-primary-200 \
+                               focus:ring-primary-200\n\
+                              \                                           \
+                               focus:ring-[1px] focus:outline-none";
+                            ];
+                        ]
+                      ();
+                  ];
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "CPU Id" ];
+                    select
+                      ~a:
+                        [
+                          a_id "cpuid";
+                          a_name "cpuid";
+                          a_class
+                            [
+                              "ring-primary-100 mt-1.5 transition block w-full \
+                               px-3 py-3 rounded-xl shadow-sm border \
+                               hover:border-primary-200\n\
+                              \                                           \
+                               focus:border-primary-300 bg-primary-50 \
+                               bg-opacity-0 hover:bg-opacity-50 \
+                               focus:bg-opacity-50 ring-primary-200 \
+                               focus:ring-primary-200\n\
+                              \                                           \
+                               focus:ring-[1px] focus:outline-none";
+                            ];
+                        ]
+                      (List.map
+                         (fun (cpu_id, count) ->
+                           option
+                             ~a:[ a_value (string_of_int cpu_id) ]
+                             (txt
+                                ("CPU " ^ string_of_int cpu_id ^ " (used by "
+                               ^ string_of_int count ^ " unikernels)")))
+                         count_cpuid_usage);
+                  ];
+                div
+                  ~a:[ a_class [ "" ] ]
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Fail Behaviour" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~switch_id:"restart-on-fail"
+                          ~switch_label:"Restart"
+                          (div
+                             [
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "This unikernel will automatically \
+                                      restart on fail";
+                                 ];
+                             ]);
+                      ];
+                  ];
+                div
                   ~a:
                     [
-                      a_input_type `Text;
-                      a_name "name";
-                      a_required ();
-                      a_id "unikernel-name";
-                      a_class
-                        [
-                          "ring-primary-100 mt-1.5 transition appearance-none \
-                           block w-full px-3 py-3 rounded-xl shadow-sm border \
-                           hover:border-primary-200\n\
-                          \                                           \
-                           focus:border-primary-300 bg-primary-50 bg-opacity-0 \
-                           hover:bg-opacity-50 focus:bg-opacity-50 \
-                           ring-primary-200 focus:ring-primary-200\n\
-                          \                                           \
-                           focus:ring-[1px] focus:outline-none";
-                        ];
+                      a_class [ "space-x-5" ];
+                      Unsafe.string_attrib "x-data"
+                        ("{count : "
+                        ^ (if memory_left >= 32 then string_of_int 32
+                           else string_of_int memory_left)
+                        ^ "}");
                     ]
-                  ();
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [
+                        txt ("Memory (max " ^ string_of_int memory_left ^ "MB)");
+                      ];
+                    Utils.button_component
+                      ~attribs:
+                        [
+                          Unsafe.string_attrib "x-on:click" "count = count + 32";
+                        ]
+                      ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
+                      ~btn_type:`Primary_outlined ();
+                    span
+                      ~a:
+                        [
+                          a_id "unikernel-memory";
+                          a_contenteditable true;
+                          a_class [ "text-4xl border px-4" ];
+                          a_user_data "x-on:keydown.enter.prevent" "";
+                          Unsafe.string_attrib "x-on:input"
+                            "let value = \
+                             $event.target.innerText.replace(/[^0-9]/g,'');\n\
+                            \                                     \
+                             $event.target.innerText = value;\n\
+                            \                                     count = \
+                             parseInt(value) || 0;";
+                          Unsafe.string_attrib "x-text" "count";
+                          Unsafe.string_attrib "x-on:blur"
+                            "$event.target.innerText = count;";
+                        ]
+                      [];
+                    span ~a:[ a_class [ "text-4xl" ] ] [ txt " MB" ];
+                    Utils.button_component
+                      ~attribs:
+                        [
+                          Unsafe.string_attrib "x-on:click"
+                            "if (count > 32) count = count - 32";
+                        ]
+                      ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
+                      ~btn_type:`Danger_outlined ();
+                  ];
               ];
+            hr ();
             div
               [
                 label
-                  ~a:[ a_class [ "block text-sm font-medium" ] ]
-                  [ txt "Arguments*" ];
+                  ~a:[ a_class [ "block font-medium" ] ]
+                  [ txt "Network Interfaces" ];
+                Utils.dynamic_dropdown_form
+                  (Vmm_core.String_set.elements user_policy.bridges)
+                  ~get_label:(fun bridge -> bridge)
+                  ~get_value:(fun bridge -> bridge)
+                  ~id:"network";
+              ];
+            hr ();
+            div
+              [
+                label
+                  ~a:[ a_class [ "block font-medium" ] ]
+                  [ txt "Block devices" ];
+                Utils.dynamic_dropdown_form blocks
+                  ~get_label:(fun (name, size, used) ->
+                    Option.value ~default:"" (Vmm_core.Name.name name)
+                    ^ " - " ^ Int.to_string size ^ "MB (used: "
+                    ^ Bool.to_string used ^ ")")
+                  ~get_value:(fun (name, _, _) ->
+                    Option.value ~default:"" (Vmm_core.Name.name name))
+                  ~id:"block";
+              ];
+            hr ();
+            div
+              [
+                label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
+                p
+                  [
+                    txt "Write arguments seperated by a whitespace e.g ";
+                    code [ txt "--ip=127.0.0.1 --port=8180" ];
+                  ];
                 textarea
                   ~a:
                     [
@@ -69,10 +221,11 @@ let unikernel_create_layout =
                     ]
                   (txt "");
               ];
+            hr ();
             div
               [
                 label
-                  ~a:[ a_class [ "block text-sm font-medium" ] ]
+                  ~a:[ a_class [ "block font-medium" ] ]
                   [ txt "Unikernel Image Binary*" ];
                 input
                   ~a:

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -1,8 +1,7 @@
 let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
     (blocks : (Vmm_core.Name.t * int * bool) list) =
-  let _, _, _, total_memory_used, count_cpuid_usage, _ =
-    Utils.user_policy_usage user_policy unikernels blocks
-  in
+  let total_memory_used = Utils.total_memory_used unikernels in
+  let cpu_usage_count = Utils.cpu_usage_count user_policy unikernels in
   let memory_left = user_policy.memory - total_memory_used in
   Tyxml_html.(
     section
@@ -81,7 +80,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                              (txt
                                 ("CPU " ^ string_of_int cpu_id ^ " (used by "
                                ^ string_of_int count ^ " unikernels)")))
-                         count_cpuid_usage);
+                         cpu_usage_count);
                   ];
                 div
                   ~a:[ a_class [ "" ] ]

--- a/update_policy.ml
+++ b/update_policy.ml
@@ -205,25 +205,17 @@ let update_policy_layout (user : User_model.user) ~user_policy
             label ~a:[ a_class [ "block font-medium" ] ] [ txt "CPU IDs" ];
             div
               ~a:
-                (let cpuid_to_array_string lst =
-                   if lst = [] then "[]"
-                   else
-                     "[\""
-                     ^ String.concat "\", \"" (List.map string_of_int lst)
-                     ^ "\"]"
-                 in
-
-                 [
-                   Unsafe.string_attrib "x-data"
-                     ("multiselect("
-                     ^ cpuid_to_array_string
-                         (Vmm_core.IS.elements user_policy.cpuids)
-                     ^ ", "
-                     ^ cpuid_to_array_string
-                         (Vmm_core.IS.elements unallocated_resources.cpuids)
-                     ^ ")");
-                   a_class [ "multiselect border my-4 p-4 rounded" ];
-                 ])
+                [
+                  Unsafe.string_attrib "x-data"
+                    ("multiselect("
+                    ^ Utils.cpuid_to_array_string
+                        (Vmm_core.IS.elements user_policy.cpuids)
+                    ^ ", "
+                    ^ Utils.cpuid_to_array_string
+                        (Vmm_core.IS.elements unallocated_resources.cpuids)
+                    ^ ")");
+                  a_class [ "multiselect border my-4 p-4 rounded" ];
+                ]
               [
                 div
                   ~a:[ a_class [ "selected-items" ] ]

--- a/utils.ml
+++ b/utils.ml
@@ -274,3 +274,79 @@ let send_http_request ?(path = "") ~base_url http_client =
                 ("accessing " ^ url ^ " resulted in an error: "
                 ^ Http_mirage_client.Status.to_string resp.status
                 ^ " " ^ resp.reason)))
+
+let user_policy_usage policy unikernels blocks =
+  let deployed_unikernels = List.length unikernels in
+  let total_volume_used =
+    List.fold_left (fun total_size (_, size, _) -> total_size + size) 0 blocks
+  in
+  let total_free_space =
+    Option.value ~default:0 policy.Vmm_core.Policy.block - total_volume_used
+  in
+  let total_memory_used =
+    List.fold_left
+      (fun total_memory (_, unikernel) ->
+        total_memory + unikernel.Vmm_core.Unikernel.memory)
+      0 unikernels
+  in
+  let count_cpuid_usage =
+    let cpuid_count = Hashtbl.create (List.length unikernels) in
+    (* count usage of each cpuid in unikernels *)
+    List.iter
+      (fun (_, unikernel) ->
+        let cpuid = unikernel.Vmm_core.Unikernel.cpuid in
+        let count =
+          Hashtbl.find_opt cpuid_count cpuid |> Option.value ~default:0
+        in
+        Hashtbl.replace cpuid_count cpuid (count + 1))
+      unikernels;
+    (* Prepare list of all cpuids from policy *)
+    let policy_cpuids = Vmm_core.IS.elements policy.cpuids in
+    (* Generate the list with all policy.cpuids and their respective counts *)
+    List.map
+      (fun cpuid ->
+        let count =
+          Hashtbl.find_opt cpuid_count cpuid |> Option.value ~default:0
+        in
+        (cpuid, count))
+      policy_cpuids
+  in
+  let count_bridge_usage =
+    let bridge_count =
+      Hashtbl.create (Vmm_core.String_set.cardinal policy.bridges)
+    in
+    (* Initialize all policy bridges with a count of 0 *)
+    Vmm_core.String_set.iter
+      (fun bridge -> Hashtbl.replace bridge_count bridge 0)
+      policy.bridges;
+
+    (* Count each bridge usage from unikernel.bridges, but only if it's in policy.bridges *)
+    List.iter
+      (fun (_, unikernel) ->
+        List.iter
+          (fun { Vmm_core.Unikernel.host_device; _ } ->
+            (* Only count if the bridge is in policy.bridges *)
+            if Vmm_core.String_set.mem host_device policy.bridges then
+              let count =
+                Hashtbl.find_opt bridge_count host_device
+                |> Option.value ~default:0
+              in
+              Hashtbl.replace bridge_count host_device (count + 1))
+          unikernel.Vmm_core.Unikernel.bridges)
+      unikernels;
+
+    (* Convert the hash table to a sorted list of (bridge_name, count) *)
+    let bridge_usage_list =
+      Hashtbl.fold
+        (fun bridge count acc -> (bridge, count) :: acc)
+        bridge_count []
+    in
+    (* Sort the list by bridge name *)
+    List.sort (fun (b1, _) (b2, _) -> String.compare b1 b2) bridge_usage_list
+  in
+  ( deployed_unikernels,
+    total_volume_used,
+    total_free_space,
+    total_memory_used,
+    count_cpuid_usage,
+    count_bridge_usage )

--- a/utils.ml
+++ b/utils.ml
@@ -183,12 +183,15 @@ let bytes_to_megabytes bytes =
 (*10 minutes for a rollback to be valid*)
 let rollback_seconds_limit = 600
 
-let switch_button ~switch_id ~switch_label html_content =
+let switch_button ~switch_id ~switch_label ?(initial_state = false) html_content
+    =
   Tyxml_html.(
     div
       ~a:
         [
-          a_class [ "my-6" ]; Unsafe.string_attrib "x-data" "{ toggle: false }";
+          a_class [ "my-6" ];
+          Unsafe.string_attrib "x-data"
+            ("{ toggle: " ^ string_of_bool initial_state ^ " }");
         ]
       [
         label
@@ -206,6 +209,7 @@ let switch_button ~switch_id ~switch_label html_content =
                   a_class [ "peer sr-only" ];
                   a_role [ "switch" ];
                   Unsafe.string_attrib "x-model" "toggle";
+                  (if initial_state then a_checked () else a_alt "");
                 ]
               ();
             span


### PR DESCRIPTION
This PR redesigns the form used to deploy unikernels. Previously all unikernel configurations were given as a a json string. Now the UI is more intuitive with a form element handling each part of the configuration: for instance selecting network interfaces and block devices, a toggle for fail_behaviour and a dropdown for cpuids etc. 