### PR TITLE
re-add albatross retry and view errors endpoint

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2865,6 +2865,16 @@ struct
             check_meth `GET (fun () ->
                 authenticate ~check_admin:true store reqd
                   (albatross_settings store !albatross_instances))
+        | "/admin/albatross/errors" ->
+            check_meth `GET (fun () ->
+                authenticate ~check_admin:true store reqd
+                  (albatross_instance req.H1.Request.target
+                     (view_albatross_error_logs store)))
+        | "/api/admin/albatross/retry" ->
+            check_meth `GET (fun () ->
+                authenticate ~check_admin:true ~api_meth:true store reqd
+                  (albatross_instance req.H1.Request.target
+                     (retry_initializing_instance stack albatross_instances)))
         | "/admin/settings/email" ->
             check_meth `GET (fun () ->
                 authenticate ~check_admin:true store reqd (email_settings store))


### PR DESCRIPTION
These endpoints were errorneously removed in commit 3047399201b4e2e016ccff3e5c26be78480413d7