### PR TITLE
Deploy directly from our reproducible build infrastructure and make deployment simpler

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -452,7 +452,17 @@ async function deployUnikernel(albatross_instance) {
 	const formAlert = document.getElementById("form-alert");
 	const deployButton = document.getElementById("deploy-button");
 	const name = document.getElementById("unikernel-name").value;
-	const cpuid = document.getElementById("cpuid").value;
+	let cpuid = document.getElementById("cpuid").value;
+	if (cpuid === "") {
+		const cpuSelect = document.getElementById("cpuid");
+		const validOptions = Array.from(cpuSelect.options).filter(opt => opt.value !== "");
+		if (validOptions.length > 0) {
+			const randomOpt = validOptions[Math.floor(Math.random() * validOptions.length)];
+			cpuid = randomOpt.value;
+		} else {
+			cpuid = "0";
+		}
+	}
 	const startup = document.getElementById("startup-priority").innerText;
 	const fail_behaviour = document.getElementById("restart-on-fail").checked;
 	const force_create = document.getElementById("force-create").checked;
@@ -469,6 +479,9 @@ async function deployUnikernel(albatross_instance) {
 
 	const argumentsString = document.getElementById("unikernel-arguments").value.trim();
 	const argumentsList = argumentsString ? argumentsString.split(/\s+/) : [];
+	const manualCheckbox = document.getElementById("manual-upload-toggle");
+	const isManual = manualCheckbox ? manualCheckbox.checked : false;
+	const buildJob = document.getElementById("unikernel-dropdown").value;
 	const binary = document.getElementById("unikernel-binary").files[0];
 	const molly_csrf = document.getElementById("molly-csrf").value;
 
@@ -480,7 +493,15 @@ async function deployUnikernel(albatross_instance) {
 		return;
 	}
 
-	if (!binary) {
+	if (!isManual && !buildJob) {
+		formAlert.classList.remove("hidden", "text-primary-500");
+		formAlert.classList.add("text-secondary-500");
+		formAlert.textContent = "Please select a unikernel from the dropdown";
+		buttonLoading(deployButton, false, "Deploy");
+		return;
+	}
+
+	if (isManual && !binary) {
 		formAlert.classList.remove("hidden", "text-primary-500");
 		formAlert.classList.add("text-secondary-500");
 		formAlert.textContent = "Please upload the unikernel image";
@@ -505,7 +526,12 @@ async function deployUnikernel(albatross_instance) {
 	formData.append("unikernel_config", JSON.stringify(unikernel_config));
 	formData.append("unikernel_force_create", force_create);
 	formData.append("molly_csrf", molly_csrf);
-	formData.append("binary", binary);
+	if (isManual) {
+		formData.append("binary", binary);
+	} else {
+		formData.append("build_job", buildJob);
+		formData.append("binary", new Blob([]), "binary");
+	}
 
 	try {
 		const response = await fetch("/api/unikernel/create", {

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -65,6 +65,36 @@ let list_of_json parse_fn json =
     (Ok []) json
   |> Result.map List.rev
 
+let string_of_json = function
+  | `String s -> Ok s
+  | js ->
+      Error (`Msg ("invalid json for string: " ^ Utils.Json.to_string js))
+
+let jobs_of_json = function
+  | `Assoc xs -> (
+      match Utils.Json.get "jobs_by_section" xs with
+      | Some (`Assoc sections) -> (
+          let get_section_jobs name =
+            match Utils.Json.get name sections with
+            | Some (`List jobs_json) -> list_of_json string_of_json jobs_json
+            | _ -> Ok []
+          in
+          match
+            ( get_section_jobs "Unikernels (with metrics reported to Influx)",
+              get_section_jobs "Unikernels" )
+          with
+          | Ok metrics, Ok normal -> Ok (metrics @ normal)
+          | Error e, _ | _, Error e -> Error e)
+      | _ ->
+          Error
+            (`Msg
+              "invalid json for jobs: 'jobs_by_section' object not found"))
+  | js ->
+      Error
+        (`Msg
+           ("invalid json for jobs payload, expected a dict: "
+          ^ Utils.Json.to_string js))
+
 let duniverse_detailed_diff_of_json = function
   | `Assoc xs -> (
       match Utils.Json.(get "name" xs) with

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -67,8 +67,7 @@ let list_of_json parse_fn json =
 
 let string_of_json = function
   | `String s -> Ok s
-  | js ->
-      Error (`Msg ("invalid json for string: " ^ Utils.Json.to_string js))
+  | js -> Error (`Msg ("invalid json for string: " ^ Utils.Json.to_string js))
 
 let jobs_of_json = function
   | `Assoc xs -> (
@@ -87,8 +86,7 @@ let jobs_of_json = function
           | Error e, _ | _, Error e -> Error e)
       | _ ->
           Error
-            (`Msg
-              "invalid json for jobs: 'jobs_by_section' object not found"))
+            (`Msg "invalid json for jobs: 'jobs_by_section' object not found"))
   | js ->
       Error
         (`Msg

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1152,8 +1152,22 @@ struct
                   (Utils.Json.to_string (`Assoc json_dict))))
           `Bad_request
 
-  let deploy_form stack store albatross _ (user : User_model.user) reqd =
+  let deploy_form stack store albatross _ (user : User_model.user) http_client reqd =
     let now = Mirage_ptime.now () in
+    Update_flow.get_jobs http_client >>= fun jobs_result ->
+    let jobs =
+      match jobs_result with
+      | Ok j -> j
+      | Error e ->
+          let err_str =
+            match e with
+            | Update_flow.Albatross_err err -> err
+            | Update_flow.Builder_req_err err -> err
+            | Update_flow.Builder_parse_err err -> err
+          in
+          Logs.warn (fun m -> m "Failed to fetch jobs: %s" err_str);
+          []
+    in
     user_unikernels_by_instance stack albatross user.name
     >>= fun unikernels_by_albatross_instance ->
     user_volumes_by_instance stack albatross user.name
@@ -1168,7 +1182,7 @@ struct
                   (Dashboard.dashboard_layout ~csrf user
                      ~page_title:"Deploy a Unikernel"
                      ~content:
-                       (Unikernel_create.unikernel_create_layout ~user_policy
+                       (Unikernel_create.unikernel_create_layout ~user_policy jobs
                           unikernels_by_albatross_instance
                           blocks_by_albatross_instance
                           albatross.configuration.name)
@@ -1846,7 +1860,7 @@ struct
         Middleware.http_response reqd
           ~data:(`String "Couldn't find unikernel name in json") `Bad_request
 
-  let unikernel_create stack albatross_instances token_or_cookie
+  let unikernel_create stack albatross_instances http_client token_or_cookie
       (user : User_model.user) reqd =
     let generate_http_error_response msg code =
       Logs.warn (fun m -> m "Unikernel_create error: %s" msg);
@@ -1863,12 +1877,17 @@ struct
         let force_ref = ref None in
         let csrf_ref = ref None in
         let albatross_instance_ref = ref None in
+        let build_job_ref = ref None in
         let process_stream () =
           Lwt_stream.iter_s
             (function
               | (Some "albatross_instance", _), _, contents ->
                   consume_part_content contents >>= fun v ->
                   albatross_instance_ref := Some v;
+                  Lwt.return_unit
+              | (Some "build_job", _), _, contents ->
+                  consume_part_content contents >>= fun v ->
+                  build_job_ref := Some v;
                   Lwt.return_unit
               | (Some "unikernel_name", _), _, contents ->
                   consume_part_content contents >>= fun v ->
@@ -1912,11 +1931,41 @@ struct
                                 `Unikernel_cmd (`Unikernel_force_create cfg)
                               else `Unikernel_cmd (`Unikernel_create cfg)
                             in
-                            Albatross_state.query stack albatross
-                              ~domain:user.name ~name:unikernel_name
-                              ~push:(fun () -> Lwt_stream.get contents)
-                              albatross_cmd
-                            >>= function
+                            let push, fetch_promise =
+                              match !build_job_ref with
+                              | Some job when job <> "" ->
+                                  let data_stream, push_chunks =
+                                    Lwt_stream.create ()
+                                  in
+                                  let url =
+                                    Builder_web.base_url ^ "/job/" ^ job
+                                    ^ "/build/latest/main-binary"
+                                  in
+                                  let f resp _acc chunk =
+                                    if
+                                      Http_mirage_client.Status.is_successful
+                                        resp.Http_mirage_client.status
+                                    then Lwt.return (push_chunks (Some chunk))
+                                    else Lwt.return_unit
+                                  in
+                                  let promise =
+                                    Http_mirage_client.request http_client ~follow_redirect:true url f ()
+                                    >>= fun res ->
+                                    push_chunks None;
+                                    Lwt.return res
+                                  in
+                                  ((fun () -> Lwt_stream.get data_stream), Some promise)
+                              | _ -> ((fun () -> Lwt_stream.get contents), None)
+                            in
+                            Lwt.both
+                              (match fetch_promise with
+                              | Some p -> p >>= fun _ -> Lwt.return_unit
+                              | None -> Lwt.return_unit)
+                              (Albatross_state.query stack albatross
+                                 ~domain:user.name ~name:unikernel_name ~push
+                                 albatross_cmd)
+                            >>= fun (_, query_res) ->
+                            match query_res with
                             | Error err ->
                                 generate_http_error_response
                                   ("Albatross Query Error: " ^ err)
@@ -3160,7 +3209,7 @@ struct
             check_meth `GET (fun () ->
                 authenticate store reqd
                   (albatross_instance "/unikernel/deploy"
-                     (deploy_form stack store)))
+                     (fun albatross tok user req -> deploy_form stack store albatross tok user http_client req)))
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
@@ -3180,7 +3229,7 @@ struct
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (fun token_or_cookie user reqd ->
-                    unikernel_create stack !albatross_instances token_or_cookie
+                    unikernel_create stack !albatross_instances http_client token_or_cookie
                       user reqd))
         | "/unikernel/update" ->
             check_meth `GET (fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1152,7 +1152,8 @@ struct
                   (Utils.Json.to_string (`Assoc json_dict))))
           `Bad_request
 
-  let deploy_form stack store albatross _ (user : User_model.user) http_client reqd =
+  let deploy_form stack store albatross _ (user : User_model.user) http_client
+      reqd =
     let now = Mirage_ptime.now () in
     Update_flow.get_jobs http_client >>= fun jobs_result ->
     let jobs =
@@ -1182,8 +1183,8 @@ struct
                   (Dashboard.dashboard_layout ~csrf user
                      ~page_title:"Deploy a Unikernel"
                      ~content:
-                       (Unikernel_create.unikernel_create_layout ~user_policy jobs
-                          unikernels_by_albatross_instance
+                       (Unikernel_create.unikernel_create_layout ~user_policy
+                          jobs unikernels_by_albatross_instance
                           blocks_by_albatross_instance
                           albatross.configuration.name)
                      ~icon:"/images/robur.png" ())
@@ -1949,12 +1950,14 @@ struct
                                     else Lwt.return_unit
                                   in
                                   let promise =
-                                    Http_mirage_client.request http_client ~follow_redirect:true url f ()
+                                    Http_mirage_client.request http_client
+                                      ~follow_redirect:true url f ()
                                     >>= fun res ->
                                     push_chunks None;
                                     Lwt.return res
                                   in
-                                  ((fun () -> Lwt_stream.get data_stream), Some promise)
+                                  ( (fun () -> Lwt_stream.get data_stream),
+                                    Some promise )
                               | _ -> ((fun () -> Lwt_stream.get contents), None)
                             in
                             Lwt.both
@@ -3209,7 +3212,9 @@ struct
             check_meth `GET (fun () ->
                 authenticate store reqd
                   (albatross_instance "/unikernel/deploy"
-                     (fun albatross tok user req -> deploy_form stack store albatross tok user http_client req)))
+                     (fun albatross tok user req ->
+                       deploy_form stack store albatross tok user http_client
+                         req)))
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
@@ -3229,8 +3234,8 @@ struct
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (fun token_or_cookie user reqd ->
-                    unikernel_create stack !albatross_instances http_client token_or_cookie
-                      user reqd))
+                    unikernel_create stack !albatross_instances http_client
+                      token_or_cookie user reqd))
         | "/unikernel/update" ->
             check_meth `GET (fun () ->
                 authenticate store reqd

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -79,7 +79,11 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) jobs unikernels
                           ~a:
                             [
                               a_label_for "manual-upload-toggle";
-                              a_class [ "inline-flex cursor-pointer items-center gap-3" ];
+                              a_class
+                                [
+                                  "inline-flex cursor-pointer items-center \
+                                   gap-3";
+                                ];
                             ]
                           [
                             input
@@ -99,17 +103,27 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) jobs unikernels
                                   a_class
                                     [
                                       "relative h-6 w-11 after:h-5 after:w-5 \
-                                       peer-checked:after:translate-x-5 rounded-full border \
-                                       border-gray-300 bg-gray-50 after:absolute \
-                                       after:bottom-0 after:left-[0.0625rem] after:top-0 \
-                                       after:my-auto after:rounded-full after:bg-gray-600 \
+                                       peer-checked:after:translate-x-5 \
+                                       rounded-full border border-gray-300 \
+                                       bg-gray-50 after:absolute \
+                                       after:bottom-0 after:left-[0.0625rem] \
+                                       after:top-0 after:my-auto \
+                                       after:rounded-full after:bg-gray-600 \
                                        after:transition-all after:content-[''] \
-                                       peer-checked:bg-primary-500 peer-checked:after:bg-white";
+                                       peer-checked:bg-primary-500 \
+                                       peer-checked:after:bg-white";
                                     ];
                                 ]
                               [];
                             span
-                              ~a:[ a_class [ "tracking-wide text-sm font-medium text-gray-600" ] ]
+                              ~a:
+                                [
+                                  a_class
+                                    [
+                                      "tracking-wide text-sm font-medium \
+                                       text-gray-600";
+                                    ];
+                                ]
                               [ txt "Upload unikernel binary manually" ];
                           ];
                       ];
@@ -120,9 +134,8 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) jobs unikernels
                           Unsafe.string_attrib "x-show" "!manual";
                           a_class
                             [
-                              "ring-primary-100 mt-1.5 transition \
-                               block w-full px-3 py-3 \
-                               rounded-xl shadow-sm border \
+                              "ring-primary-100 mt-1.5 transition block w-full \
+                               px-3 py-3 rounded-xl shadow-sm border \
                                hover:border-primary-200\n\
                               \                                           \
                                focus:border-primary-300 bg-primary-50 \
@@ -133,8 +146,12 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) jobs unikernels
                                focus:ring-[1px] focus:outline-none";
                             ];
                         ]
-                      (option ~a:[ a_value "" ] (txt "Select unikernel from builds.robur.coop")
-                      :: List.map (fun j -> option ~a:[ a_value j ] (txt j)) jobs);
+                      (option
+                         ~a:[ a_value "" ]
+                         (txt "Select unikernel from builds.robur.coop")
+                      :: List.map
+                           (fun j -> option ~a:[ a_value j ] (txt j))
+                           jobs);
                     input
                       ~a:
                         [

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -1,11 +1,15 @@
-let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
+let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) jobs unikernels
     (blocks : (Vmm_core.Name.t * int * bool) list) albatross_instance =
   let total_memory_used = Utils.total_memory_used unikernels in
   let cpu_usage_count = Utils.cpu_usage_count user_policy unikernels in
   let memory_left = user_policy.memory - total_memory_used in
   Tyxml_html.(
     section
-      ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
+      ~a:
+        [
+          a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
+          Unsafe.string_attrib "x-data" "{ advanced: false, manual: false }";
+        ]
       [
         div
           ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
@@ -13,6 +17,19 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
             p
               ~a:[ a_class [ "font-bold text-gray-700" ] ]
               [ txt "Deploy a Unikernel" ];
+            button
+              ~a:
+                [
+                  a_button_type `Button;
+                  a_class
+                    [
+                      "text-primary-600 border border-primary-600 px-4 py-1 \
+                       rounded-md hover:bg-primary-600 hover:text-white \
+                       transition";
+                    ];
+                  Unsafe.string_attrib "x-on:click" "advanced = !advanced";
+                ]
+              [ txt "Advanced Settings" ];
           ];
         hr ();
         div
@@ -50,19 +67,62 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ();
                   ];
                 div
+                  ~a:[ a_class [ "" ] ]
                   [
                     label
                       ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "CPU Id" ];
+                      [ txt "Unikernel Source*" ];
+                    div
+                      ~a:[ a_class [ "flex items-center space-x-2 mt-2 mb-2" ] ]
+                      [
+                        label
+                          ~a:
+                            [
+                              a_label_for "manual-upload-toggle";
+                              a_class [ "inline-flex cursor-pointer items-center gap-3" ];
+                            ]
+                          [
+                            input
+                              ~a:
+                                [
+                                  a_id "manual-upload-toggle";
+                                  a_input_type `Checkbox;
+                                  a_class [ "peer sr-only" ];
+                                  a_role [ "switch" ];
+                                  Unsafe.string_attrib "x-model" "manual";
+                                ]
+                              ();
+                            span
+                              ~a:
+                                [
+                                  a_aria "hidden" [ "true" ];
+                                  a_class
+                                    [
+                                      "relative h-6 w-11 after:h-5 after:w-5 \
+                                       peer-checked:after:translate-x-5 rounded-full border \
+                                       border-gray-300 bg-gray-50 after:absolute \
+                                       after:bottom-0 after:left-[0.0625rem] after:top-0 \
+                                       after:my-auto after:rounded-full after:bg-gray-600 \
+                                       after:transition-all after:content-[''] \
+                                       peer-checked:bg-primary-500 peer-checked:after:bg-white";
+                                    ];
+                                ]
+                              [];
+                            span
+                              ~a:[ a_class [ "tracking-wide text-sm font-medium text-gray-600" ] ]
+                              [ txt "Upload unikernel binary manually" ];
+                          ];
+                      ];
                     select
                       ~a:
                         [
-                          a_id "cpuid";
-                          a_name "cpuid";
+                          a_id "unikernel-dropdown";
+                          Unsafe.string_attrib "x-show" "!manual";
                           a_class
                             [
-                              "ring-primary-100 mt-1.5 transition block w-full \
-                               px-3 py-3 rounded-xl shadow-sm border \
+                              "ring-primary-100 mt-1.5 transition \
+                               block w-full px-3 py-3 \
+                               rounded-xl shadow-sm border \
                                hover:border-primary-200\n\
                               \                                           \
                                focus:border-primary-300 bg-primary-50 \
@@ -73,55 +133,32 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                                focus:ring-[1px] focus:outline-none";
                             ];
                         ]
-                      (List.map
-                         (fun (cpu_id, count) ->
-                           option
-                             ~a:[ a_value (string_of_int cpu_id) ]
-                             (txt
-                                ("CPU " ^ string_of_int cpu_id ^ " (used by "
-                               ^ string_of_int count ^ " unikernels)")))
-                         (List.sort
-                            (fun (_, count1) (_, count2) ->
-                              Int.compare count1 count2)
-                            cpu_usage_count));
+                      (option ~a:[ a_value "" ] (txt "Select unikernel from builds.robur.coop")
+                      :: List.map (fun j -> option ~a:[ a_value j ] (txt j)) jobs);
+                    input
+                      ~a:
+                        [
+                          a_input_type `File;
+                          a_name "binary";
+                          a_id "unikernel-binary";
+                          Unsafe.string_attrib "x-show" "manual";
+                          a_class
+                            [
+                              "ring-primary-100 mt-1.5 transition \
+                               appearance-none block w-full px-3 py-3 \
+                               rounded-xl shadow-sm border \
+                               hover:border-primary-200\n\
+                              \                                           \
+                               focus:border-primary-300 bg-primary-50 \
+                               bg-opacity-0 hover:bg-opacity-50 \
+                               focus:bg-opacity-50 ring-primary-200 \
+                               focus:ring-primary-200\n\
+                              \                                           \
+                               focus:ring-[1px] focus:outline-none";
+                            ];
+                        ]
+                      ();
                   ];
-                Utils.increment_or_decrement_ui ~id:"unikernel-memory"
-                  ~max_value:memory_left ~min_value:0 ~default_value:32
-                  ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
-                Utils.increment_or_decrement_ui ~id:"startup-priority"
-                  ~max_value:100 ~min_value:0 ~default_value:50
-                  ~label':"Startup Priority" ();
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Network Interfaces" ];
-                Utils.dynamic_dropdown_form
-                  (Vmm_core.String_set.elements user_policy.bridges)
-                  ~get_label:(fun bridge -> bridge)
-                  ~get_value:(fun bridge -> bridge)
-                  ~id:"network";
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Block devices" ];
-                Utils.dynamic_dropdown_form blocks
-                  ~get_label:(fun (name, size, used) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name))
-                    ^ " - " ^ Int.to_string size ^ "MB (used: "
-                    ^ Bool.to_string used ^ ")")
-                  ~get_value:(fun (name, _, _) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name)))
-                  ~id:"block";
               ];
             hr ();
             div
@@ -136,7 +173,6 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                   ~a:
                     [
                       a_rows 4;
-                      a_required ();
                       a_name "arguments";
                       a_id "unikernel-arguments";
                       a_class
@@ -154,92 +190,154 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     ]
                   (txt "");
               ];
-            hr ();
             div
+              ~a:
+                [
+                  a_class [ "space-y-6" ];
+                  Unsafe.string_attrib "x-show" "advanced";
+                  Unsafe.string_attrib "x-cloak" "";
+                ]
               [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Unikernel Image Binary*" ];
-                input
-                  ~a:
-                    [
-                      a_input_type `File;
-                      a_name "binary";
-                      a_required ();
-                      a_id "unikernel-binary";
-                      a_class
-                        [
-                          "ring-primary-100 mt-1.5 transition appearance-none \
-                           block w-full px-3 py-3 rounded-xl shadow-sm border \
-                           hover:border-primary-200\n\
-                          \                                           \
-                           focus:border-primary-300 bg-primary-50 bg-opacity-0 \
-                           hover:bg-opacity-50 focus:bg-opacity-50 \
-                           ring-primary-200 focus:ring-primary-200\n\
-                          \                                           \
-                           focus:ring-[1px] focus:outline-none";
-                        ];
-                    ]
-                  ();
-              ];
-            div
-              ~a:[ a_class [ "" ] ]
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Fail Behaviour" ];
+                hr ();
+                div
+                  ~a:[ a_class [ "grid grid-cols-2 gap-3" ] ]
+                  [
+                    div
+                      [
+                        label
+                          ~a:[ a_class [ "block font-medium" ] ]
+                          [ txt "CPU Id" ];
+                        select
+                          ~a:
+                            [
+                              a_id "cpuid";
+                              a_name "cpuid";
+                              a_class
+                                [
+                                  "ring-primary-100 mt-1.5 transition block \
+                                   w-full px-3 py-3 rounded-xl shadow-sm \
+                                   border hover:border-primary-200\n\
+                                  \                                           \
+                                   focus:border-primary-300 bg-primary-50 \
+                                   bg-opacity-0 hover:bg-opacity-50 \
+                                   focus:bg-opacity-50 ring-primary-200 \
+                                   focus:ring-primary-200\n\
+                                  \                                           \
+                                   focus:ring-[1px] focus:outline-none";
+                                ];
+                            ]
+                          (option ~a:[ a_value "" ] (txt "Auto-select CPU")
+                          :: List.map
+                               (fun (cpu_id, count) ->
+                                 option
+                                   ~a:[ a_value (string_of_int cpu_id) ]
+                                   (txt
+                                      ("CPU " ^ string_of_int cpu_id
+                                     ^ " (used by " ^ string_of_int count
+                                     ^ " unikernels)")))
+                               (List.sort
+                                  (fun (_, count1) (_, count2) ->
+                                    Int.compare count1 count2)
+                                  cpu_usage_count));
+                      ];
+                    Utils.increment_or_decrement_ui ~id:"unikernel-memory"
+                      ~max_value:memory_left ~min_value:0 ~default_value:32
+                      ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
+                    Utils.increment_or_decrement_ui ~id:"startup-priority"
+                      ~max_value:100 ~min_value:0 ~default_value:50
+                      ~label':"Startup Priority" ();
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Network Interfaces" ];
+                    Utils.dynamic_dropdown_form
+                      (Vmm_core.String_set.elements user_policy.bridges)
+                      ~get_label:(fun bridge -> bridge)
+                      ~get_value:(fun bridge -> bridge)
+                      ~id:"network";
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Block devices" ];
+                    Utils.dynamic_dropdown_form blocks
+                      ~get_label:(fun (name, size, used) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name))
+                        ^ " - " ^ Int.to_string size ^ "MB (used: "
+                        ^ Bool.to_string used ^ ")")
+                      ~get_value:(fun (name, _, _) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name)))
+                      ~id:"block";
+                  ];
+                hr ();
                 div
                   ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~switch_id:"restart-on-fail"
-                      ~switch_label:"Restart"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Fail Behaviour" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~switch_id:"restart-on-fail"
+                          ~initial_state:true ~switch_label:"Restart"
+                          (div
                              [
-                               txt
-                                 "This unikernel will automatically restart on \
-                                  fail";
-                             ];
-                         ]);
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "This unikernel will automatically \
+                                      restart on fail";
+                                 ];
+                             ]);
+                      ];
                   ];
-              ];
-            div
-              ~a:[ a_class [ "" ] ]
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Force create" ];
                 div
                   ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~initial_state:true
-                      ~switch_id:"force-create"
-                      ~switch_label:"Force create this unikernel"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Force create" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~initial_state:false
+                          ~switch_id:"force-create"
+                          ~switch_label:"Force create this unikernel"
+                          (div
                              [
-                               txt
-                                 "If a unikernel exist with this same name, it \
-                                  will be destroyed first and this one \
-                                  created.";
-                             ];
-                         ]);
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "If a unikernel exist with this same \
+                                      name, it will be destroyed first and \
+                                      this one created.";
+                                 ];
+                             ]);
+                      ];
                   ];
               ];
             div
-              ~a:[ a_class [ "flex justify-items-center mx-auto w-60" ] ]
+              ~a:[ a_class [ "flex justify-items-center mx-auto w-60 mt-6" ] ]
               [
                 Utils.button_component
                   ~attribs:

--- a/update_flow.ml
+++ b/update_flow.ml
@@ -75,8 +75,8 @@ let error_response_params unikernel_name = function
         "Received unexpected data format from the build server." )
 
 let get_jobs http_client =
-  fetch_json http_client ~base_url:Builder_web.base_url
-    ~path:"/" Builder_web.jobs_of_json "fetching jobs"
+  fetch_json http_client ~base_url:Builder_web.base_url ~path:"/"
+    Builder_web.jobs_of_json "fetching jobs"
 
 let check_for_update name unikernel http_client =
   let base_url = Builder_web.base_url in

--- a/update_flow.ml
+++ b/update_flow.ml
@@ -74,6 +74,10 @@ let error_response_params unikernel_name = function
       ( Printf.sprintf "Builder data error for %s: %s" unikernel_name e,
         "Received unexpected data format from the build server." )
 
+let get_jobs http_client =
+  fetch_json http_client ~base_url:Builder_web.base_url
+    ~path:"/" Builder_web.jobs_of_json "fetching jobs"
+
 let check_for_update name unikernel http_client =
   let base_url = Builder_web.base_url in
   (* Fetch current build info *)


### PR DESCRIPTION
This PR:
- (1) queries builds.robur.coop to fetch all "unikernel" jobs
- two ways to add a unikernel binary
   - populates a dropdown from 1 above on the deploy page where users can select a job and deploy it. 
   - alternatively, the user can select the unikermel and do a manual upload.
- the user should know what the unikernel needs beforehand such as block devices and network interfaces and configure it
- Apart from unikernel arguments, everything else is under an advanced setting button and where possible, uses a default value.
