### PR TITLE
check auth token for some endpoints

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2883,15 +2883,15 @@ struct
                 authenticate store reqd (api_tokens store))
         | "/api/tokens/create" ->
             check_meth `POST (fun () ->
-                authenticate ~api_meth:true store reqd
+                authenticate ~api_meth:true ~check_token:true store reqd
                   (extract_json_csrf_token (create_token store)))
         | "/api/tokens/delete" ->
             check_meth `POST (fun () ->
-                authenticate ~api_meth:true store reqd
+                authenticate ~api_meth:true ~check_token:true store reqd
                   (extract_json_csrf_token (delete_token store)))
         | "/api/tokens/update" ->
             check_meth `POST (fun () ->
-                authenticate ~api_meth:true store reqd
+                authenticate ~api_meth:true ~check_token:true store reqd
                   (extract_json_csrf_token (update_token store)))
         | "/admin/users" ->
             check_meth `GET (fun () ->


### PR DESCRIPTION
While writing documentation for the rest API and testing them, I noticed the API methods for tokens management was missing the `check_token` flag. This PR corrects that.