### PR TITLE
Simpler deployment ui

### DIFF
--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -144,7 +144,11 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
   let memory_left = user_policy.memory - total_memory_used in
   Tyxml_html.(
     section
-      ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
+      ~a:
+        [
+          a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
+          Unsafe.string_attrib "x-data" "{ advanced: false }";
+        ]
       [
         div
           ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
@@ -202,79 +206,9 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ];
                   ];
               ];
+            (* Solo5 options moved to basic view *)
             div
-              ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
-              [
-                cpu_multiselect cpu_usage_count;
-                Utils.increment_or_decrement_ui ~id:"unikernel-memory"
-                  ~max_value:memory_left ~min_value:0 ~default_value:32
-                  ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
-                Utils.increment_or_decrement_ui ~id:"startup-priority"
-                  ~max_value:100 ~min_value:0 ~default_value:50
-                  ~label':"Startup Priority" ();
-              ];
-            (* BHyve Specific Options *)
-            div
-              ~a:
-                [
-                  a_id "bhyve-options";
-                  a_class [ "hidden grid grid-cols-2 gap-3" ];
-                ]
-              [
-                Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
-                  ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
-                div
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Linux Boot Partition" ];
-                    input
-                      ~a:
-                        [
-                          a_input_type `Text;
-                          a_name "linux_boot_partition";
-                          a_id "linux-boot-partition";
-                          a_placeholder "Optional (e.g. /dev/sda1)";
-                          a_class [ input_classes ];
-                        ]
-                      ();
-                  ];
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Network Interfaces" ];
-                Utils.dynamic_dropdown_form
-                  (Vmm_core.String_set.elements user_policy.bridges)
-                  ~get_label:(fun bridge -> bridge)
-                  ~get_value:(fun bridge -> bridge)
-                  ~id:"network" ();
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Block devices" ];
-                Utils.dynamic_dropdown_form blocks
-                  ~get_label:(fun (name, size, used) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name))
-                    ^ " - " ^ Int.to_string size ^ "MB (used: "
-                    ^ Bool.to_string used ^ ")")
-                  ~get_value:(fun (name, _, _) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name)))
-                  ~id:"block" ~manual_entry:true ();
-              ];
-            hr ();
-            (* Solo5 only *)
-            div
-              ~a:[ a_id "solo5-options" ]
+              ~a:[ a_id "solo5-options"; a_class [ "space-y-4 pt-4" ] ]
               [
                 div
                   [
@@ -282,6 +216,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ~a:[ a_class [ "block font-medium" ] ]
                       [ txt "Arguments" ];
                     p
+                      ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
                       [
                         txt "Write arguments seperated by a whitespace e.g ";
                         code [ txt "--ip=127.0.0.1 --port=8180" ];
@@ -289,7 +224,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     textarea
                       ~a:
                         [
-                          a_rows 4;
+                          a_rows 2;
                           a_required ();
                           a_name "arguments";
                           a_id "unikernel-arguments";
@@ -297,78 +232,215 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                         ]
                       (txt "");
                   ];
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Unikernel Image Binary*" ];
-                input
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Unikernel Image Binary*" ];
+                    input
+                      ~a:
+                        [
+                          a_input_type `File;
+                          a_name "binary";
+                          a_required ();
+                          a_id "unikernel-binary";
+                          a_class [ input_classes; "bg-white" ];
+                        ]
+                      ();
+                  ];
+              ];
+            div
+              ~a:
+                [
+                  a_class
+                    [
+                      "mt-4 bg-white border border-gray-200 rounded-lg \
+                       shadow-sm p-4 text-center mx-auto";
+                    ];
+                ]
+              [
+                h3
+                  ~a:[ a_class [ "text-lg font-bold text-gray-800" ] ]
+                  [ txt "Advanced Configuration" ];
+                p
                   ~a:
                     [
-                      a_input_type `File;
-                      a_name "binary";
-                      a_required ();
-                      a_id "unikernel-binary";
-                      a_class [ input_classes ];
+                      a_class
+                        [ "text-sm text-gray-500 mt-2 mb-4 mx-auto max-w-xl" ];
                     ]
-                  ();
-              ];
-            div
-              ~a:[ a_class [ "" ] ]
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Fail Behaviour" ];
-                div
-                  ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~switch_id:"restart-on-fail"
-                      ~switch_label:"Restart"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
-                             [
-                               txt
-                                 "This unikernel will automatically restart on \
-                                  fail";
-                             ];
-                         ]);
+                    txt
+                      "Configure network or block devices, customize hardware \
+                       allocation, or set failure recovery strategies.";
+                  ];
+                button
+                  ~a:
+                    [
+                      a_button_type `Button;
+                      a_class
+                        [
+                          "inline-flex items-center px-4 py-2 border \
+                           border-primary-300 shadow-sm text-sm font-medium \
+                           rounded-md text-primary-700 bg-primary-50 \
+                           hover:bg-primary-100 focus:outline-none \
+                           focus:ring-2 focus:ring-offset-2 \
+                           focus:ring-primary-500";
+                        ];
+                      Unsafe.string_attrib "x-on:click" "advanced = !advanced";
+                    ]
+                  [
+                    span
+                      ~a:
+                        [
+                          Unsafe.string_attrib "x-text"
+                            "advanced ? 'Hide Advanced Settings' : 'Show \
+                             Advanced Settings'";
+                        ]
+                      [];
                   ];
               ];
             div
-              ~a:[ a_class [ "" ] ]
+              ~a:
+                [
+                  a_class
+                    [
+                      "space-y-6 mt-6 p-6 border border-gray-200 rounded-lg \
+                       bg-white";
+                    ];
+                  Unsafe.string_attrib "x-show" "advanced";
+                  Unsafe.string_attrib "x-transition" "";
+                  Unsafe.string_attrib "x-cloak" "";
+                ]
               [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Force create" ];
+                div
+                  ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
+                  [
+                    cpu_multiselect cpu_usage_count;
+                    Utils.increment_or_decrement_ui ~id:"unikernel-memory"
+                      ~max_value:memory_left ~min_value:0 ~default_value:32
+                      ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
+                    Utils.increment_or_decrement_ui ~id:"startup-priority"
+                      ~max_value:100 ~min_value:0 ~default_value:50
+                      ~label':"Startup Priority" ();
+                  ];
+                (* BHyve Specific Options *)
+                div
+                  ~a:
+                    [
+                      a_id "bhyve-options";
+                      a_class [ "hidden grid grid-cols-2 gap-3" ];
+                    ]
+                  [
+                    Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
+                      ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
+                    div
+                      [
+                        label
+                          ~a:[ a_class [ "block font-medium" ] ]
+                          [ txt "Linux Boot Partition" ];
+                        input
+                          ~a:
+                            [
+                              a_input_type `Text;
+                              a_name "linux_boot_partition";
+                              a_id "linux-boot-partition";
+                              a_placeholder "Optional (e.g. /dev/sda1)";
+                              a_class [ input_classes ];
+                            ]
+                          ();
+                      ];
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Network Interfaces" ];
+                    Utils.dynamic_dropdown_form
+                      (Vmm_core.String_set.elements user_policy.bridges)
+                      ~get_label:(fun bridge -> bridge)
+                      ~get_value:(fun bridge -> bridge)
+                      ~id:"network" ();
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Block devices" ];
+                    Utils.dynamic_dropdown_form blocks
+                      ~get_label:(fun (name, size, used) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name))
+                        ^ " - " ^ Int.to_string size ^ "MB (used: "
+                        ^ Bool.to_string used ^ ")")
+                      ~get_value:(fun (name, _, _) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name)))
+                      ~id:"block" ~manual_entry:true ();
+                  ];
+                hr ();
                 div
                   ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~initial_state:true
-                      ~switch_id:"force-create"
-                      ~switch_label:"Force create this unikernel"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Fail Behaviour" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~switch_id:"restart-on-fail"
+                          ~switch_label:"Restart" ~initial_state:true
+                          (div
                              [
-                               txt
-                                 "If a unikernel exist with this same name, it \
-                                  will be destroyed first and this one \
-                                  created.";
-                             ];
-                         ]);
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "This unikernel will automatically \
+                                      restart on fail";
+                                 ];
+                             ]);
+                      ];
+                  ];
+                div
+                  ~a:[ a_class [ "" ] ]
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Force create" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~initial_state:false
+                          ~switch_id:"force-create"
+                          ~switch_label:"Force create this unikernel"
+                          (div
+                             [
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "If a unikernel exist with this same \
+                                      name, it will be destroyed first and \
+                                      this one created.";
+                                 ];
+                             ]);
+                      ];
                   ];
               ];
             div
-              ~a:[ a_class [ "flex justify-items-center mx-auto w-60" ] ]
+              ~a:[ a_class [ "pt-6 flex justify-items-center mx-auto w-64" ] ]
               [
                 Utils.button_component
                   ~attribs:

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -5,9 +5,14 @@ let input_classes =
    ring-primary-200 focus:ring-primary-200 focus:ring-[1px] focus:outline-none"
 
 let cpu_multiselect cpu_usage_count =
+  let sorted_cpus =
+    cpu_usage_count |> List.sort (fun (_, c1) (_, c2) -> Int.compare c1 c2)
+  in
+  let default_cpu =
+    match sorted_cpus with (id, _) :: _ -> string_of_int id | [] -> ""
+  in
   let options =
-    cpu_usage_count
-    |> List.sort (fun (_, c1) (_, c2) -> Int.compare c1 c2)
+    sorted_cpus
     |> List.map (fun (id, cnt) ->
         Printf.sprintf "{id:%d, txt:'CPU %d (%d)'}" id id cnt)
     |> String.concat "," |> Printf.sprintf "[%s]"
@@ -25,10 +30,10 @@ let cpu_multiselect cpu_usage_count =
               Unsafe.string_attrib "x-on:click.outside" "open = false";
               Unsafe.string_attrib "x-data"
                 (Printf.sprintf
-                   "{ open: false, sel: [], opts: %s, toggle(id) { \
+                   "{ open: false, sel: [%s], opts: %s, toggle(id) { \
                     this.sel.includes(id) ? this.sel = this.sel.filter(x => \
                     x!==id) : this.sel.push(id) } }"
-                   options);
+                   default_cpu options);
             ]
           [
             div

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -349,9 +349,18 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     Utils.increment_or_decrement_ui ~id:"unikernel-memory"
                       ~max_value:memory_left ~min_value:0 ~default_value:32
                       ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
-                    Utils.increment_or_decrement_ui ~id:"startup-priority"
-                      ~max_value:100 ~min_value:0 ~default_value:50
-                      ~label':"Startup Priority" ();
+                    div
+                      [
+                        Utils.increment_or_decrement_ui ~id:"startup-priority"
+                          ~max_value:100 ~min_value:0 ~default_value:50
+                          ~label':"Startup Priority" ();
+                        small
+                          [
+                            txt
+                              "The order to start unkernels. Smallest number \
+                               is started first.";
+                          ];
+                      ];
                   ];
                 (* BHyve Specific Options *)
                 div

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -358,8 +358,8 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       [ txt "Network Interfaces" ];
                     Utils.dynamic_dropdown_form
                       (Vmm_core.String_set.elements user_policy.bridges)
-                      ~get_label:(fun bridge -> bridge)
-                      ~get_value:(fun bridge -> bridge)
+                      ~get_label:Fun.id
+                      ~get_value:Fun.id
                       ~id:"network" ();
                   ];
                 hr ();

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -358,9 +358,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       [ txt "Network Interfaces" ];
                     Utils.dynamic_dropdown_form
                       (Vmm_core.String_set.elements user_policy.bridges)
-                      ~get_label:Fun.id
-                      ~get_value:Fun.id
-                      ~id:"network" ();
+                      ~get_label:Fun.id ~get_value:Fun.id ~id:"network" ();
                   ];
                 hr ();
                 div

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -206,6 +206,36 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ];
                   ];
               ];
+            hr ();
+            div
+              [
+                label
+                  ~a:[ a_class [ "block font-medium" ] ]
+                  [ txt "Network Interfaces" ];
+                Utils.dynamic_dropdown_form
+                  (Vmm_core.String_set.elements user_policy.bridges)
+                  ~get_label:Fun.id ~get_value:Fun.id ~id:"network" ();
+              ];
+            hr ();
+            div
+              [
+                label
+                  ~a:[ a_class [ "block font-medium" ] ]
+                  [ txt "Block devices" ];
+                Utils.dynamic_dropdown_form blocks
+                  ~get_label:(fun (name, size, used) ->
+                    Option.value ~default:""
+                      (Option.map Vmm_core.Name.Label.to_string
+                         (Vmm_core.Name.name name))
+                    ^ " - " ^ Int.to_string size ^ "MB (used: "
+                    ^ Bool.to_string used ^ ")")
+                  ~get_value:(fun (name, _, _) ->
+                    Option.value ~default:""
+                      (Option.map Vmm_core.Name.Label.to_string
+                         (Vmm_core.Name.name name)))
+                  ~id:"block" ~manual_entry:true ();
+              ];
+            hr ();
             (* Solo5 options moved to basic view *)
             div
               ~a:[ a_id "solo5-options"; a_class [ "space-y-4 pt-4" ] ]
@@ -349,35 +379,6 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                             ]
                           ();
                       ];
-                  ];
-                hr ();
-                div
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Network Interfaces" ];
-                    Utils.dynamic_dropdown_form
-                      (Vmm_core.String_set.elements user_policy.bridges)
-                      ~get_label:Fun.id ~get_value:Fun.id ~id:"network" ();
-                  ];
-                hr ();
-                div
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Block devices" ];
-                    Utils.dynamic_dropdown_form blocks
-                      ~get_label:(fun (name, size, used) ->
-                        Option.value ~default:""
-                          (Option.map Vmm_core.Name.Label.to_string
-                             (Vmm_core.Name.name name))
-                        ^ " - " ^ Int.to_string size ^ "MB (used: "
-                        ^ Bool.to_string used ^ ")")
-                      ~get_value:(fun (name, _, _) ->
-                        Option.value ~default:""
-                          (Option.map Vmm_core.Name.Label.to_string
-                             (Vmm_core.Name.name name)))
-                      ~id:"block" ~manual_entry:true ();
                   ];
                 hr ();
                 div


### PR DESCRIPTION
This PR tackles some of the issues mentioned in https://github.com/robur-coop/mollymawk/issues/191

When deploying, the simpler UI contains:
- the name input for the unikernel
- the type of unikernel (solo5, bhyve)
- the unikernel arguments
- an input to upload the unikernel binary

The advanced configuration button displays more settings:
- cpu ids
- memory
- startup priority
- network devices
- block devices
- fail behaviour
- force create toggle

### Simple deployment form
<img width="2761" height="1579" alt="image" src="https://github.com/user-attachments/assets/3666bbc5-f804-4412-b80b-22a47a43fa99" />

### Advanced configuration
<img width="2761" height="1579" alt="image" src="https://github.com/user-attachments/assets/57397462-ea3d-4f1d-8ce1-25927834d175" />

