### PR TITLE
Some ui fixes

### DIFF
--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -131,10 +131,11 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     Utils.button_component
                       ~attribs:
                         [
-                          Unsafe.string_attrib "x-on:click" "count = count + 32";
+                          Unsafe.string_attrib "x-on:click"
+                            "if (count > 32) count = count - 32";
                         ]
-                      ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
-                      ~btn_type:`Primary_outlined ();
+                      ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
+                      ~btn_type:`Danger_outlined ();
                     span
                       ~a:
                         [
@@ -158,11 +159,10 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     Utils.button_component
                       ~attribs:
                         [
-                          Unsafe.string_attrib "x-on:click"
-                            "if (count > 32) count = count - 32";
+                          Unsafe.string_attrib "x-on:click" "count = count + 32";
                         ]
-                      ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
-                      ~btn_type:`Danger_outlined ();
+                      ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
+                      ~btn_type:`Primary_outlined ();
                   ];
               ];
             hr ();

--- a/update_policy.ml
+++ b/update_policy.ml
@@ -36,9 +36,12 @@ let update_policy_layout (user : User_model.user) ~user_policy
                 ]
               [
                 Utils.button_component
-                  ~attribs:[ Unsafe.string_attrib "x-on:click" "count++" ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
-                  ~btn_type:`Primary_outlined ();
+                  ~attribs:
+                    [
+                      Unsafe.string_attrib "x-on:click" "if (count > 0) count--";
+                    ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
+                  ~btn_type:`Danger_outlined ();
                 span
                   ~a:
                     [
@@ -59,12 +62,9 @@ let update_policy_layout (user : User_model.user) ~user_policy
                     ]
                   [];
                 Utils.button_component
-                  ~attribs:
-                    [
-                      Unsafe.string_attrib "x-on:click" "if (count > 0) count--";
-                    ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
-                  ~btn_type:`Danger_outlined ();
+                  ~attribs:[ Unsafe.string_attrib "x-on:click" "count++" ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
+                  ~btn_type:`Primary_outlined ();
               ];
           ];
         hr ();
@@ -96,9 +96,12 @@ let update_policy_layout (user : User_model.user) ~user_policy
               [
                 Utils.button_component
                   ~attribs:
-                    [ Unsafe.string_attrib "x-on:click" "count = count + 50" ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
-                  ~btn_type:`Primary_outlined ();
+                    [
+                      Unsafe.string_attrib "x-on:click"
+                        "if (count > 0) count = count - 50";
+                    ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
+                  ~btn_type:`Danger_outlined ();
                 span
                   ~a:
                     [
@@ -121,12 +124,9 @@ let update_policy_layout (user : User_model.user) ~user_policy
                 span ~a:[ a_class [ "text-4xl" ] ] [ txt " MB" ];
                 Utils.button_component
                   ~attribs:
-                    [
-                      Unsafe.string_attrib "x-on:click"
-                        "if (count > 0) count = count - 50";
-                    ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
-                  ~btn_type:`Danger_outlined ();
+                    [ Unsafe.string_attrib "x-on:click" "count = count + 50" ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
+                  ~btn_type:`Primary_outlined ();
               ];
           ];
         hr ();
@@ -166,9 +166,12 @@ let update_policy_layout (user : User_model.user) ~user_policy
               [
                 Utils.button_component
                   ~attribs:
-                    [ Unsafe.string_attrib "x-on:click" "count = count + 50" ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
-                  ~btn_type:`Primary_outlined ();
+                    [
+                      Unsafe.string_attrib "x-on:click"
+                        "if (count > 0) count = count - 50";
+                    ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
+                  ~btn_type:`Danger_outlined ();
                 span
                   ~a:
                     [
@@ -191,12 +194,9 @@ let update_policy_layout (user : User_model.user) ~user_policy
                 span ~a:[ a_class [ "text-4xl" ] ] [ txt "MB" ];
                 Utils.button_component
                   ~attribs:
-                    [
-                      Unsafe.string_attrib "x-on:click"
-                        "if (count > 0) count = count - 50";
-                    ]
-                  ~content:(i ~a:[ a_class [ "fa-solid fa-minus" ] ] [])
-                  ~btn_type:`Danger_outlined ();
+                    [ Unsafe.string_attrib "x-on:click" "count = count + 50" ]
+                  ~content:(i ~a:[ a_class [ "fa-solid fa-plus" ] ] [])
+                  ~btn_type:`Primary_outlined ();
               ];
           ];
         div

--- a/utils.ml
+++ b/utils.ml
@@ -283,6 +283,28 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
         div
           ~a:[ a_class [ "flex items-center space-x-2 my-2" ] ]
           [
+            (* Text input with dynamic ID *)
+            input
+              ~a:
+                [
+                  a_input_type `Text;
+                  a_name "name";
+                  a_required ();
+                  a_placeholder "Name of this device in your unikernel";
+                  a_class
+                    [
+                      "ring-primary-100 mt-1.5 transition appearance-none \
+                       block w-full px-3 py-3 rounded-xl shadow-sm border";
+                      "hover:border-primary-200 focus:border-primary-300 \
+                       bg-primary-50 bg-opacity-0";
+                      "hover:bg-opacity-50 focus:bg-opacity-50 \
+                       ring-primary-200 focus:ring-primary-200";
+                      "focus:ring-[1px] focus:outline-none";
+                    ];
+                  Unsafe.string_attrib ":id" "field_id + '-input-' + index";
+                  Unsafe.string_attrib "x-model" "field.title";
+                ]
+              ();
             (* Dropdown select with dynamic ID *)
             select
               ~a:
@@ -307,28 +329,6 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
             </template>
           |};
               ];
-            (* Text input with dynamic ID *)
-            input
-              ~a:
-                [
-                  a_input_type `Text;
-                  a_name "name";
-                  a_required ();
-                  a_placeholder "Name of this device in your unikernel";
-                  a_class
-                    [
-                      "ring-primary-100 mt-1.5 transition appearance-none \
-                       block w-full px-3 py-3 rounded-xl shadow-sm border";
-                      "hover:border-primary-200 focus:border-primary-300 \
-                       bg-primary-50 bg-opacity-0";
-                      "hover:bg-opacity-50 focus:bg-opacity-50 \
-                       ring-primary-200 focus:ring-primary-200";
-                      "focus:ring-[1px] focus:outline-none";
-                    ];
-                  Unsafe.string_attrib ":id" "field_id + '-input-' + index";
-                  Unsafe.string_attrib "x-model" "field.title";
-                ]
-              ();
             (* Remove button *)
             Unsafe.data
               {|


### PR DESCRIPTION
This Pr fixes some minor issues including:

- unikernel deploy ui:  move input for names of devices to the left
-  unikernel deploy ui:  move `+`button for memory to the right
- edit policy ui:  move `+`button for allowed_unikernels,  memory and storage  to the right