### PR TITLE
Prevent sliding cursors

### DIFF
--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -142,17 +142,18 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                           a_id "unikernel-memory";
                           a_contenteditable true;
                           a_class [ "text-4xl border px-4" ];
-                          a_user_data "x-on:keydown.enter.prevent" "";
-                          Unsafe.string_attrib "x-on:input"
-                            "let value = \
-                             $event.target.innerText.replace(/[^0-9]/g,'');\n\
-                            \                                     \
-                             $event.target.innerText = value;\n\
-                            \                                     count = \
-                             parseInt(value) || 0;";
+                          Unsafe.string_attrib "@keydown.enter.prevent" "";
                           Unsafe.string_attrib "x-text" "count";
                           Unsafe.string_attrib "x-on:blur"
-                            "$event.target.innerText = count;";
+                            "\n\
+                            \                        count = \
+                             parseInt($event.target.innerText.replace(/[^0-9]/g,'')) \
+                             || 0;\n\
+                            \                        let value = \
+                             $event.target.innerText.replace(/[^0-9]/g,'');count \
+                             = parseInt(value) || 0;$event.target.innerText = \
+                             count;";
+                          Unsafe.string_attrib "x-init" "$el.innerText = count";
                         ]
                       [];
                     span ~a:[ a_class [ "text-4xl" ] ] [ txt " MB" ];

--- a/update_policy.ml
+++ b/update_policy.ml
@@ -48,17 +48,17 @@ let update_policy_layout (user : User_model.user) ~user_policy
                       a_id "f_allowed_unikernels";
                       a_contenteditable true;
                       a_class [ "text-4xl border px-4" ];
-                      a_user_data "x-on:keydown.enter.prevent" "";
-                      Unsafe.string_attrib "x-on:input"
-                        "let value = \
-                         $event.target.innerText.replace(/[^0-9]/g,'');\n\
-                        \                                     \
-                         $event.target.innerText = value;\n\
-                        \                                     count = \
-                         parseInt(value) || 0;";
+                      Unsafe.string_attrib "@keydown.enter.prevent" "";
                       Unsafe.string_attrib "x-text" "count";
                       Unsafe.string_attrib "x-on:blur"
-                        "$event.target.innerText = count;";
+                        "\n\
+                        \                        count = \
+                         parseInt($event.target.innerText.replace(/[^0-9]/g,'')) \
+                         || 0;\n\
+                        \                        let value = \
+                         $event.target.innerText.replace(/[^0-9]/g,'');count = \
+                         parseInt(value) || 0;$event.target.innerText = count;";
+                      Unsafe.string_attrib "x-init" "$el.innerText = count";
                     ]
                   [];
                 Utils.button_component
@@ -108,17 +108,17 @@ let update_policy_layout (user : User_model.user) ~user_policy
                       a_id "f_allowed_memory";
                       a_contenteditable true;
                       a_class [ "text-4xl border px-4" ];
-                      a_user_data "x-on:keydown.enter.prevent" "";
-                      Unsafe.string_attrib "x-on:input"
-                        "let value = \
-                         $event.target.innerText.replace(/[^0-9]/g,'');\n\
-                        \                                     \
-                         $event.target.innerText = value;\n\
-                        \                                     count = \
-                         parseInt(value) || 0;";
+                      Unsafe.string_attrib "@keydown.enter.prevent" "";
                       Unsafe.string_attrib "x-text" "count";
                       Unsafe.string_attrib "x-on:blur"
-                        "$event.target.innerText = count;";
+                        "\n\
+                        \                        count = \
+                         parseInt($event.target.innerText.replace(/[^0-9]/g,'')) \
+                         || 0;\n\
+                        \                        let value = \
+                         $event.target.innerText.replace(/[^0-9]/g,'');count = \
+                         parseInt(value) || 0;$event.target.innerText = count;";
+                      Unsafe.string_attrib "x-init" "$el.innerText = count";
                     ]
                   [];
                 span ~a:[ a_class [ "text-4xl" ] ] [ txt " MB" ];
@@ -178,17 +178,17 @@ let update_policy_layout (user : User_model.user) ~user_policy
                       a_id "f_allowed_storage";
                       a_contenteditable true;
                       a_class [ "text-4xl border px-4" ];
-                      a_user_data "x-on:keydown.enter.prevent" "";
-                      Unsafe.string_attrib "x-on:input"
-                        "let value = \
-                         $event.target.innerText.replace(/[^0-9]/g,'');\n\
-                        \                                     \
-                         $event.target.innerText = value;\n\
-                        \                                     count = \
-                         parseInt(value) || 0;";
+                      Unsafe.string_attrib "@keydown.enter.prevent" "";
                       Unsafe.string_attrib "x-text" "count";
                       Unsafe.string_attrib "x-on:blur"
-                        "$event.target.innerText = count;";
+                        "\n\
+                        \                        count = \
+                         parseInt($event.target.innerText.replace(/[^0-9]/g,'')) \
+                         || 0;\n\
+                        \                        let value = \
+                         $event.target.innerText.replace(/[^0-9]/g,'');count = \
+                         parseInt(value) || 0;$event.target.innerText = count;";
+                      Unsafe.string_attrib "x-init" "$el.innerText = count";
                     ]
                   [];
                 span ~a:[ a_class [ "text-4xl" ] ] [ txt "MB" ];


### PR DESCRIPTION
In the ui elements with a `-` and `+` buttons, manually typing a value reorders this as the cursor slides to the beginning. This PR fixes that.