### PR TITLE
Module for autoscaling logic of unikernels

### DIFF
--- a/albatross.ml
+++ b/albatross.ml
@@ -345,6 +345,26 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     in
     continue_reading name dec d tls_flow
 
+  let stats name f tls_flow d =
+    let dec = function
+      | Error s ->
+          Logs.err (fun m ->
+              m "albatross stop reading stats %a: error %s" Vmm_core.Name.pp
+                name s);
+          Error ()
+      | Ok (_, `Data (`Stats_data t)) -> f t
+      | Ok (_, `Success (`String _)) ->
+          (* ignore the success subscribed *)
+          Ok ()
+      | Ok w ->
+          Logs.warn (fun m ->
+              m "albatross unexpected reply, need stats output, got %a"
+                (Vmm_commands.pp_wire ~verbose:false)
+                w);
+          Ok ()
+    in
+    continue_reading name dec d tls_flow
+
   let raw_query (stack : S.t) t ?(name = Vmm_core.Name.root) certificates cmd
       ?push f =
     let open Lwt.Infix in
@@ -593,6 +613,13 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     | Ok (vmm_name, certificates) ->
         raw_query stack t ~name:vmm_name certificates cmd
           (block_data vmm_name f)
+
+  let query_stats stack t ~domain ~name f =
+    let cmd = `Stats_cmd `Stats_subscribe in
+    match certs t domain name cmd with
+    | Error str -> Lwt.return (Error str)
+    | Ok (vmm_name, certificates) ->
+        raw_query stack t ~name:vmm_name certificates cmd (stats vmm_name f)
 
   let set_policy stack t ~domain policy =
     let open Lwt.Infix in

--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -112,7 +112,7 @@ let res = function
   | `Failure f -> Error (`String ("failure: " ^ String.escaped f))
   | `Data (`Console_data (ts, data)) -> Ok (console_data_to_json (ts, data))
   | `Data (`Utc_console_data (ts, data)) -> Ok (console_data_to_json (ts, data))
-  | `Data (`Stats_data t) -> Ok t
+  | `Data (`Stats_data _) -> Error (`String "stats data not supported")
   | `Data (`Block_data _) -> Error (`String "block data not supported")
 
 let fail_behaviour_of_json js =

--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -112,7 +112,7 @@ let res = function
   | `Failure f -> Error (`String ("failure: " ^ String.escaped f))
   | `Data (`Console_data (ts, data)) -> Ok (console_data_to_json (ts, data))
   | `Data (`Utc_console_data (ts, data)) -> Ok (console_data_to_json (ts, data))
-  | `Data (`Stats_data _) -> Error (`String "stats not supported")
+  | `Data (`Stats_data t) -> Ok t
   | `Data (`Block_data _) -> Error (`String "block data not supported")
 
 let fail_behaviour_of_json js =

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,4 +1,4 @@
-let poll_interval = 300.0 (* check every 5 minutes *)
+let poll_interval = Duration.of_min 5 (* check every 5 minutes *)
 let trigger_ticks = 5
 (* number of times a unikernel is checked and is overloaded before spawning a new clone i.e trigger_ticks x poll_interval determines how load a unikernel is overloaded for before we spawn. Currently this will be 25 minutes. *)
 

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -19,7 +19,7 @@ module Cpu_monitor = struct
     let sys_t = rusage_to_float r.stime in
     user_t +. sys_t
 
-  type t = { mutable last_cpu_time : float; mutable last_wall_time : Ptime.t }
+  type t = { last_cpu_time : float; last_wall_time : Ptime.t }
 
   let create now (initial_rusage : Vmm_core.Stats.rusage) =
     { last_cpu_time = get_total_cpu_time initial_rusage; last_wall_time = now }
@@ -30,8 +30,8 @@ module Cpu_monitor = struct
     let cpu_delta = curr_cpu_time -. t.last_cpu_time in
     let wall_span = Ptime.diff curr_wall_time t.last_wall_time in
     let wall_delta = Ptime.Span.to_float_s wall_span in
-    t.last_cpu_time <- curr_cpu_time;
-    t.last_wall_time <- curr_wall_time;
+    { last_cpu_time = curr_cpu_time; last_wall_time = curr_wall_time }
+    |> fun t ->
     if wall_delta <= 0.000001 then 0.0
     else
       let pct = cpu_delta /. wall_delta *. 100.0 in

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,0 +1,81 @@
+module Cpu_monitor = struct
+  let rusage_to_float (sec, usec) =
+    let s = Int64.to_float sec in
+    let u = float_of_int usec in
+    s +. (u /. 1_000_000.0)
+
+  let get_total_cpu_time (r : Vmm_core.Stats.rusage) =
+    let user_t = rusage_to_float r.utime in
+    let sys_t = rusage_to_float r.stime in
+    user_t +. sys_t
+
+  type t = { mutable last_cpu_time : float; mutable last_wall_time : Ptime.t }
+
+  let create now (initial_rusage : Vmm_core.Stats.rusage) =
+    { last_cpu_time = get_total_cpu_time initial_rusage; last_wall_time = now }
+
+  let measure t now (current_rusage : Vmm_core.Stats.rusage) =
+    let curr_cpu_time = get_total_cpu_time current_rusage in
+    let curr_wall_time = now in
+    let cpu_delta = curr_cpu_time -. t.last_cpu_time in
+    let wall_span = Ptime.diff curr_wall_time t.last_wall_time in
+    let wall_delta = Ptime.Span.to_float_s wall_span in
+    t.last_cpu_time <- curr_cpu_time;
+    t.last_wall_time <- curr_wall_time;
+    if wall_delta <= 0.000001 then 0.0
+    else
+      let pct = cpu_delta /. wall_delta *. 100.0 in
+      Float.min 100.0 (Float.max 0.0 pct)
+end
+
+type t = {
+  monitor : Cpu_monitor.t;
+  mutable consecutive_high_ticks : int;
+  mutable last_spawn_time : Ptime.t option;
+}
+
+type status =
+  | Overloaded
+  | Pending of int * float
+    (* We have a high load but waiting for required number of polls to complete*)
+  | Cooldown of float
+  | Normal of float
+
+let poll_interval = 300.0 (* check every 5 minutes *)
+let trigger_ticks = 5
+(* number of times a unikernel is checked and is overloaded before spawning a new clone i.e trigger_ticks x poll_interval determines how load a unikernel is overloaded for before we spawn. Currently this will be 25 minutes. *)
+
+let threshold_percent =
+  90.0 (* if CPU usage >= 90% for 5 consercutive checks then we spawn. *)
+
+let cooldown_period = 600.0
+(* after spawning a new clone, wait for 10 minutes before we start checking this unikernel again *)
+
+let create now initial_rusage =
+  {
+    monitor = Cpu_monitor.create now initial_rusage;
+    consecutive_high_ticks = 0;
+    last_spawn_time = None;
+  }
+
+let in_cooldown now = function
+  | { last_spawn_time = None; _ } -> false
+  | { last_spawn_time = Some t; _ } ->
+      let span = Ptime.diff now t in
+      Ptime.Span.to_float_s span < cooldown_period
+
+let check t now current_rusage =
+  let usage = Cpu_monitor.measure t.monitor now current_rusage in
+  if in_cooldown now t then (
+    t.consecutive_high_ticks <- 0;
+    Cooldown usage)
+  else if usage > threshold_percent then (
+    t.consecutive_high_ticks <- t.consecutive_high_ticks + 1;
+    if t.consecutive_high_ticks >= trigger_ticks then (
+      t.consecutive_high_ticks <- 0;
+      t.last_spawn_time <- Some now;
+      Overloaded)
+    else Pending (t.consecutive_high_ticks, usage))
+  else (
+    t.consecutive_high_ticks <- 0;
+    Normal usage)

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -8,6 +8,9 @@ let threshold_percent =
 let cooldown_period = 600.0
 (* after spawning a new clone, wait for 10 minutes before we start checking this unikernel again *)
 
+let death_timeout = 900.0
+(* Timeout in seconds. If no stats for 15 minutes, assume destroyed. *)
+
 module Cpu_monitor = struct
   let rusage_to_float (sec, usec) =
     let s = Int64.to_float sec in
@@ -63,6 +66,7 @@ module Cluster_manager = struct
     primary : string * t;
     mutable clones : (string * t) list;
     mutable last_scale_action : Ptime.t option;
+    mutable last_stats_received : Ptime.t;
     mutable next_id : int;
     mutable consecutive_high_ticks : int;
   }
@@ -223,4 +227,19 @@ module Cluster_manager = struct
         else (
           group.consecutive_high_ticks <- 0;
           Ok (Normal current_vm_state))
+
+  let prune_dead_clusters now =
+    let dead_keys =
+      Hashtbl.fold
+        (fun primary_name group acc ->
+          let span = Ptime.diff now group.last_stats_received in
+          if Ptime.Span.to_float_s span > death_timeout then primary_name :: acc
+          else acc)
+        clusters []
+    in
+    List.iter
+      (fun key ->
+        Logs.warn (fun m -> m "[Cluster Manager] Pruning dead cluster: %s" key);
+        Hashtbl.remove clusters key)
+      dead_keys
 end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,3 +1,13 @@
+let poll_interval = 300.0 (* check every 5 minutes *)
+let trigger_ticks = 5
+(* number of times a unikernel is checked and is overloaded before spawning a new clone i.e trigger_ticks x poll_interval determines how load a unikernel is overloaded for before we spawn. Currently this will be 25 minutes. *)
+
+let threshold_percent =
+  90.0 (* if CPU usage >= 90% for 5 consercutive checks then we spawn. *)
+
+let cooldown_period = 600.0
+(* after spawning a new clone, wait for 10 minutes before we start checking this unikernel again *)
+
 module Cpu_monitor = struct
   let rusage_to_float (sec, usec) =
     let s = Int64.to_float sec in
@@ -28,54 +38,195 @@ module Cpu_monitor = struct
       Float.min 100.0 (Float.max 0.0 pct)
 end
 
-type t = {
-  monitor : Cpu_monitor.t;
-  mutable consecutive_high_ticks : int;
-  mutable last_spawn_time : Ptime.t option;
-}
+type t = { mutable monitor : Cpu_monitor.t; mutable last_cpu_usage : float }
 
 type status =
-  | Overloaded
+  | Overloaded of
+      t (* the usage of the clone or cm that is checked in the group *)
   | Pending of int * float
     (* We have a high load but waiting for required number of polls to complete*)
   | Cooldown of float
   | Normal of float
 
-let poll_interval = 300.0 (* check every 5 minutes *)
-let trigger_ticks = 5
-(* number of times a unikernel is checked and is overloaded before spawning a new clone i.e trigger_ticks x poll_interval determines how load a unikernel is overloaded for before we spawn. Currently this will be 25 minutes. *)
-
-let threshold_percent =
-  90.0 (* if CPU usage >= 90% for 5 consercutive checks then we spawn. *)
-
-let cooldown_period = 600.0
-(* after spawning a new clone, wait for 10 minutes before we start checking this unikernel again *)
-
 let create now initial_rusage =
   {
     monitor = Cpu_monitor.create now initial_rusage;
-    consecutive_high_ticks = 0;
-    last_spawn_time = None;
+    last_cpu_usage =
+      Cpu_monitor.measure
+        (Cpu_monitor.create now initial_rusage)
+        now initial_rusage;
   }
 
-let in_cooldown now = function
-  | { last_spawn_time = None; _ } -> false
-  | { last_spawn_time = Some t; _ } ->
-      let span = Ptime.diff now t in
-      Ptime.Span.to_float_s span < cooldown_period
+module Cluster_manager = struct
+  type group = {
+    primary : string * t;
+    mutable clones : (string * t) list;
+    mutable last_scale_action : Ptime.t option;
+    mutable next_id : int;
+    mutable consecutive_high_ticks : int;
+  }
 
-let check t now current_rusage =
-  let usage = Cpu_monitor.measure t.monitor now current_rusage in
-  if in_cooldown now t then (
-    t.consecutive_high_ticks <- 0;
-    Cooldown usage)
-  else if usage > threshold_percent then (
-    t.consecutive_high_ticks <- t.consecutive_high_ticks + 1;
-    if t.consecutive_high_ticks >= trigger_ticks then (
-      t.consecutive_high_ticks <- 0;
-      t.last_spawn_time <- Some now;
-      Overloaded)
-    else Pending (t.consecutive_high_ticks, usage))
-  else (
-    t.consecutive_high_ticks <- 0;
-    Normal usage)
+  let clusters : (string, group) Hashtbl.t = Hashtbl.create 10
+
+  let in_cooldown now = function
+    | { last_scale_action = None; _ } -> false
+    | { last_scale_action = Some t; _ } ->
+        let span = Ptime.diff now t in
+        Ptime.Span.to_float_s span < cooldown_period
+
+  let get_or_create primary =
+    match Hashtbl.find_opt clusters (fst primary) with
+    | Some g -> g
+    | None ->
+        let g =
+          {
+            primary;
+            clones = [];
+            consecutive_high_ticks = 0;
+            last_scale_action = None;
+            next_id = 1;
+          }
+        in
+        Hashtbl.add clusters (fst primary) g;
+        g
+
+  let find_group_by_name primary_name = Hashtbl.find_opt clusters primary_name
+
+  let get_primary_from_clone clone =
+    let clone_name = fst clone in
+    let parts = String.split_on_char '-' clone_name in
+    match List.rev parts with
+    | _id_str :: "clone" :: primary_parts_rev ->
+        let primary_name = String.concat "-" (List.rev primary_parts_rev) in
+        Some primary_name
+    | _ -> None
+
+  let is_clone name =
+    if String.contains name '-' then
+      let parts = String.split_on_char '-' name in
+      match List.rev parts with
+      | _id_str :: "clone" :: _primary_parts_rev -> true
+      | _ -> false
+    else false
+
+  let find_or_create_group ~name ~key t =
+    if is_clone name then
+      match get_primary_from_clone (name, ()) with
+      | Some primary_name -> (
+          match find_group_by_name primary_name with
+          | Some g -> Ok (g, name)
+          | None ->
+              Error
+                (Fmt.str
+                   "No primary group found for primary '%s' (derived from \
+                    clone '%s')."
+                   primary_name name))
+      | None ->
+          Error (Fmt.str "Could not derive primary name from clone '%s'." name)
+    else
+      match find_group_by_name key with
+      | Some g -> Ok (g, key)
+      | None -> get_or_create (key, t) |> fun g -> Ok (g, key)
+
+  let next_clone_name vm =
+    if is_clone (fst vm) then
+      match get_primary_from_clone vm with
+      | Some primary_name -> (
+          match find_group_by_name primary_name with
+          | Some g ->
+              let id = g.next_id in
+              g.next_id <- g.next_id + 1;
+              Ok (Fmt.str "%s-clone-%d" primary_name id)
+          | None ->
+              Error
+                (Fmt.str
+                   "No primary group found for primary '%s' (derived from \
+                    clone '%s')."
+                   primary_name (fst vm)))
+      | None ->
+          Error
+            (Fmt.str "Could not derive primary name from clone '%s'." (fst vm))
+    else
+      let g = get_or_create vm in
+      let id = g.next_id in
+      g.next_id <- g.next_id + 1;
+      Ok (Fmt.str "%s-clone-%d" (fst g.primary) id)
+
+  let register_clone clone =
+    match get_primary_from_clone clone with
+    | None ->
+        Error
+          (Fmt.str "Invalid clone name '%s'. Cannot extract primary name."
+             (fst clone))
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g ->
+            g.clones <- clone :: g.clones;
+            g.last_scale_action <- Some (Ptime_clock.now ());
+            Ok ()
+        | None ->
+            Error
+              (Fmt.str
+                 "No primary group found for primary '%s' (derived from clone \
+                  '%s')."
+                 primary_name (fst clone)))
+
+  let remove_clone clone =
+    match get_primary_from_clone clone with
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g ->
+            g.clones <- List.filter (fun c -> fst c <> fst clone) g.clones;
+            g.last_scale_action <- Some (Ptime_clock.now ());
+            Ok ()
+        | None -> Error "Primary group not found during removal")
+    | None -> Error "Could not derive primary name for removal"
+
+  let record_action primary =
+    let g = get_or_create primary in
+    g.last_scale_action <- Some (Ptime_clock.now ())
+
+  let check_group_average group key now rusage =
+    let all_instances = group.primary :: group.clones in
+    match
+      List.find_opt (fun (name, _) -> String.equal name key) all_instances
+    with
+    | None -> Error "Current VM not found in group during average check"
+    | Some (_, vm) ->
+        let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
+        let new_monitor = Cpu_monitor.create now rusage in
+        let current_vm_state =
+          { monitor = new_monitor; last_cpu_usage = current_vm_usage }
+        in
+        vm.monitor <- new_monitor;
+        vm.last_cpu_usage <- current_vm_usage;
+        let other_vms_usage =
+          List.fold_left
+            (fun acc (name, vm) ->
+              if key = name then acc else acc +. vm.last_cpu_usage)
+            0.0 all_instances
+        in
+        let total_usage = current_vm_usage +. other_vms_usage in
+        let average_usage =
+          total_usage /. float_of_int (List.length all_instances)
+        in
+        Ok (average_usage, current_vm_state)
+
+  let check_group_status group key now rusage =
+    match check_group_average group key now rusage with
+    | Error e -> Error e
+    | Ok (average_usage, current_vm_state) ->
+        if in_cooldown now group then (
+          group.consecutive_high_ticks <- 0;
+          Ok (Cooldown average_usage))
+        else if average_usage > threshold_percent then (
+          group.consecutive_high_ticks <- group.consecutive_high_ticks + 1;
+          if group.consecutive_high_ticks >= trigger_ticks then (
+            group.consecutive_high_ticks <- 0;
+            group.last_scale_action <- Some (Ptime_clock.now ());
+            Ok (Overloaded current_vm_state))
+          else Ok (Pending (group.consecutive_high_ticks, average_usage)))
+        else (
+          group.consecutive_high_ticks <- 0;
+          Ok (Normal average_usage))
+end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -43,11 +43,11 @@ type t = { mutable monitor : Cpu_monitor.t; mutable last_cpu_usage : float }
 
 type status =
   | Overloaded of
-      t (* the usage of the clone or cm that is checked in the group *)
-  | Pending of int * float
+      t (* the usage of the clone or vm that is checked in the group *)
+  | Pending of int * t
     (* We have a high load but waiting for required number of polls to complete*)
-  | Cooldown of float
-  | Normal of float
+  | Cooldown of t
+  | Normal of t
 
 let create now initial_rusage =
   {
@@ -219,15 +219,15 @@ module Cluster_manager = struct
     | Ok (average_usage, current_vm_state) ->
         if in_cooldown now group then (
           group.consecutive_high_ticks <- 0;
-          Ok (Cooldown average_usage))
+          Ok (Cooldown current_vm_state))
         else if average_usage > threshold_percent then (
           group.consecutive_high_ticks <- group.consecutive_high_ticks + 1;
           if group.consecutive_high_ticks >= trigger_ticks then (
             group.consecutive_high_ticks <- 0;
             group.last_scale_action <- Some (Ptime_clock.now ());
             Ok (Overloaded current_vm_state))
-          else Ok (Pending (group.consecutive_high_ticks, average_usage)))
+          else Ok (Pending (group.consecutive_high_ticks, current_vm_state)))
         else (
           group.consecutive_high_ticks <- 0;
-          Ok (Normal average_usage))
+          Ok (Normal current_vm_state))
 end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -93,22 +93,14 @@ module Cluster_manager = struct
 
   let find_group_by_name primary_name = Hashtbl.find_opt clusters primary_name
 
-  let get_primary_from_clone clone =
-    let clone_name = fst clone in
-    let parts = String.split_on_char '-' clone_name in
-    match List.rev parts with
+  let extract_primary name =
+    match List.rev (String.split_on_char '-' name) with
     | _id_str :: "clone" :: primary_parts_rev ->
-        let primary_name = String.concat "-" (List.rev primary_parts_rev) in
-        Some primary_name
+        Some (String.concat "-" (List.rev primary_parts_rev))
     | _ -> None
 
-  let is_clone name =
-    if String.contains name '-' then
-      let parts = String.split_on_char '-' name in
-      match List.rev parts with
-      | _id_str :: "clone" :: _primary_parts_rev -> true
-      | _ -> false
-    else false
+  let get_primary_from_clone clone = extract_primary (fst clone)
+  let is_clone name = Option.is_some (extract_primary name)
 
   let find_or_create_group ~name ~key t =
     if is_clone name then

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -33,9 +33,10 @@ module Cpu_monitor = struct
     { last_cpu_time = curr_cpu_time; last_wall_time = curr_wall_time }
     |> fun t ->
     if wall_delta <= 0.000001 then 0.0
+    else if cpu_delta < 0.0 then 0.0
     else
       let pct = cpu_delta /. wall_delta *. 100.0 in
-      Float.min 100.0 (Float.max 0.0 pct)
+      Float.min 100.0 pct
 end
 
 type t = { mutable monitor : Cpu_monitor.t; mutable last_cpu_usage : float }

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -85,6 +85,7 @@ module Cluster_manager = struct
             clones = [];
             consecutive_high_ticks = 0;
             last_scale_action = None;
+            last_stats_received = Mirage_ptime.now ();
             next_id = 1;
           }
         in
@@ -155,7 +156,7 @@ module Cluster_manager = struct
         match find_group_by_name primary_name with
         | Some g ->
             g.clones <- clone :: g.clones;
-            g.last_scale_action <- Some (Ptime_clock.now ());
+            g.last_scale_action <- Some (Mirage_ptime.now ());
             Ok ()
         | None ->
             Error
@@ -170,14 +171,14 @@ module Cluster_manager = struct
         match find_group_by_name primary_name with
         | Some g ->
             g.clones <- List.filter (fun c -> fst c <> fst clone) g.clones;
-            g.last_scale_action <- Some (Ptime_clock.now ());
+            g.last_scale_action <- Some (Mirage_ptime.now ());
             Ok ()
         | None -> Error "Primary group not found during removal")
     | None -> Error "Could not derive primary name for removal"
 
   let record_action primary =
     let g = get_or_create primary in
-    g.last_scale_action <- Some (Ptime_clock.now ())
+    g.last_scale_action <- Some (Mirage_ptime.now ())
 
   let check_group_average group key now rusage =
     let all_instances = group.primary :: group.clones in
@@ -216,7 +217,7 @@ module Cluster_manager = struct
           group.consecutive_high_ticks <- group.consecutive_high_ticks + 1;
           if group.consecutive_high_ticks >= trigger_ticks then (
             group.consecutive_high_ticks <- 0;
-            group.last_scale_action <- Some (Ptime_clock.now ());
+            group.last_scale_action <- Some now;
             Ok (Overloaded current_vm_state))
           else Ok (Pending (group.consecutive_high_ticks, current_vm_state)))
         else (

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -487,7 +487,7 @@ struct
         update_albatross_status state (`Incompatible, reply, "unikernel info");
         []
 
-  let user_unikernels_generic selector stack albatross_instances user_name =
+  let user_unikernels_with_albatross stack albatross_instances user_name =
     Lwt_list.map_p
       (fun (_name, (instance : Albatross.t)) ->
         Albatross_state.query stack instance ~domain:user_name
@@ -497,21 +497,20 @@ struct
         | Ok (_hdr, `Success (`Old_unikernel_info4 unikernels))
         | Ok (_hdr, `Success (`Unikernel_info unikernels)) ->
             Albatross.set_online instance;
-            (selector instance, unikernels)
+            (instance, unikernels)
         | Ok reply ->
             update_albatross_status instance
               (`Incompatible, reply, "unikernel info");
-            (selector instance, [])
-        | Error _msg -> (selector instance, []))
+            (instance, [])
+        | Error _msg -> (instance, []))
       (Albatross.Albatross_map.bindings albatross_instances)
 
   let user_unikernels stack instances user_name =
-    user_unikernels_generic
-      (fun i -> i.Albatross.configuration.name)
-      stack instances user_name
-
-  let user_unikernels_with_albatross stack instances user_name =
-    user_unikernels_generic (fun i -> i) stack instances user_name
+    user_unikernels_with_albatross stack instances user_name >|= fun results ->
+    List.map
+      (fun (instance, unikernels) ->
+        (instance.Albatross.configuration.name, unikernels))
+      results
 
   let user_unikernel stack state ~user_name ~unikernel_name =
     Albatross_state.query stack state ~domain:user_name ~name:unikernel_name

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2861,8 +2861,7 @@ struct
           Logs.err (fun m ->
               m "CPU memory checks failed: %s" (Printexc.to_string exn));
           Lwt.return [])
-      >>= fun _ ->
-      Mirage_sleep.ns (Duration.of_f Autoscaler.poll_interval) >>= loop
+      >>= fun _ -> Mirage_sleep.ns Autoscaler.poll_interval >>= loop
     in
     Lwt.async loop
 

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2758,7 +2758,7 @@ struct
           Autoscaler.Cluster_manager.check_group_status group key now rusage
         with
         | Ok (Autoscaler.Normal usage_pct) ->
-            Logs.info (fun m ->
+            Logs.debug (fun m ->
                 m "[%s] Normal load: %.2f%%" unikernel_name usage_pct);
             Ok ()
         | Ok (Autoscaler.Pending (ticks, usage_pct)) ->
@@ -2794,7 +2794,7 @@ struct
                           unikernel_name new_name);
                     Ok ()))
         | Error err ->
-            Logs.err (fun m ->
+            Logs.warn (fun m ->
                 m "Error checking cluster group status for unikernel %s: %s"
                   unikernel_name err);
             Ok ())

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2757,19 +2757,20 @@ struct
         match
           Autoscaler.Cluster_manager.check_group_status group key now rusage
         with
-        | Ok (Autoscaler.Normal usage_pct) ->
+        | Ok (Autoscaler.Normal scaler) ->
             Logs.debug (fun m ->
-                m "[%s] Normal load: %.2f%%" unikernel_name usage_pct);
+                m "[%s] Normal load: %.2f%%" unikernel_name
+                  scaler.last_cpu_usage);
             Ok ()
-        | Ok (Autoscaler.Pending (ticks, usage_pct)) ->
+        | Ok (Autoscaler.Pending (ticks, scaler)) ->
             Logs.info (fun m ->
                 m "[%s] High load detected (%.2f%%). Tick %d/%d" unikernel_name
-                  usage_pct ticks Autoscaler.trigger_ticks);
+                  scaler.last_cpu_usage ticks Autoscaler.trigger_ticks);
             Ok ()
-        | Ok (Autoscaler.Cooldown usage_pct) ->
+        | Ok (Autoscaler.Cooldown scaler) ->
             Logs.info (fun m ->
                 m "[%s] Cooling down (Usage: %.2f%%)..." unikernel_name
-                  usage_pct);
+                  scaler.last_cpu_usage);
             Ok ()
         | Ok (Autoscaler.Overloaded scaler) -> (
             match

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2740,6 +2740,132 @@ struct
               ~data:(`String (Fmt.str "Test failed: %s" (String.escaped err)))
               `Bad_request)
 
+  let handle_stats (stats : Vmm_core.Stats.t) ~unikernel_key ~unikernel_name =
+    let rusage, _, _, _ = stats in
+    let now = Mirage_ptime.now () in
+    match
+      Autoscaler.Cluster_manager.find_or_create_group ~name:unikernel_name
+        ~key:unikernel_key
+        (Autoscaler.create now rusage)
+    with
+    | Error err ->
+        Logs.err (fun m ->
+            m "Error finding cluster group for unikernel %s: %s" unikernel_name
+              err);
+        Ok ()
+    | Ok (group, key) -> (
+        match
+          Autoscaler.Cluster_manager.check_group_status group key now rusage
+        with
+        | Ok (Autoscaler.Normal usage_pct) ->
+            Logs.info (fun m ->
+                m "[%s] Normal load: %.2f%%" unikernel_name usage_pct);
+            Ok ()
+        | Ok (Autoscaler.Pending (ticks, usage_pct)) ->
+            Logs.info (fun m ->
+                m "[%s] High load detected (%.2f%%). Tick %d/%d" unikernel_name
+                  usage_pct ticks Autoscaler.trigger_ticks);
+            Ok ()
+        | Ok (Autoscaler.Cooldown usage_pct) ->
+            Logs.info (fun m ->
+                m "[%s] Cooling down (Usage: %.2f%%)..." unikernel_name
+                  usage_pct);
+            Ok ()
+        | Ok (Autoscaler.Overloaded scaler) -> (
+            match
+              Autoscaler.Cluster_manager.next_clone_name (unikernel_name, scaler)
+            with
+            | Error _e -> Ok ()
+            | Ok new_name -> (
+                match
+                  Autoscaler.Cluster_manager.register_clone (new_name, scaler)
+                with
+                | Error _e -> Ok ()
+                | Ok () ->
+                    (* TODO 
+                    1) Deploy new clone with name new_name
+                    2) Add new clone to load balancer pool
+                    3) Update Autoscaler.Cluster_manager.record_action
+                  *)
+                    Logs.err (fun m ->
+                        m
+                          "[%s] OVERLOAD CONFIRMED. Initiating Scale-Up! New \
+                           clone name: %s"
+                          unikernel_name new_name);
+                    Ok ()))
+        | Error err ->
+            Logs.err (fun m ->
+                m "Error checking cluster group status for unikernel %s: %s"
+                  unikernel_name err);
+            Ok ())
+
+  let unikernel_stat stack albatross unikernel_name (user : User_model.user) =
+    let unikernel_key =
+      Fmt.str "%s-%s-%s"
+        (Configuration.name_to_str user.name)
+        (Configuration.name_to_str albatross.Albatross.configuration.name)
+        (Configuration.name_to_str unikernel_name)
+    in
+    Logs.info (fun m -> m "Checking CPU load for unikernel %s" unikernel_key);
+    Albatross_state.query_stats stack albatross ~domain:user.name
+      ~name:unikernel_name (fun s ->
+        handle_stats s ~unikernel_key
+          ~unikernel_name:(Configuration.name_to_str unikernel_name))
+    >>= function
+    | Error err ->
+        Logs.info (fun m ->
+            m "Failed to get stats for unikernel %s: %s" unikernel_key err);
+        Lwt.return_unit
+    | Ok () ->
+        Albatross.set_online albatross;
+        Lwt.return_unit
+
+  let unikernel_statistics stack albatross_instances user =
+    user_unikernels_with_albatross stack albatross_instances
+      user.User_model.name
+    >>= fun unikernels_per_instance ->
+    Lwt_list.map_p
+      (fun (instance, unikernels) ->
+        Lwt_list.filter_map_p
+          (fun (name, _unikernel) ->
+            match Vmm_core.Name.name name with
+            | Some unikernel_name ->
+                Lwt.async (fun () ->
+                    unikernel_stat stack instance unikernel_name user
+                    >>= fun _ -> Lwt.return_unit);
+                Lwt.return_none
+            | None ->
+                Logs.info (fun m ->
+                    m "Invalid unikernel name for stats: %s"
+                      (Vmm_core.Name.to_string name));
+                Lwt.return_none)
+          unikernels
+        >>= fun _ -> Lwt.return_unit)
+      unikernels_per_instance
+
+  let check_all_unikernel_cpu_loads stack albatross_instances users =
+    Lwt_list.fold_left_s
+      (fun acc user ->
+        unikernel_statistics stack albatross_instances user >>= fun _results ->
+        Lwt.return acc)
+      [] users
+
+  let start_background_cpu_usage_scheduler stack store albatross_instances_ref =
+    let rec loop () =
+      Lwt.catch
+        (fun () ->
+          Logs.info (fun m -> m "Starting CPU memory checks...");
+          check_all_unikernel_cpu_loads stack !albatross_instances_ref
+            (Store.users store))
+        (fun exn ->
+          Logs.err (fun m ->
+              m "CPU memory checks failed: %s" (Printexc.to_string exn));
+          Lwt.return [])
+      >>= fun _ ->
+      Mirage_sleep.ns (Duration.of_f Autoscaler.poll_interval) >>= loop
+    in
+    Lwt.async loop
+
   let seconds_until_next_midnight () =
     let now = Mirage_ptime.now () in
     let date, _ = Ptime.to_date_time now in
@@ -3237,5 +3363,7 @@ struct
         Lwt.pause () >>= fun () ->
         start_background_scheduler happy_eyeballs stack store
           albatross_instances http_client;
+        Lwt.pause () >>= fun () ->
+        start_background_cpu_usage_scheduler stack store albatross_instances;
         th
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -487,24 +487,31 @@ struct
         update_albatross_status state (`Incompatible, reply, "unikernel info");
         []
 
-  let user_unikernels stack (albatross_instances : Albatross_state.a_map)
-      user_name =
+  let user_unikernels_generic selector stack albatross_instances user_name =
     Lwt_list.map_p
       (fun (_name, (instance : Albatross.t)) ->
         Albatross_state.query stack instance ~domain:user_name
           (`Unikernel_cmd `Unikernel_info)
         >|= function
-        | Error _msg -> (instance.configuration.name, [])
         | Ok (_hdr, `Success (`Old_unikernel_info3 unikernels))
         | Ok (_hdr, `Success (`Old_unikernel_info4 unikernels))
         | Ok (_hdr, `Success (`Unikernel_info unikernels)) ->
             Albatross.set_online instance;
-            (instance.configuration.name, unikernels)
+            (selector instance, unikernels)
         | Ok reply ->
             update_albatross_status instance
               (`Incompatible, reply, "unikernel info");
-            (instance.configuration.name, []))
+            (selector instance, [])
+        | Error _msg -> (selector instance, []))
       (Albatross.Albatross_map.bindings albatross_instances)
+
+  let user_unikernels stack instances user_name =
+    user_unikernels_generic
+      (fun i -> i.Albatross.configuration.name)
+      stack instances user_name
+
+  let user_unikernels_with_albatross stack instances user_name =
+    user_unikernels_generic (fun i -> i) stack instances user_name
 
   let user_unikernel stack state ~user_name ~unikernel_name =
     Albatross_state.query stack state ~domain:user_name ~name:unikernel_name


### PR DESCRIPTION
This is the first step to automatic scaling of unikernels. This pr adds a new module `Autoscaler` which is meant to handle all the logic involved with checking the load of a unikernel and determining it's state. We have 4 states:

- `Overloaded:` we should spawn a new clone.
- `Pending:` usage is high but we are still monitoring to be sure it wasn't a single incidental spike.
- `Cooldown:` we spawned a new unikernel and now we'll wait for sometime and monitor usage again.
- `Normal:`  all is okay with no usage spikes

We also have some static values which determine the behaviour of the autoscaler:
- cpu is checked every 5 minutes
- if CPU ≥ 90% for 5 consecutive checks i.e overload detected (~25 minutes sustained load)
- after spawning a new clone:
     - ignore overload signals for 10 minutes