### PR TITLE
Deploy vms directly from builds.robur.coop

### DIFF
--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -264,8 +264,8 @@ let config_of_json str =
     Option.fold ~none:(Ok 1) (* Default to 1 vCPU *)
       ~some:(function
         | `Int n when n > 0 -> Ok n
-        | _ -> Error (`Msg "numcpus must be a positive integer greater than 0"))
-      (get "numcpus" dict)
+        | _ -> Error (`Msg "vcpus must be a positive integer greater than 0"))
+      (get "vcpus" dict)
   in
   let* linux_boot_partition =
     match get "linux_boot_partition" dict with

--- a/assets/main.js
+++ b/assets/main.js
@@ -1362,3 +1362,38 @@ function areCharactersValid(s) {
 	}
 	return true;
 }
+
+window.mapFields = function (field_id, detail, options) {
+	if (!detail || !detail[field_id]) return [];
+	let reqs = detail[field_id];
+	if (field_id === 'network') {
+		let unassigned = [...options];
+		let fields = reqs.map(n => {
+			let idx = unassigned.findIndex(o => o.value === n || o.label === n);
+			if (idx !== -1) {
+				let match = unassigned.splice(idx, 1)[0];
+				return { title: n, selected: match.value };
+			}
+			return { title: n, selected: '' };
+		});
+		if (reqs.length === 1 && options.length === 1 && fields[0].selected === '') {
+			fields[0].selected = options[0].value;
+		} else if (reqs.length === options.length && unassigned.length === 1) {
+			let unmatched = fields.find(f => f.selected === '');
+			if (unmatched) unmatched.selected = unassigned[0].value;
+		}
+		return fields;
+	} else if (field_id === 'block') {
+		let job_name = detail.job_name;
+		return reqs.map(n => {
+			let exact = options.find(o => o.value === n);
+			if (exact) return { title: n, selected: exact.value };
+			if (job_name) {
+				let job_match = options.find(o => o.value === job_name || o.value === job_name + '-data');
+				if (job_match) return { title: n, selected: job_match.value };
+			}
+			return { title: n, selected: '' };
+		});
+	}
+	return reqs.map(n => ({ title: n, selected: '' }));
+};

--- a/assets/main.js
+++ b/assets/main.js
@@ -463,31 +463,27 @@ async function deployUnikernel(albatross_instance) {
 		if (!networkData || !blockData) {
 			return;
 		}
-		if (deploy_mode !== 'builder') {
-			if (typ === 'solo5' && !binary) {
-				showError(formAlert, "Please upload the unikernel image");
-				return;
-			}
+		if (deploy_mode === 'manual' && !binary) {
+			showError(formAlert, "Please upload the unikernel image");
+			return;
 		}
 
 		buttonLoading(deployButton, true, "Deploying...");
 
 		let specificConfig = {};
 
-		if (deploy_mode !== 'builder') {
-			if (typ === 'solo5') {
-				const argumentsString = document.getElementById("unikernel-arguments").value.trim();
-				specificConfig = {
-					arguments: argumentsString ? argumentsString.split(/\s+/) : []
-				};
-			} else if (typ === 'bhyve') {
-				const vcpus = document.getElementById("numcpus").innerText;
-				const bootPartition = document.getElementById("linux-boot-partition").value;
-				specificConfig = {
-					vcpus: Number(vcpus),
-					linux_boot_partition: bootPartition === "" ? null : bootPartition
-				};
-			}
+		if (typ === 'solo5') {
+			const argumentsString = document.getElementById("unikernel-arguments").value.trim();
+			specificConfig = {
+				arguments: argumentsString ? argumentsString.split(/\s+/) : []
+			};
+		} else if (typ === 'bhyve') {
+			const vcpus = document.getElementById("numcpus").innerText;
+			const bootPartition = document.getElementById("linux-boot-partition").value;
+			specificConfig = {
+				vcpus: Number(vcpus),
+				linux_boot_partition: bootPartition === "" ? null : bootPartition
+			};
 		}
 
 		const unikernel_config = {

--- a/assets/main.js
+++ b/assets/main.js
@@ -434,72 +434,89 @@ function gatherFieldsForDevices(fieldId, targetKey, formAlert) {
 async function deployUnikernel(albatross_instance) {
 	const formAlert = document.getElementById("form-alert");
 	const deployButton = document.getElementById("deploy-button");
-	const name = document.getElementById("unikernel-name").value;
-	const type = document.getElementById("unikernel-type").value;
-	const startup = document.getElementById("startup-priority").innerText;
-	const fail_behaviour = document.getElementById("restart-on-fail").checked;
-	const force_create = document.getElementById("force-create").checked;
-	const memory = document.getElementById("unikernel-memory").innerText;
-	const molly_csrf = document.getElementById("molly-csrf").value;
-	const cpuidsStr = document.getElementById("cpuids").value;
-	const cpuids = cpuidsStr ? cpuidsStr.split(',').map(Number) : [];
-	const networkData = gatherFieldsForDevices("network", "network_interfaces", formAlert);
-	const blockData = gatherFieldsForDevices("block", "block_devices", formAlert);
-	if (networkData === null || blockData === null) {
+	const handleFailure = (msg) => {
+		postAlert("bg-secondary-300", msg);
+		showError(formAlert, msg);
 		buttonLoading(deployButton, false, "Deploy");
-		return;
-	}
-	if (!isValidName(name)) {
-		showError(formAlert, "Please provide a valid name (alphanumeric, no spaces or special symbols, must not start with a hyphen, max 64 chars).");
-		document.getElementById("unikernel-name").classList.add("border-secondary-500", "ring-secondary-500");
-		buttonLoading(deployButton, false, "Deploy");
-		return;
-	}
-	let specificConfig = {};
-	const binary = document.getElementById("unikernel-binary").files[0];
-	if (type === 'solo5') {
-		if (!binary) {
-			showError(formAlert, "Please upload the unikernel image");
-			buttonLoading(deployButton, false, "Deploy");
+	};
+	try {
+		const name = document.getElementById("unikernel-name").value;
+		const typ = document.getElementById("unikernel-type").value;
+		const startup = document.getElementById("startup-priority").innerText;
+		const fail_behaviour = document.getElementById("restart-on-fail").checked;
+		const force_create = document.getElementById("force-create").checked;
+		const memory = document.getElementById("unikernel-memory").innerText;
+		const molly_csrf = document.getElementById("molly-csrf").value;
+		const cpuidsStr = document.getElementById("cpuids").value;
+		const deployModeNode = document.querySelector('input[name="deploy_mode"]:checked');
+		const deploy_mode = deployModeNode ? deployModeNode.value : 'manual';
+		const binaryInput = document.getElementById("unikernel-binary");
+		const binary = (binaryInput && binaryInput.files) ? binaryInput.files[0] : null;
+		if (!isValidName(name)) {
+			document.getElementById("unikernel-name").classList.add("border-secondary-500", "ring-secondary-500");
+			showError(formAlert, "Please provide a valid name (alphanumeric, no spaces or special symbols, must not start with a hyphen, max 64 chars).");
 			return;
 		}
-		const argumentsString = document.getElementById("unikernel-arguments").value.trim();
-		specificConfig = {
-			typ: "solo5",
-			arguments: argumentsString ? argumentsString.split(/\s+/) : []
+
+		const networkData = gatherFieldsForDevices("network", "network_interfaces", formAlert);
+		const blockData = gatherFieldsForDevices("block", "block_devices", formAlert);
+		if (!networkData || !blockData) {
+			return;
+		}
+		if (deploy_mode !== 'builder') {
+			if (typ === 'solo5' && !binary) {
+				showError(formAlert, "Please upload the unikernel image");
+				return;
+			}
+		}
+
+		buttonLoading(deployButton, true, "Deploying...");
+
+		let specificConfig = {};
+
+		if (deploy_mode !== 'builder') {
+			if (typ === 'solo5') {
+				const argumentsString = document.getElementById("unikernel-arguments").value.trim();
+				specificConfig = {
+					arguments: argumentsString ? argumentsString.split(/\s+/) : []
+				};
+			} else if (typ === 'bhyve') {
+				const vcpus = document.getElementById("numcpus").innerText;
+				const bootPartition = document.getElementById("linux-boot-partition").value;
+				specificConfig = {
+					vcpus: Number(vcpus),
+					linux_boot_partition: bootPartition === "" ? null : bootPartition
+				};
+			}
+		}
+
+		const unikernel_config = {
+			typ: typ,
+			cpuids: cpuidsStr ? cpuidsStr.split(',').map(Number) : [],
+			startup: Number(startup),
+			fail_behaviour: fail_behaviour ? { "restart": fail_behaviour } : "quit",
+			memory: Number(memory),
+			...networkData,
+			...blockData,
+			...specificConfig
 		};
-	} else if (type === 'bhyve') {
-		const vcpus = document.getElementById("numcpus").innerText;
-		const bootPartition = document.getElementById("linux-boot-partition").value;
-		specificConfig = {
-			typ: "bhyve",
-			vcpus: Number(vcpus),
-			linux_boot_partition: bootPartition == "" ? null : bootPartition
-		};
-	}
-	buttonLoading(deployButton, true, "Deploying...");
-	let formData = new FormData();
-	const unikernel_config = {
-		cpuids: cpuids,
-		startup: Number(startup),
-		fail_behaviour: fail_behaviour ? { "restart": fail_behaviour } : "quit",
-		memory: Number(memory),
-		...networkData,
-		...blockData,
-		...specificConfig
-	};
-	formData.append("albatross_instance", albatross_instance);
-	formData.append("unikernel_name", name);
-	formData.append("typ", type);
-	formData.append("unikernel_config", JSON.stringify(unikernel_config));
-	formData.append("unikernel_force_create", force_create);
-	formData.append("molly_csrf", molly_csrf);
-	if (binary) {
-		formData.append("binary", binary);
-	} else {
-		formData.append("binary", "");
-	}
-	try {
+
+		const formData = new FormData();
+		formData.append("albatross_instance", albatross_instance);
+		formData.append("unikernel_name", name);
+		formData.append("unikernel_config", JSON.stringify(unikernel_config));
+		formData.append("unikernel_force_create", force_create);
+		formData.append("molly_csrf", molly_csrf);
+		formData.append("deploy_mode", deploy_mode);
+
+		if (deploy_mode === 'builder') {
+			const builderJobSelect = document.getElementById("builder-job-select");
+			if (builderJobSelect) formData.append("builder_job", builderJobSelect.value);
+			formData.append("binary", "");
+		} else {
+			formData.append("binary", binary);
+		}
+
 		const response = await fetch("/api/unikernel/create", {
 			method: 'POST',
 			body: formData
@@ -509,19 +526,14 @@ async function deployUnikernel(albatross_instance) {
 		if (data.status === 200 && data.success) {
 			showError(formAlert, "Successfully updated", true);
 			postAlert("bg-primary-300", `${name} has been deployed successfully.`);
-			setTimeout(function () {
+			setTimeout(() => {
 				window.location.href = "/dashboard";
 			}, 2000);
 		} else {
-			handleFailure(data.data);
+			handleFailure(data.data || "An error occurred during deployment.");
 		}
 	} catch (error) {
-		handleFailure(error);
-	}
-	function handleFailure(msg) {
-		postAlert("bg-secondary-300", msg);
-		showError(formAlert, msg);
-		buttonLoading(deployButton, false, "Deploy");
+		handleFailure(error.message || "A network error occurred.");
 	}
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -1365,7 +1365,7 @@ window.mapFields = function (field_id, detail, options) {
 	if (field_id === 'network') {
 		let unassigned = [...options];
 		let fields = reqs.map(n => {
-			let idx = unassigned.findIndex(o => o.value === n || o.label === n);
+			let idx = unassigned.findIndex(o => o.value === n);
 			if (idx !== -1) {
 				let match = unassigned.splice(idx, 1)[0];
 				return { title: n, selected: match.value };

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -361,19 +361,19 @@ let job_of_json = function
                   | Ok manifest -> Ok (Some { name; synopsis; manifest })
                   | Error e -> Error e)
               | _ ->
-                  Logs.info (fun i ->
+                  Logs.debug (fun i ->
                       i
                         "builder_web.jobs_of_json: no valid target type. \
-                         requires hvt unikernels.");
+                         requires hvt or spt unikernels.");
                   Ok None)
           | _ ->
-              Logs.info (fun i ->
+              Logs.debug (fun i ->
                   i
                     "builder_web.jobs_of_json: no solo5_abi section in the \
                      json.");
               Ok None)
       | _ ->
-          Logs.info (fun i ->
+          Logs.debug (fun i ->
               i "builder_web.jobs_of_json: no latest section in the json.");
           Ok None)
   | _ -> Error (`Msg "Invalid job JSON")
@@ -406,14 +406,14 @@ let fetch_unikernel_jobs http_client =
           match jobs_of_json json with
           | Ok jobs -> Lwt.return jobs
           | Error (`Msg e) ->
-              Logs.err (fun m -> m "jobs_of_json: Failed to fetch jobs: %s" e);
+              Logs.info (fun m -> m "jobs_of_json: Failed to fetch jobs: %s" e);
               Lwt.return [])
       | Error (`Msg e) ->
-          Logs.err (fun m ->
+          Logs.info (fun m ->
               m "utils.json.from_string: Failed to fetch jobs: %s" e);
           Lwt.return [])
   | Error (`Msg msg) ->
-      Logs.err (fun m ->
+      Logs.info (fun m ->
           m "utils.http.send_http_request: Failed to fetch jobs: %s" msg);
       Lwt.return []
 

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -303,13 +303,14 @@ let compare_of_json = function
            ("invalid json for builder_web diff, expected a dict: "
           ^ Utils.Json.to_string js))
 
-type device = { name : string; type_ : string }
+type device = Network of string | Block of string
 type device_manifest = { uuid : string; devices : device list }
 
 let device_of_json = function
   | `Assoc xs -> (
       match (Utils.Json.get "name" xs, Utils.Json.get "type" xs) with
-      | Some (`String name), Some (`String type_) -> Ok { name; type_ }
+      | Some (`String name), Some (`String "NET_BASIC") -> Ok (Network name)
+      | Some (`String name), Some (`String "BLOCK_BASIC") -> Ok (Block name)
       | _ -> Error (`Msg "Invalid device JSON"))
   | _ -> Error (`Msg "Invalid device JSON format")
 

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -348,7 +348,8 @@ let job_of_json = function
         match Utils.Json.get "synopsis" xs with
         | Some (`String s) -> Ok s
         | _ ->
-            Error (`Msg "no synopsis in the job json or synopsis is not a string")
+            Error
+              (`Msg "no synopsis in the job json or synopsis is not a string")
       in
       match Utils.Json.get "latest" xs with
       | Some (`Assoc latest) -> (

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -348,7 +348,7 @@ let job_of_json = function
         match Utils.Json.get "synopsis" xs with
         | Some (`String s) -> Ok s
         | _ ->
-            Error (`Msg "no synopsis in the json or synopsis is not a string")
+            Error (`Msg "no synopsis in the job json or synopsis is not a string")
       in
       match Utils.Json.get "latest" xs with
       | Some (`Assoc latest) -> (

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -313,53 +313,74 @@ let device_of_json = function
       | _ -> Error (`Msg "Invalid device JSON"))
   | _ -> Error (`Msg "Invalid device JSON format")
 
-let manifest_of_json body =
-  match Utils.Json.from_string body with
-  | Ok (`Assoc xs) -> (
-      match (Utils.Json.get "uuid" xs, Utils.Json.get "solo5_manifest" xs) with
-      | Some (`String uuid), Some (`Assoc manifest) -> (
-          match Utils.Json.get "devices" manifest with
-          | Some (`List devices) ->
-              let req_devices =
-                List.filter_map
-                  (fun d -> Result.to_option (device_of_json d))
-                  devices
-              in
-              Ok { uuid; devices = req_devices }
-          | Some _ -> Error (`Msg "solo5_manifest.devices is not a list")
-          | None -> Ok { uuid; devices = [] } (* No devices required *))
-      | Some (`String uuid), None -> Ok { uuid; devices = [] }
-      | _ -> Error (`Msg "Missing uuid or solo5_manifest"))
-  | _ -> Error (`Msg "Invalid manifest JSON format")
+let manifest_of_json (`Assoc xs) =
+  match (Utils.Json.get "uuid" xs, Utils.Json.get "solo5_manifest" xs) with
+  | Some (`String uuid), Some (`Assoc manifest) -> (
+      match Utils.Json.get "devices" manifest with
+      | Some (`List devices) ->
+          let req_devices =
+            List.fold_left
+              (fun acc d ->
+                match (acc, device_of_json d) with
+                | Ok acc, Ok d -> Ok (d :: acc)
+                | Error e, _ -> Error e
+                | _, Error e -> Error e)
+              (Ok []) devices
+            |> Result.map List.rev
+          in
+          Result.map (fun devices -> { uuid; devices }) req_devices
+      | Some _ -> Error (`Msg "solo5_manifest.devices is not a list")
+      | None -> Ok { uuid; devices = [] } (* No devices required *))
+  | Some (`String uuid), None -> Ok { uuid; devices = [] }
+  | _ -> Error (`Msg "Missing uuid or solo5_manifest")
+
+type job = { name : string; synopsis : string; manifest : device_manifest }
+
+let job_of_json = function
+  | `Assoc xs -> (
+      let name =
+        match Utils.Json.get "name" xs with Some (`String s) -> s | _ -> ""
+      in
+      let synopsis =
+        match Utils.Json.get "synopsis" xs with
+        | Some (`String s) -> s
+        | _ -> ""
+      in
+      match Utils.Json.get "latest" xs with
+      | Some (`Assoc latest) -> (
+          match Utils.Json.get "solo5_abi" latest with
+          | Some (`Assoc abi) -> (
+              match Utils.Json.get "target" abi with
+              | Some (`String "hvt") -> (
+                  match manifest_of_json (`Assoc latest) with
+                  | Ok manifest -> Ok (Some { name; synopsis; manifest })
+                  | Error e -> Error e)
+              | _ -> Ok None)
+          | _ -> Ok None)
+      | _ -> Ok None)
+  | _ -> Error (`Msg "Invalid job JSON")
 
 let jobs_of_json = function
   | `Assoc xs -> (
-      match Utils.Json.get "jobs_by_section" xs with
-      | Some (`Assoc sections) ->
-          let u1 =
-            match Utils.Json.get "Unikernels" sections with
-            | Some (`List l) -> l
-            | _ -> []
-          in
-          let u2 =
-            match
-              Utils.Json.get "Unikernels (with metrics reported to Influx)"
-                sections
-            with
-            | Some (`List l) -> l
-            | _ -> []
-          in
-          let combine = u1 @ u2 in
-          let jobs =
-            List.filter_map (function `String s -> Some s | _ -> None) combine
-          in
-          Ok jobs
-      | _ -> Error (`Msg "No jobs_by_section"))
+      match Utils.Json.get "jobs" xs with
+      | Some (`List jobs_json) ->
+          List.fold_left
+            (fun acc j ->
+              match (acc, job_of_json j) with
+              | Ok acc, Ok (Some job) -> Ok (job :: acc)
+              | Ok acc, Ok None -> Ok acc
+              | Error e, _ -> Error e
+              | _, Error e -> Error e)
+            (Ok []) jobs_json
+          |> Result.map List.rev
+      | _ -> Error (`Msg "No jobs array found"))
   | _ -> Error (`Msg "Invalid JSON root")
 
 let fetch_unikernel_jobs http_client =
   let open Lwt.Syntax in
-  let* res = Utils.Http.send_http_request ~base_url http_client in
+  let* res =
+    Utils.Http.send_http_request ~path:"/all-builds" ~base_url http_client
+  in
   match res with
   | Ok body -> (
       match Utils.Json.from_string body with
@@ -367,28 +388,14 @@ let fetch_unikernel_jobs http_client =
           match jobs_of_json json with
           | Ok jobs -> Lwt.return jobs
           | Error (`Msg e) ->
-              Logs.err (fun m ->
-                  m "Failed to fetch builder jobs in deploy_form: %s" e);
+              Logs.err (fun m -> m "Failed to fetch jobs: %s" e);
               Lwt.return [])
       | Error (`Msg e) ->
-          Logs.err (fun m ->
-              m "Failed to fetch builder jobs in deploy_form: %s" e);
+          Logs.err (fun m -> m "Failed to fetch jobs: %s" e);
           Lwt.return [])
   | Error (`Msg msg) ->
-      Logs.err (fun m ->
-          m "Failed to fetch builder jobs in deploy_form: %s" msg);
+      Logs.err (fun m -> m "Failed to fetch jobs: %s" msg);
       Lwt.return []
-
-let fetch_latest_build_manifest http_client job_name =
-  let open Lwt.Syntax in
-  let* res =
-    Utils.Http.send_http_request
-      ~path:("/job/" ^ job_name ^ "/build/latest/")
-      ~base_url http_client
-  in
-  match res with
-  | Ok body -> Lwt.return (manifest_of_json body)
-  | Error (`Msg e) -> Lwt.return (Error (`Msg e))
 
 let fetch_unikernel_binary_image http_client ~job ~version push_chunks =
   let open Lwt.Infix in

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -356,7 +356,7 @@ let job_of_json = function
           match Utils.Json.get "solo5_abi" latest with
           | Some (`Assoc abi) -> (
               match Utils.Json.get "target" abi with
-              | Some (`String "hvt") -> (
+              | Some (`String ("hvt" | "spt")) -> (
                   match manifest_of_json (`Assoc latest) with
                   | Ok manifest -> Ok (Some { name; synopsis; manifest })
                   | Error e -> Error e)

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -335,7 +335,13 @@ let manifest_of_json (`Assoc xs) =
   | Some (`String uuid), None -> Ok { uuid; devices = [] }
   | _ -> Error (`Msg "Missing uuid or solo5_manifest")
 
-type job = { name : string; synopsis : string; manifest : device_manifest }
+type job = {
+  name : string;
+  synopsis : string;
+  manifest : device_manifest;
+  abi_target : string;
+  abi_version : int;
+}
 
 let job_of_json = function
   | `Assoc xs -> (
@@ -355,10 +361,15 @@ let job_of_json = function
       | Some (`Assoc latest) -> (
           match Utils.Json.get "solo5_abi" latest with
           | Some (`Assoc abi) -> (
-              match Utils.Json.get "target" abi with
-              | Some (`String ("hvt" | "spt")) -> (
+              match Utils.Json.(get "target" abi, get "version" abi) with
+              | Some (`String abi_target), Some (`Int abi_version)
+                when String.equal abi_target "hvt"
+                     || String.equal abi_target "spt" -> (
                   match manifest_of_json (`Assoc latest) with
-                  | Ok manifest -> Ok (Some { name; synopsis; manifest })
+                  | Ok manifest ->
+                      Ok
+                        (Some
+                           { name; synopsis; manifest; abi_target; abi_version })
                   | Error e -> Error e)
               | _ ->
                   Logs.debug (fun i ->

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -342,7 +342,7 @@ let job_of_json = function
       let* name =
         match Utils.Json.get "name" xs with
         | Some (`String s) -> Ok s
-        | _ -> Error (`Msg "No name in the json or name is not a string")
+        | _ -> Error (`Msg "No name in the job json or name is not a string")
       in
       let* synopsis =
         match Utils.Json.get "synopsis" xs with

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -302,3 +302,119 @@ let compare_of_json = function
         (`Msg
            ("invalid json for builder_web diff, expected a dict: "
           ^ Utils.Json.to_string js))
+
+type device = { name : string; type_ : string }
+type device_manifest = { uuid : string; devices : device list }
+
+let device_of_json = function
+  | `Assoc xs -> (
+      match (Utils.Json.get "name" xs, Utils.Json.get "type" xs) with
+      | Some (`String name), Some (`String type_) -> Ok { name; type_ }
+      | _ -> Error (`Msg "Invalid device JSON"))
+  | _ -> Error (`Msg "Invalid device JSON format")
+
+let manifest_of_json body =
+  match Utils.Json.from_string body with
+  | Ok (`Assoc xs) -> (
+      match (Utils.Json.get "uuid" xs, Utils.Json.get "solo5_manifest" xs) with
+      | Some (`String uuid), Some (`Assoc manifest) -> (
+          match Utils.Json.get "devices" manifest with
+          | Some (`List devices) ->
+              let req_devices =
+                List.filter_map
+                  (fun d -> Result.to_option (device_of_json d))
+                  devices
+              in
+              Ok { uuid; devices = req_devices }
+          | Some _ -> Error (`Msg "solo5_manifest.devices is not a list")
+          | None -> Ok { uuid; devices = [] } (* No devices required *))
+      | Some (`String uuid), None -> Ok { uuid; devices = [] }
+      | _ -> Error (`Msg "Missing uuid or solo5_manifest"))
+  | _ -> Error (`Msg "Invalid manifest JSON format")
+
+let jobs_of_json = function
+  | `Assoc xs -> (
+      match Utils.Json.get "jobs_by_section" xs with
+      | Some (`Assoc sections) ->
+          let u1 =
+            match Utils.Json.get "Unikernels" sections with
+            | Some (`List l) -> l
+            | _ -> []
+          in
+          let u2 =
+            match
+              Utils.Json.get "Unikernels (with metrics reported to Influx)"
+                sections
+            with
+            | Some (`List l) -> l
+            | _ -> []
+          in
+          let combine = u1 @ u2 in
+          let jobs =
+            List.filter_map (function `String s -> Some s | _ -> None) combine
+          in
+          Ok jobs
+      | _ -> Error (`Msg "No jobs_by_section"))
+  | _ -> Error (`Msg "Invalid JSON root")
+
+let fetch_unikernel_jobs http_client =
+  let open Lwt.Syntax in
+  let* res = Utils.Http.send_http_request ~base_url http_client in
+  match res with
+  | Ok body -> (
+      match Utils.Json.from_string body with
+      | Ok json -> (
+          match jobs_of_json json with
+          | Ok jobs -> Lwt.return jobs
+          | Error (`Msg e) ->
+              Logs.err (fun m ->
+                  m "Failed to fetch builder jobs in deploy_form: %s" e);
+              Lwt.return [])
+      | Error (`Msg e) ->
+          Logs.err (fun m ->
+              m "Failed to fetch builder jobs in deploy_form: %s" e);
+          Lwt.return [])
+  | Error (`Msg msg) ->
+      Logs.err (fun m ->
+          m "Failed to fetch builder jobs in deploy_form: %s" msg);
+      Lwt.return []
+
+let fetch_latest_build_manifest http_client job_name =
+  let open Lwt.Syntax in
+  let* res =
+    Utils.Http.send_http_request
+      ~path:("/job/" ^ job_name ^ "/build/latest/")
+      ~base_url http_client
+  in
+  match res with
+  | Ok body -> Lwt.return (manifest_of_json body)
+  | Error (`Msg e) -> Lwt.return (Error (`Msg e))
+
+let fetch_unikernel_binary_image http_client ~job ~version push_chunks =
+  let open Lwt.Infix in
+  let url = base_url ^ "/job/" ^ job ^ "/build/" ^ version ^ "/main-binary" in
+  let f resp _acc chunk =
+    if Http_mirage_client.Status.is_successful resp.Http_mirage_client.status
+    then Lwt.return (push_chunks (Some chunk))
+    else Lwt.return_unit
+  in
+  Lwt.both
+    ( Http_mirage_client.request http_client ~follow_redirect:true url f ()
+    >>= fun e ->
+      push_chunks None;
+      match e with
+      | Error (`Msg err) -> Lwt.return (Error (`Msg err))
+      | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
+      | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
+      | Ok (resp, ()) ->
+          if
+            Http_mirage_client.Status.is_successful
+              resp.Http_mirage_client.status
+          then Lwt.return (Ok ())
+          else
+            Lwt.return
+              (Error
+                 (`Msg
+                    ("accessing " ^ url ^ " resulted in an error: "
+                    ^ Http_mirage_client.Status.to_string resp.status
+                    ^ " " ^ resp.reason))) )

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -362,7 +362,8 @@ let job_of_json = function
           match Utils.Json.get "solo5_abi" latest with
           | Some (`Assoc abi) -> (
               match Utils.Json.(get "target" abi, get "version" abi) with
-              | Some (`String ("hvt" | "spt" as abi_target)), Some (`Int abi_version) -> (
+              | ( Some (`String (("hvt" | "spt") as abi_target)),
+                  Some (`Int abi_version) ) -> (
                   match manifest_of_json (`Assoc latest) with
                   | Ok manifest ->
                       Ok

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -362,9 +362,7 @@ let job_of_json = function
           match Utils.Json.get "solo5_abi" latest with
           | Some (`Assoc abi) -> (
               match Utils.Json.(get "target" abi, get "version" abi) with
-              | Some (`String abi_target), Some (`Int abi_version)
-                when String.equal abi_target "hvt"
-                     || String.equal abi_target "spt" -> (
+              | Some (`String ("hvt" | "spt" as abi_target)), Some (`Int abi_version) -> (
                   match manifest_of_json (`Assoc latest) with
                   | Ok manifest ->
                       Ok

--- a/builder_web.ml
+++ b/builder_web.ml
@@ -339,13 +339,16 @@ type job = { name : string; synopsis : string; manifest : device_manifest }
 
 let job_of_json = function
   | `Assoc xs -> (
-      let name =
-        match Utils.Json.get "name" xs with Some (`String s) -> s | _ -> ""
+      let* name =
+        match Utils.Json.get "name" xs with
+        | Some (`String s) -> Ok s
+        | _ -> Error (`Msg "No name in the json or name is not a string")
       in
-      let synopsis =
+      let* synopsis =
         match Utils.Json.get "synopsis" xs with
-        | Some (`String s) -> s
-        | _ -> ""
+        | Some (`String s) -> Ok s
+        | _ ->
+            Error (`Msg "no synopsis in the json or synopsis is not a string")
       in
       match Utils.Json.get "latest" xs with
       | Some (`Assoc latest) -> (
@@ -356,9 +359,22 @@ let job_of_json = function
                   match manifest_of_json (`Assoc latest) with
                   | Ok manifest -> Ok (Some { name; synopsis; manifest })
                   | Error e -> Error e)
-              | _ -> Ok None)
-          | _ -> Ok None)
-      | _ -> Ok None)
+              | _ ->
+                  Logs.info (fun i ->
+                      i
+                        "builder_web.jobs_of_json: no valid target type. \
+                         requires hvt unikernels.");
+                  Ok None)
+          | _ ->
+              Logs.info (fun i ->
+                  i
+                    "builder_web.jobs_of_json: no solo5_abi section in the \
+                     json.");
+              Ok None)
+      | _ ->
+          Logs.info (fun i ->
+              i "builder_web.jobs_of_json: no latest section in the json.");
+          Ok None)
   | _ -> Error (`Msg "Invalid job JSON")
 
 let jobs_of_json = function
@@ -389,13 +405,15 @@ let fetch_unikernel_jobs http_client =
           match jobs_of_json json with
           | Ok jobs -> Lwt.return jobs
           | Error (`Msg e) ->
-              Logs.err (fun m -> m "Failed to fetch jobs: %s" e);
+              Logs.err (fun m -> m "jobs_of_json: Failed to fetch jobs: %s" e);
               Lwt.return [])
       | Error (`Msg e) ->
-          Logs.err (fun m -> m "Failed to fetch jobs: %s" e);
+          Logs.err (fun m ->
+              m "utils.json.from_string: Failed to fetch jobs: %s" e);
           Lwt.return [])
   | Error (`Msg msg) ->
-      Logs.err (fun m -> m "Failed to fetch jobs: %s" msg);
+      Logs.err (fun m ->
+          m "utils.http.send_http_request: Failed to fetch jobs: %s" msg);
       Lwt.return []
 
 let fetch_unikernel_binary_image http_client ~job ~version push_chunks =

--- a/header_layout.ml
+++ b/header_layout.ml
@@ -14,6 +14,14 @@ let header ?(page_title = "Mollymawk") ~icon () =
             ]
           ();
         script ~a:[ a_src "/main.js" ] (txt "");
+        (* add htmx for seamless backend querying and updating of html DOM without page reload*)
+        script
+          ~a:
+            [
+              a_src
+                "https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js";
+            ]
+          (txt "");
         link ~rel:[ `Stylesheet ]
           ~href:"https://unpkg.com/aos@2.3.1/dist/aos.css" ();
         link ~rel:[ `Stylesheet ] ~href:"/style.css" ();

--- a/liveliness_checks.ml
+++ b/liveliness_checks.ml
@@ -30,7 +30,7 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     | Ok _response -> Ok ()
 
   let check_http http_client base_url =
-    Update_flow.send_http_request http_client ~base_url >|= function
+    Utils.Http.send_http_request http_client ~base_url >|= function
     | Error (`Msg err) ->
         Logs.err (fun m ->
             m "http-liveliness-check: Error response of %s with error: %s"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1167,6 +1167,7 @@ struct
   let deploy_form stack store http_client albatross _ (user : User_model.user)
       reqd =
     let now = Mirage_ptime.now () in
+    Builder_web.fetch_unikernel_jobs http_client >>= fun builder_jobs ->
     user_unikernels_by_instance stack albatross user.name
     >>= fun unikernels_by_albatross_instance ->
     user_blocks_by_instance stack albatross user.name
@@ -1184,7 +1185,7 @@ struct
                        (Unikernel_create.unikernel_create_layout ~user_policy
                           unikernels_by_albatross_instance
                           blocks_by_albatross_instance
-                          albatross.configuration.name)
+                          albatross.configuration.name builder_jobs)
                      ~icon:"/images/robur.png" ())
                   ~header_list:[ ("X-MOLLY-CSRF", csrf) ]
                   `OK

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1409,38 +1409,8 @@ struct
     | Ok () -> (
         let data_stream, push_chunks = Lwt_stream.create () in
         let push () = Lwt_stream.get data_stream in
-        let url =
-          Builder_web.base_url ^ "/job/" ^ job ^ "/build/"
-          ^ to_be_updated_unikernel ^ "/main-binary"
-        in
-        let f resp _acc chunk =
-          if
-            Http_mirage_client.Status.is_successful
-              resp.Http_mirage_client.status
-          then Lwt.return (push_chunks (Some chunk))
-          else Lwt.return_unit
-        in
-
-        Lwt.both
-          ( Http_mirage_client.request http_client ~follow_redirect:true url f ()
-          >>= fun e ->
-            push_chunks None;
-            match e with
-            | Error (`Msg err) -> Lwt.return (Error (`Msg err))
-            | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
-            | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
-            | Ok (resp, ()) ->
-                if
-                  Http_mirage_client.Status.is_successful
-                    resp.Http_mirage_client.status
-                then Lwt.return (Ok ())
-                else
-                  Lwt.return
-                    (Error
-                       (`Msg
-                          ("accessing " ^ url ^ " resulted in an error: "
-                          ^ Http_mirage_client.Status.to_string resp.status
-                          ^ " " ^ resp.reason))) )
+        Builder_web.fetch_unikernel_binary_image http_client ~job
+          ~version:to_be_updated_unikernel push_chunks
           (force_create_unikernel stack albatross ~unikernel_name ~push
              unikernel_cfg user)
         >>= function

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1152,7 +1152,20 @@ struct
                   (Utils.Json.to_string (`Assoc json_dict))))
           `Bad_request
 
-  let deploy_form stack store albatross _ (user : User_model.user) reqd =
+  let deploy_manifest stack store http_client job albatross _
+      (user : User_model.user) reqd =
+    Builder_web.fetch_latest_build_manifest http_client job >>= function
+    | Ok manifest ->
+        user_blocks_by_instance stack albatross user.name >>= fun blocks ->
+        let html_str =
+          Format.asprintf "%a" (Tyxml.Html.pp_elt ())
+            (Unikernel_create.builder_manifest_components manifest)
+        in
+        reply reqd ~content_type:"text/html" html_str `OK
+    | Error (`Msg err) -> reply reqd ~content_type:"text/html" err `Bad_request
+
+  let deploy_form stack store http_client albatross _ (user : User_model.user)
+      reqd =
     let now = Mirage_ptime.now () in
     user_unikernels_by_instance stack albatross user.name
     >>= fun unikernels_by_albatross_instance ->
@@ -3177,7 +3190,17 @@ struct
             check_meth `GET (fun () ->
                 authenticate store reqd
                   (albatross_instance "/unikernel/deploy"
-                     (deploy_form stack store)))
+                     (deploy_form stack store http_client)))
+        | "/api/deploy/manifest" ->
+            check_meth `GET (fun () ->
+                match get_query_parameter "job" with
+                | Ok job ->
+                    authenticate store reqd
+                      (albatross_instance req.H1.Request.target
+                         (deploy_manifest stack store http_client job))
+                | Error err ->
+                    Middleware.http_response ~api_meth:false ~data:(`String err)
+                      reqd `Bad_request)
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1893,7 +1893,7 @@ struct
                             generate_http_error_response
                               ("Invalid unikernel arguments: " ^ err)
                               `Bad_request
-                        | Ok cfg ->
+                        | Ok cfg -> (
                             let albatross_cmd =
                               if bool_of_string force_create then
                                 `Unikernel_cmd (`Unikernel_force_create cfg)
@@ -1923,24 +1923,29 @@ struct
                                         ("Albatross JSON Error: " ^ err_msg)
                                         `Internal_server_error)
                             in
-                            if String.equal "builder" deploy_mode then
-                              match !builder_job_ref with
-                              | Some job ->
-                                  let data_stream, push_chunks =
-                                    Lwt_stream.create ()
-                                  in
-                                  let push () = Lwt_stream.get data_stream in
-                                  Builder_web.fetch_unikernel_binary_image
-                                    http_client ~job ~version:"latest"
-                                    push_chunks
-                                    (execute_albatross_cmd push)
-                                  >>= fun (_, res) -> Lwt.return res
-                              | _ ->
-                                  generate_http_error_response
-                                    "Missing builder job or uuid" `Bad_request
-                            else
-                              execute_albatross_cmd (fun () ->
-                                  Lwt_stream.get contents)
+                            match deploy_mode with
+                            | "builder" -> (
+                                match !builder_job_ref with
+                                | Some job ->
+                                    let data_stream, push_chunks =
+                                      Lwt_stream.create ()
+                                    in
+                                    let push () = Lwt_stream.get data_stream in
+                                    Builder_web.fetch_unikernel_binary_image
+                                      http_client ~job ~version:"latest"
+                                      push_chunks
+                                      (execute_albatross_cmd push)
+                                    >>= fun (_, res) -> Lwt.return res
+                                | _ ->
+                                    generate_http_error_response
+                                      "Missing builder job or uuid" `Bad_request
+                                )
+                            | "manual" ->
+                                execute_albatross_cmd (fun () ->
+                                    Lwt_stream.get contents)
+                            | _ ->
+                                generate_http_error_response
+                                  "Invalid deploy mode" `Bad_request)
                       in
                       match
                         ( Configuration.name_of_str instance_name,

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1862,7 +1862,7 @@ struct
         Middleware.http_response reqd
           ~data:(`String "Couldn't find unikernel name in json") `Bad_request
 
-  let unikernel_create stack albatross_instances token_or_cookie
+  let unikernel_create stack albatross_instances http_client token_or_cookie
       (user : User_model.user) reqd =
     let generate_http_error_response msg code =
       Logs.warn (fun m -> m "Unikernel_create error: %s" msg);
@@ -1879,6 +1879,8 @@ struct
         let force_ref = ref None in
         let csrf_ref = ref None in
         let albatross_instance_ref = ref None in
+        let deploy_mode_ref = ref None in
+        let builder_job_ref = ref None in
         let process_stream () =
           Lwt_stream.iter_s
             (function
@@ -1902,19 +1904,29 @@ struct
                   consume_part_content contents >>= fun v ->
                   csrf_ref := Some v;
                   Lwt.return_unit
+              | (Some "deploy_mode", _), _, contents ->
+                  consume_part_content contents >>= fun v ->
+                  deploy_mode_ref := Some v;
+                  Lwt.return_unit
+              | (Some "builder_job", _), _, contents ->
+                  consume_part_content contents >>= fun v ->
+                  builder_job_ref := Some v;
+                  Lwt.return_unit
               | (Some "binary", _), _, contents -> (
                   match
                     ( !albatross_instance_ref,
                       !name_ref,
                       !cfg_ref,
                       !force_ref,
-                      !csrf_ref )
+                      !csrf_ref,
+                      !deploy_mode_ref )
                   with
                   | ( Some instance_name,
                       Some unikernel_name,
                       Some cfg,
                       Some force_create,
-                      Some csrf ) -> (
+                      Some csrf,
+                      Some deploy_mode ) -> (
                       let process_unikernel_create albatross unikernel_name
                           _reqd =
                         match Albatross_json.config_of_json cfg with
@@ -1922,35 +1934,58 @@ struct
                             generate_http_error_response
                               ("Invalid unikernel arguments: " ^ err)
                               `Bad_request
-                        | Ok cfg -> (
+                        | Ok cfg ->
                             let albatross_cmd =
                               if bool_of_string force_create then
                                 `Unikernel_cmd (`Unikernel_force_create cfg)
                               else `Unikernel_cmd (`Unikernel_create cfg)
                             in
-                            Albatross_state.query stack albatross
-                              ~domain:user.name ~name:unikernel_name
-                              ~push:(fun () -> Lwt_stream.get contents)
-                              albatross_cmd
-                            >>= function
-                            | Error err ->
-                                generate_http_error_response
-                                  ("Albatross Query Error: " ^ err)
-                                  `Internal_server_error
-                            | Ok (_hdr, res) -> (
-                                Albatross.set_online albatross;
-                                match Albatross_json.res res with
-                                | Ok res_json ->
-                                    Middleware.http_response reqd ~data:res_json
-                                      `OK
-                                | Error (`String err_str) ->
-                                    generate_http_error_response
-                                      ("Albatross Response Error: " ^ err_str)
-                                      `Internal_server_error
-                                | Error (`Msg err_msg) ->
-                                    generate_http_error_response
-                                      ("Albatross JSON Error: " ^ err_msg)
-                                      `Internal_server_error))
+                            let is_builder =
+                              Option.value ~default:"manual" !deploy_mode_ref
+                              = "builder"
+                            in
+                            let execute_albatross_cmd push =
+                              Albatross_state.query stack albatross
+                                ~domain:user.name ~name:unikernel_name ~push
+                                albatross_cmd
+                              >>= function
+                              | Error err ->
+                                  generate_http_error_response
+                                    ("Albatross Query Error: " ^ err)
+                                    `Internal_server_error
+                              | Ok (_hdr, res) -> (
+                                  Albatross.set_online albatross;
+                                  match Albatross_json.res res with
+                                  | Ok res_json ->
+                                      Middleware.http_response reqd
+                                        ~data:res_json `OK
+                                  | Error (`String err_str) ->
+                                      generate_http_error_response
+                                        ("Albatross Response Error: " ^ err_str)
+                                        `Internal_server_error
+                                  | Error (`Msg err_msg) ->
+                                      generate_http_error_response
+                                        ("Albatross JSON Error: " ^ err_msg)
+                                        `Internal_server_error)
+                            in
+                            if is_builder then
+                              match !builder_job_ref with
+                              | Some job ->
+                                  let data_stream, push_chunks =
+                                    Lwt_stream.create ()
+                                  in
+                                  let push () = Lwt_stream.get data_stream in
+                                  Builder_web.fetch_unikernel_binary_image
+                                    http_client ~job ~version:"latest"
+                                    push_chunks
+                                    (execute_albatross_cmd push)
+                                  >>= fun (_, res) -> Lwt.return res
+                              | _ ->
+                                  generate_http_error_response
+                                    "Missing builder job or uuid" `Bad_request
+                            else
+                              execute_albatross_cmd (fun () ->
+                                  Lwt_stream.get contents)
                       in
                       match
                         ( Configuration.name_of_str instance_name,
@@ -2001,8 +2036,7 @@ struct
             Logs.info (fun m -> m "Multipart parser thread error: %s" e);
             Lwt.return_unit
         | Ok _ ->
-            Logs.info (fun m ->
-                m "Multipart streamed correctly and unikernel created.");
+            Logs.info (fun m -> m "Multipart streamed correctly.");
             Lwt.return_unit)
 
   let unikernel_console stack albatross unikernel_name _
@@ -3220,8 +3254,8 @@ struct
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (fun token_or_cookie user reqd ->
-                    unikernel_create stack !albatross_instances token_or_cookie
-                      user reqd))
+                    unikernel_create stack !albatross_instances http_client
+                      token_or_cookie user reqd))
         | "/unikernel/update" ->
             check_meth `GET (fun () ->
                 authenticate store reqd

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1152,18 +1152,6 @@ struct
                   (Utils.Json.to_string (`Assoc json_dict))))
           `Bad_request
 
-  let deploy_manifest stack store http_client job albatross _
-      (user : User_model.user) reqd =
-    Builder_web.fetch_latest_build_manifest http_client job >>= function
-    | Ok manifest ->
-        user_blocks_by_instance stack albatross user.name >>= fun blocks ->
-        let html_str =
-          Format.asprintf "%a" (Tyxml.Html.pp_elt ())
-            (Unikernel_create.builder_manifest_components manifest)
-        in
-        reply reqd ~content_type:"text/html" html_str `OK
-    | Error (`Msg err) -> reply reqd ~content_type:"text/html" err `Bad_request
-
   let deploy_form stack store http_client albatross _ (user : User_model.user)
       reqd =
     let now = Mirage_ptime.now () in
@@ -3202,16 +3190,6 @@ struct
                 authenticate store reqd
                   (albatross_instance "/unikernel/deploy"
                      (deploy_form stack store http_client)))
-        | "/api/deploy/manifest" ->
-            check_meth `GET (fun () ->
-                match get_query_parameter "job" with
-                | Ok job ->
-                    authenticate store reqd
-                      (albatross_instance req.H1.Request.target
-                         (deploy_manifest stack store http_client job))
-                | Error err ->
-                    Middleware.http_response ~api_meth:false ~data:(`String err)
-                      reqd `Bad_request)
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1899,10 +1899,6 @@ struct
                                 `Unikernel_cmd (`Unikernel_force_create cfg)
                               else `Unikernel_cmd (`Unikernel_create cfg)
                             in
-                            let is_builder =
-                              Option.value ~default:"manual" !deploy_mode_ref
-                              = "builder"
-                            in
                             let execute_albatross_cmd push =
                               Albatross_state.query stack albatross
                                 ~domain:user.name ~name:unikernel_name ~push
@@ -1927,7 +1923,7 @@ struct
                                         ("Albatross JSON Error: " ^ err_msg)
                                         `Internal_server_error)
                             in
-                            if is_builder then
+                            if String.equal "builder" deploy_mode then
                               match !builder_job_ref with
                               | Some job ->
                                   let data_stream, push_chunks =

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -144,7 +144,11 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
   let memory_left = user_policy.memory - total_memory_used in
   Tyxml_html.(
     section
-      ~a:[ a_class [ "col-span-7 p-4 bg-gray-50 my-1" ] ]
+      ~a:
+        [
+          a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
+          Unsafe.string_attrib "x-data" "{ advanced: false }";
+        ]
       [
         div
           ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
@@ -202,79 +206,9 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ];
                   ];
               ];
+            (* Solo5 options moved to basic view *)
             div
-              ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
-              [
-                cpu_multiselect cpu_usage_count;
-                Utils.increment_or_decrement_ui ~id:"unikernel-memory"
-                  ~max_value:memory_left ~min_value:0 ~default_value:32
-                  ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
-                Utils.increment_or_decrement_ui ~id:"startup-priority"
-                  ~max_value:100 ~min_value:0 ~default_value:50
-                  ~label':"Startup Priority" ();
-              ];
-            (* BHyve Specific Options *)
-            div
-              ~a:
-                [
-                  a_id "bhyve-options";
-                  a_class [ "hidden grid grid-cols-2 gap-3" ];
-                ]
-              [
-                Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
-                  ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
-                div
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Linux Boot Partition" ];
-                    input
-                      ~a:
-                        [
-                          a_input_type `Text;
-                          a_name "linux_boot_partition";
-                          a_id "linux-boot-partition";
-                          a_placeholder "Optional (e.g. /dev/sda1)";
-                          a_class [ input_classes ];
-                        ]
-                      ();
-                  ];
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Network Interfaces" ];
-                Utils.dynamic_dropdown_form
-                  (Vmm_core.String_set.elements user_policy.bridges)
-                  ~get_label:(fun bridge -> bridge)
-                  ~get_value:(fun bridge -> bridge)
-                  ~id:"network" ();
-              ];
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Block devices" ];
-                Utils.dynamic_dropdown_form blocks
-                  ~get_label:(fun (name, size, used) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name))
-                    ^ " - " ^ Int.to_string size ^ "MB (used: "
-                    ^ Bool.to_string used ^ ")")
-                  ~get_value:(fun (name, _, _) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name)))
-                  ~id:"block" ~manual_entry:true ();
-              ];
-            hr ();
-            (* Solo5 only *)
-            div
-              ~a:[ a_id "solo5-options" ]
+              ~a:[ a_id "solo5-options"; a_class [ "space-y-4 pt-4" ] ]
               [
                 div
                   [
@@ -282,6 +216,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ~a:[ a_class [ "block font-medium" ] ]
                       [ txt "Arguments" ];
                     p
+                      ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
                       [
                         txt "Write arguments seperated by a whitespace e.g ";
                         code [ txt "--ip=127.0.0.1 --port=8180" ];
@@ -289,7 +224,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                     textarea
                       ~a:
                         [
-                          a_rows 4;
+                          a_rows 2;
                           a_required ();
                           a_name "arguments";
                           a_id "unikernel-arguments";
@@ -297,78 +232,215 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                         ]
                       (txt "");
                   ];
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Unikernel Image Binary*" ];
-                input
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Unikernel Image Binary*" ];
+                    input
+                      ~a:
+                        [
+                          a_input_type `File;
+                          a_name "binary";
+                          a_required ();
+                          a_id "unikernel-binary";
+                          a_class [ input_classes; "bg-white" ];
+                        ]
+                      ();
+                  ];
+              ];
+            div
+              ~a:
+                [
+                  a_class
+                    [
+                      "mt-4 bg-white border border-gray-200 rounded-lg \
+                       shadow-sm p-4 text-center mx-auto";
+                    ];
+                ]
+              [
+                h3
+                  ~a:[ a_class [ "text-lg font-bold text-gray-800" ] ]
+                  [ txt "Advanced Configuration" ];
+                p
                   ~a:
                     [
-                      a_input_type `File;
-                      a_name "binary";
-                      a_required ();
-                      a_id "unikernel-binary";
-                      a_class [ input_classes ];
+                      a_class
+                        [ "text-sm text-gray-500 mt-2 mb-4 mx-auto max-w-xl" ];
                     ]
-                  ();
-              ];
-            div
-              ~a:[ a_class [ "" ] ]
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Fail Behaviour" ];
-                div
-                  ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~switch_id:"restart-on-fail"
-                      ~switch_label:"Restart"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
-                             [
-                               txt
-                                 "This unikernel will automatically restart on \
-                                  fail";
-                             ];
-                         ]);
+                    txt
+                      "Configure network or block devices, customize hardware \
+                       allocation, or set failure recovery strategies.";
+                  ];
+                button
+                  ~a:
+                    [
+                      a_button_type `Button;
+                      a_class
+                        [
+                          "inline-flex items-center px-4 py-2 border \
+                           border-primary-300 shadow-sm text-sm font-medium \
+                           rounded-md text-primary-700 bg-primary-50 \
+                           hover:bg-primary-100 focus:outline-none \
+                           focus:ring-2 focus:ring-offset-2 \
+                           focus:ring-primary-500";
+                        ];
+                      Unsafe.string_attrib "x-on:click" "advanced = !advanced";
+                    ]
+                  [
+                    span
+                      ~a:
+                        [
+                          Unsafe.string_attrib "x-text"
+                            "advanced ? 'Hide Advanced Settings' : 'Show \
+                             Advanced Settings'";
+                        ]
+                      [];
                   ];
               ];
             div
-              ~a:[ a_class [ "" ] ]
+              ~a:
+                [
+                  a_class
+                    [
+                      "space-y-6 mt-6 p-6 border border-gray-200 rounded-lg \
+                       bg-white";
+                    ];
+                  Unsafe.string_attrib "x-show" "advanced";
+                  Unsafe.string_attrib "x-transition" "";
+                  Unsafe.string_attrib "x-cloak" "";
+                ]
               [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Force create" ];
+                div
+                  ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
+                  [
+                    cpu_multiselect cpu_usage_count;
+                    Utils.increment_or_decrement_ui ~id:"unikernel-memory"
+                      ~max_value:memory_left ~min_value:0 ~default_value:32
+                      ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
+                    Utils.increment_or_decrement_ui ~id:"startup-priority"
+                      ~max_value:100 ~min_value:0 ~default_value:50
+                      ~label':"Startup Priority" ();
+                  ];
+                (* BHyve Specific Options *)
+                div
+                  ~a:
+                    [
+                      a_id "bhyve-options";
+                      a_class [ "hidden grid grid-cols-2 gap-3" ];
+                    ]
+                  [
+                    Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
+                      ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
+                    div
+                      [
+                        label
+                          ~a:[ a_class [ "block font-medium" ] ]
+                          [ txt "Linux Boot Partition" ];
+                        input
+                          ~a:
+                            [
+                              a_input_type `Text;
+                              a_name "linux_boot_partition";
+                              a_id "linux-boot-partition";
+                              a_placeholder "Optional (e.g. /dev/sda1)";
+                              a_class [ input_classes ];
+                            ]
+                          ();
+                      ];
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Network Interfaces" ];
+                    Utils.dynamic_dropdown_form
+                      (Vmm_core.String_set.elements user_policy.bridges)
+                      ~get_label:(fun bridge -> bridge)
+                      ~get_value:(fun bridge -> bridge)
+                      ~id:"network" ();
+                  ];
+                hr ();
+                div
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Block devices" ];
+                    Utils.dynamic_dropdown_form blocks
+                      ~get_label:(fun (name, size, used) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name))
+                        ^ " - " ^ Int.to_string size ^ "MB (used: "
+                        ^ Bool.to_string used ^ ")")
+                      ~get_value:(fun (name, _, _) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name)))
+                      ~id:"block" ~manual_entry:true ();
+                  ];
+                hr ();
                 div
                   ~a:[ a_class [ "" ] ]
                   [
-                    Utils.switch_button ~initial_state:true
-                      ~switch_id:"force-create"
-                      ~switch_label:"Force create this unikernel"
-                      (div
-                         [
-                           label
-                             ~a:
-                               [
-                                 a_class [ "block text-sm font-medium" ];
-                                 a_label_for "restart_description";
-                               ]
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Fail Behaviour" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~switch_id:"restart-on-fail"
+                          ~switch_label:"Restart" ~initial_state:true
+                          (div
                              [
-                               txt
-                                 "If a unikernel exist with this same name, it \
-                                  will be destroyed first and this one \
-                                  created.";
-                             ];
-                         ]);
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "This unikernel will automatically \
+                                      restart on fail";
+                                 ];
+                             ]);
+                      ];
+                  ];
+                div
+                  ~a:[ a_class [ "" ] ]
+                  [
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
+                      [ txt "Force create" ];
+                    div
+                      ~a:[ a_class [ "" ] ]
+                      [
+                        Utils.switch_button ~initial_state:false
+                          ~switch_id:"force-create"
+                          ~switch_label:"Force create this unikernel"
+                          (div
+                             [
+                               label
+                                 ~a:
+                                   [
+                                     a_class [ "block text-sm font-medium" ];
+                                     a_label_for "restart_description";
+                                   ]
+                                 [
+                                   txt
+                                     "If a unikernel exist with this same \
+                                      name, it will be destroyed first and \
+                                      this one created.";
+                                 ];
+                             ]);
+                      ];
                   ];
               ];
             div
-              ~a:[ a_class [ "flex justify-items-center mx-auto w-60" ] ]
+              ~a:[ a_class [ "pt-6 flex justify-items-center mx-auto w-64" ] ]
               [
                 Utils.button_component
                   ~attribs:

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -5,9 +5,14 @@ let input_classes =
    ring-primary-200 focus:ring-primary-200 focus:ring-[1px] focus:outline-none"
 
 let cpu_multiselect cpu_usage_count =
+  let sorted_cpus =
+    cpu_usage_count |> List.sort (fun (_, c1) (_, c2) -> Int.compare c1 c2)
+  in
+  let default_cpu =
+    match sorted_cpus with (id, _) :: _ -> string_of_int id | [] -> ""
+  in
   let options =
-    cpu_usage_count
-    |> List.sort (fun (_, c1) (_, c2) -> Int.compare c1 c2)
+    sorted_cpus
     |> List.map (fun (id, cnt) ->
         Printf.sprintf "{id:%d, txt:'CPU %d (%d)'}" id id cnt)
     |> String.concat "," |> Printf.sprintf "[%s]"
@@ -25,10 +30,10 @@ let cpu_multiselect cpu_usage_count =
               Unsafe.string_attrib "x-on:click.outside" "open = false";
               Unsafe.string_attrib "x-data"
                 (Printf.sprintf
-                   "{ open: false, sel: [], opts: %s, toggle(id) { \
+                   "{ open: false, sel: [%s], opts: %s, toggle(id) { \
                     this.sel.includes(id) ? this.sel = this.sel.filter(x => \
                     x!==id) : this.sel.push(id) } }"
-                   options);
+                   default_cpu options);
             ]
           [
             div

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -137,6 +137,29 @@ let cpu_multiselect cpu_usage_count =
           ];
       ])
 
+let builder_manifest_components (manifest : Builder_web.device_manifest) =
+  let extract_names target_type =
+    List.filter_map
+      (fun d ->
+        if d.Builder_web.type_ = target_type then
+          Some (`String d.Builder_web.name)
+        else None)
+      manifest.devices
+  in
+  let networks_json =
+    `List (extract_names "NET_BASIC") |> Yojson.Basic.to_string
+  in
+  let blocks_json =
+    `List (extract_names "BLOCK_BASIC") |> Yojson.Basic.to_string
+  in
+  Tyxml_html.(
+    script
+      (Unsafe.data
+         (Printf.sprintf
+            "window.dispatchEvent(new CustomEvent('populate-manifest', \
+             {detail: {network: %s, block: %s}}));"
+            networks_json blocks_json)))
+
 let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
     (blocks : (Vmm_core.Name.t * int * bool) list) albatross_instance =
   let total_memory_used = Utils.total_memory_used unikernels in

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -258,7 +258,10 @@ let builder_source_section builder_jobs available_networks free_space
                        ]
                      else []
                    in
-                   option ~a:(a_value j.name :: disabled_attr) (txt j.name))
+                   option
+                     ~a:(a_value j.name :: disabled_attr)
+                     (txt
+                        (Fmt.str "%s (%s.%d)" j.name j.abi_target j.abi_version)))
                  builder_jobs);
         ];
       div

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -137,515 +137,554 @@ let cpu_multiselect cpu_usage_count =
           ];
       ])
 
-let builder_manifest_components (manifest : Builder_web.device_manifest) =
-  let extract_names target_type =
-    List.filter_map
-      (fun d ->
-        if d.Builder_web.type_ = target_type then
-          Some (`String d.Builder_web.name)
-        else None)
-      manifest.devices
-  in
-  let networks_json =
-    `List (extract_names "NET_BASIC") |> Yojson.Basic.to_string
-  in
-  let blocks_json =
-    `List (extract_names "BLOCK_BASIC") |> Yojson.Basic.to_string
-  in
-  Tyxml_html.(
-    script
-      (Unsafe.data
-         (Printf.sprintf
-            "window.dispatchEvent(new CustomEvent('populate-manifest', \
-             {detail: {network: %s, block: %s}}));"
-            networks_json blocks_json)))
+let type_and_name_section () =
+  let open Tyxml_html in
+  div
+    ~a:[ a_class [ "grid grid-cols-2 gap-3" ] ]
+    [
+      div
+        [
+          label ~a:[ a_class [ "block font-medium" ] ] [ txt "Name*" ];
+          p
+            ~a:[ a_class [ "text-xs text-gray-500 mb-1" ] ]
+            [
+              txt
+                "Must be lowercase alphanumeric, dashes are allowed (spaces \
+                 are not).";
+            ];
+          input
+            ~a:
+              [
+                a_input_type `Text;
+                a_name "name";
+                a_required ();
+                a_id "unikernel-name";
+                a_class [ input_classes ];
+              ]
+            ();
+        ];
+      div
+        [
+          label ~a:[ a_class [ "block font-medium" ] ] [ txt "Type" ];
+          p
+            ~a:[ a_class [ "text-xs text-gray-500 mb-1" ] ]
+            [ txt "The type of unikernel to create (e.g. solo5 or bhyve)." ];
+          select
+            ~a:
+              [
+                a_id "unikernel-type";
+                a_name "typ";
+                a_class [ input_classes ];
+                Unsafe.string_attrib "x-model" "typ";
+                Unsafe.string_attrib ":disabled" "deploy_mode === 'builder'";
+              ]
+            [
+              option ~a:[ a_value "solo5" ] (txt "Solo5");
+              option ~a:[ a_value "bhyve" ] (txt "BHyve");
+            ];
+        ];
+    ]
+
+let builder_source_section builder_jobs available_networks free_space
+    free_blocks_count =
+  let open Tyxml_html in
+  div
+    ~a:
+      [
+        a_id "builder-options";
+        a_class [ "space-y-4 pt-4" ];
+        Unsafe.string_attrib "x-show" "deploy_mode === 'builder'";
+      ]
+    [
+      div
+        ~a:
+          [
+            a_id "builder-web-container";
+            a_class [ "mt-4 p-4 border rounded bg-white" ];
+          ]
+        [
+          label
+            ~a:[ a_class [ "block font-medium" ] ]
+            [ txt "Select a reproducible build" ];
+          select
+            ~a:
+              [
+                a_id "builder-job-select";
+                a_name "job";
+                a_class [ input_classes ];
+                Unsafe.string_attrib "@change"
+                  "let job = window.builderJobs[$event.target.value]; if(job) \
+                   { selectedSynopsis = job.synopsis; let d = { network: \
+                   job.network, block: job.block, job_name: \
+                   $event.target.value }; window.dispatchEvent(new \
+                   CustomEvent('populate-manifest', {detail: d})); } else { \
+                   selectedSynopsis = ''; window.dispatchEvent(new \
+                   CustomEvent('populate-manifest', {detail: {}})); }";
+              ]
+            (option ~a:[ a_value "" ] (txt "Select a build")
+            :: List.map
+                 (fun (j : Builder_web.job) ->
+                   let req_nets =
+                     List.fold_left
+                       (fun acc (d : Builder_web.device) ->
+                         if d.type_ = "NET_BASIC" then acc + 1 else acc)
+                       0 j.manifest.devices
+                   in
+                   let req_blocks =
+                     List.fold_left
+                       (fun acc (d : Builder_web.device) ->
+                         if d.type_ = "BLOCK_BASIC" then acc + 1 else acc)
+                       0 j.manifest.devices
+                   in
+                   let net_disabled = req_nets > available_networks in
+                   let block_disabled =
+                     req_blocks > 0 && free_space <= 0 && free_blocks_count = 0
+                   in
+                   let disabled_attr =
+                     if net_disabled then
+                       [
+                         a_disabled ();
+                         a_title
+                           "Requires more network interfaces than available";
+                       ]
+                     else if block_disabled then
+                       [
+                         a_disabled ();
+                         a_title
+                           "Requires a block device, but you have no free \
+                            block devices or quota";
+                       ]
+                     else []
+                   in
+                   option ~a:(a_value j.name :: disabled_attr) (txt j.name))
+                 builder_jobs);
+        ];
+      div
+        ~a:
+          [
+            Unsafe.string_attrib "x-show" "selectedSynopsis !== ''";
+            a_class [ "mt-2 p-3" ];
+          ]
+        [ p ~a:[ Unsafe.string_attrib "x-text" "selectedSynopsis" ] [] ];
+    ]
+
+let manual_source_section () =
+  let open Tyxml_html in
+  div
+    ~a:
+      [
+        a_id "manual-upload-options";
+        a_class [ "space-y-4 pt-4" ];
+        Unsafe.string_attrib "x-show" "deploy_mode === 'manual'";
+      ]
+    [
+      div
+        [
+          label
+            ~a:[ a_class [ "block font-medium" ] ]
+            [ txt "Unikernel Image Binary*" ];
+          input
+            ~a:
+              [
+                a_input_type `File;
+                a_name "binary";
+                a_id "unikernel-binary";
+                a_class [ input_classes; "bg-white" ];
+                Unsafe.string_attrib ":required" "deploy_mode === 'manual'";
+              ]
+            ();
+        ];
+    ]
+
+let solo5_config_section () =
+  let open Tyxml_html in
+  div
+    ~a:
+      [
+        Unsafe.string_attrib "x-show" "typ === 'solo5'";
+        a_class [ "pt-4 space-y-4" ];
+      ]
+    [
+      label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
+      p
+        ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
+        [
+          txt "Write arguments separated by a whitespace e.g ";
+          code [ txt "--ip=127.0.0.1 --port=8180" ];
+        ];
+      textarea
+        ~a:
+          [
+            a_rows 2;
+            a_name "arguments";
+            a_id "unikernel-arguments";
+            a_class [ input_classes ];
+          ]
+        (txt "");
+    ]
+
+let advanced_config_section memory_left cpu_usage_count =
+  let open Tyxml_html in
+  div
+    [
+      div
+        ~a:
+          [
+            a_class
+              [
+                "mt-4 bg-white border border-gray-200 rounded-lg shadow-sm p-4 \
+                 text-center mx-auto";
+              ];
+          ]
+        [
+          h3
+            ~a:[ a_class [ "text-lg font-bold text-gray-800" ] ]
+            [ txt "Advanced Configuration" ];
+          p
+            ~a:
+              [ a_class [ "text-sm text-gray-500 mt-2 mb-4 mx-auto max-w-xl" ] ]
+            [
+              txt
+                "Configure network or block devices, customize hardware \
+                 allocation, or set failure recovery strategies.";
+            ];
+          button
+            ~a:
+              [
+                a_button_type `Button;
+                a_class
+                  [
+                    "inline-flex items-center px-4 py-2 border \
+                     border-primary-300 shadow-sm text-sm font-medium \
+                     rounded-md text-primary-700 bg-primary-50 \
+                     hover:bg-primary-100 focus:outline-none focus:ring-2 \
+                     focus:ring-offset-2 focus:ring-primary-500";
+                  ];
+                Unsafe.string_attrib "x-on:click" "advanced = !advanced";
+              ]
+            [
+              span
+                ~a:
+                  [
+                    Unsafe.string_attrib "x-text"
+                      "advanced ? 'Hide Advanced Settings' : 'Show Advanced \
+                       Settings'";
+                  ]
+                [];
+            ];
+        ];
+      div
+        ~a:
+          [
+            a_class
+              [
+                "space-y-6 mt-6 p-6 border border-gray-200 rounded-lg bg-white";
+              ];
+            Unsafe.string_attrib "x-show" "advanced";
+            Unsafe.string_attrib "x-transition" "";
+            Unsafe.string_attrib "x-cloak" "";
+          ]
+        [
+          div
+            ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
+            [
+              cpu_multiselect cpu_usage_count;
+              Utils.increment_or_decrement_ui ~id:"unikernel-memory"
+                ~max_value:memory_left ~min_value:0 ~default_value:32
+                ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
+              div
+                [
+                  Utils.increment_or_decrement_ui ~id:"startup-priority"
+                    ~max_value:100 ~min_value:0 ~default_value:50
+                    ~label':"Startup Priority" ();
+                  small
+                    [
+                      txt
+                        "The order to start unikernels. Smallest number is \
+                         started first.";
+                    ];
+                ];
+            ];
+          div
+            ~a:
+              [
+                a_id "bhyve-options";
+                a_class [ "grid grid-cols-2 gap-3" ];
+                Unsafe.string_attrib "x-show" "typ === 'bhyve'";
+              ]
+            [
+              Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
+                ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
+              div
+                [
+                  label
+                    ~a:[ a_class [ "block font-medium" ] ]
+                    [ txt "Linux Boot Partition" ];
+                  input
+                    ~a:
+                      [
+                        a_input_type `Text;
+                        a_name "linux_boot_partition";
+                        a_id "linux-boot-partition";
+                        a_placeholder "Optional (e.g. /dev/sda1)";
+                        a_class [ input_classes ];
+                      ]
+                    ();
+                ];
+            ];
+          hr ();
+          div
+            ~a:[ a_class [ "" ] ]
+            [
+              label
+                ~a:[ a_class [ "block font-medium" ] ]
+                [ txt "Fail Behaviour" ];
+              div
+                ~a:[ a_class [ "" ] ]
+                [
+                  Utils.switch_button ~switch_id:"restart-on-fail"
+                    ~switch_label:"Restart" ~initial_state:true
+                    (div
+                       [
+                         label
+                           ~a:
+                             [
+                               a_class [ "block text-sm font-medium" ];
+                               a_label_for "restart_description";
+                             ]
+                           [
+                             txt
+                               "This unikernel will automatically restart on \
+                                fail";
+                           ];
+                       ]);
+                ];
+            ];
+          div
+            ~a:[ a_class [ "" ] ]
+            [
+              label
+                ~a:[ a_class [ "block font-medium" ] ]
+                [ txt "Force create" ];
+              div
+                ~a:[ a_class [ "" ] ]
+                [
+                  Utils.switch_button ~initial_state:false
+                    ~switch_id:"force-create"
+                    ~switch_label:"Force create this unikernel"
+                    (div
+                       [
+                         label
+                           ~a:
+                             [
+                               a_class [ "block text-sm font-medium" ];
+                               a_label_for "restart_description";
+                             ]
+                           [
+                             txt
+                               "If a unikernel exists with this same name, it \
+                                will be destroyed first and this one created.";
+                           ];
+                       ]);
+                ];
+            ];
+        ];
+    ]
+
+let deploy_mode_toggles () =
+  let open Tyxml_html in
+  div
+    ~a:[ a_class [ "grid grid-cols-2 gap-4 mb-6" ] ]
+    [
+      label
+        ~a:
+          [
+            a_class
+              [
+                "flex flex-col items-center justify-center p-6 border-2 \
+                 rounded-lg cursor-pointer transition-colors duration-200";
+              ];
+            Unsafe.string_attrib ":class"
+              "deploy_mode === 'builder' ? 'border-primary-500 bg-primary-100 \
+               text-primary-700' : 'border-gray-200 hover:bg-gray-50 bg-white'";
+          ]
+        [
+          input
+            ~a:
+              [
+                a_class [ "sr-only" ];
+                a_input_type `Radio;
+                a_name "deploy_mode";
+                a_value "builder";
+                Unsafe.string_attrib "x-model" "deploy_mode";
+              ]
+            ();
+          span
+            ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
+            [ txt "Robur Builder" ];
+          span
+            ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
+            [ txt "Deploy directly from builds.robur.coop" ];
+        ];
+      label
+        ~a:
+          [
+            a_class
+              [
+                "flex flex-col items-center justify-center p-6 border-2 \
+                 rounded-lg cursor-pointer transition-colors duration-200";
+              ];
+            Unsafe.string_attrib ":class"
+              "deploy_mode === 'manual' ? 'border-primary-500 bg-primary-100 \
+               text-primary-700' : 'border-gray-200 hover:bg-gray-50 bg-white'";
+          ]
+        [
+          input
+            ~a:
+              [
+                a_class [ "sr-only" ];
+                a_input_type `Radio;
+                a_name "deploy_mode";
+                a_value "manual";
+                Unsafe.string_attrib "x-model" "deploy_mode";
+              ]
+            ();
+          span
+            ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
+            [ txt "Manual Upload" ];
+          span
+            ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
+            [ txt "Upload a local unikernel binary image." ];
+        ];
+    ]
 
 let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
     (blocks : (Vmm_core.Name.t * int * bool) list) albatross_instance
-    builder_jobs =
+    (builder_jobs : Builder_web.job list) =
   let total_memory_used = Utils.total_memory_used unikernels in
   let cpu_usage_count = Utils.cpu_usage_count user_policy unikernels in
   let memory_left = user_policy.memory - total_memory_used in
+  let free_space =
+    Utils.total_free_space user_policy (Utils.total_block_used blocks)
+  in
+  let free_blocks_count =
+    List.fold_left
+      (fun acc (_, _, used) -> if not used then acc + 1 else acc)
+      0 blocks
+  in
+  let available_networks = Vmm_core.String_set.cardinal user_policy.bridges in
+  let builder_jobs_json =
+    let extract_names target_type devices =
+      List.filter_map
+        (fun (d : Builder_web.device) ->
+          if d.Builder_web.type_ = target_type then
+            Some (`String d.Builder_web.name)
+          else None)
+        devices
+    in
+    let jobs =
+      List.map
+        (fun (j : Builder_web.job) ->
+          let networks = extract_names "NET_BASIC" j.manifest.devices in
+          let blocks = extract_names "BLOCK_BASIC" j.manifest.devices in
+          ( j.name,
+            `Assoc
+              [
+                ("network", `List networks);
+                ("block", `List blocks);
+                ("synopsis", `String j.synopsis);
+              ] ))
+        builder_jobs
+    in
+    `Assoc jobs |> Yojson.Basic.to_string
+  in
+  let alpine_state =
+    "{ advanced: false, deploy_mode: 'builder', typ: 'solo5', \
+     selectedSynopsis: '' }"
+  in
   Tyxml_html.(
-    section
-      ~a:
-        [
-          a_id "unikernel-create-form";
-          a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
-          Unsafe.string_attrib "x-data"
-            "{ advanced: false, deploy_mode: 'builder', solo5_options: true }";
-        ]
+    div
       [
-        div
-          ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
+        script
+          (Unsafe.data
+             (Printf.sprintf "window.builderJobs = %s;" builder_jobs_json));
+        section
+          ~a:
+            [
+              a_id "unikernel-create-form";
+              a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
+              Unsafe.string_attrib "x-data" alpine_state;
+              Unsafe.string_attrib "x-init"
+                "$watch('deploy_mode', val => { if(val === 'builder') typ = \
+                 'solo5'; })";
+            ]
           [
-            p
-              ~a:[ a_class [ "font-bold text-gray-700" ] ]
-              [ txt "Deploy a Unikernel" ];
-          ];
-        hr ();
-        div
-          ~a:[ a_class [ "space-y-6 mt-8 p-6 max-w-5xl mx-auto" ] ]
-          [
-            p ~a:[ a_id "form-alert"; a_class [ "my-4 hidden" ] ] [];
             div
-              ~a:[ a_class [ "grid grid-cols-2 gap-4 mb-6" ] ]
+              ~a:[ a_class [ "px-3 flex justify-between items-center" ] ]
               [
-                label
-                  ~a:
-                    [
-                      a_class
-                        [
-                          "flex flex-col items-center justify-center p-6 \
-                           border-2 rounded-lg cursor-pointer \
-                           transition-colors duration-200";
-                        ];
-                      Unsafe.string_attrib ":class"
-                        "deploy_mode === 'builder' ? 'border-primary-500 \
-                         bg-primary-100 text-primary-700' : 'border-gray-200 \
-                         hover:bg-gray-50 bg-white'";
-                    ]
-                  [
-                    input
-                      ~a:
-                        [
-                          a_class [ "sr-only" ];
-                          a_input_type `Radio;
-                          a_name "deploy_mode";
-                          a_value "builder";
-                          Unsafe.string_attrib "x-model" "deploy_mode";
-                        ]
-                      ();
-                    span
-                      ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
-                      [ txt "Robur Builder" ];
-                    span
-                      ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
-                      [ txt "Deploy directly from builds.robur.coop" ];
-                  ];
-                label
-                  ~a:
-                    [
-                      a_class
-                        [
-                          "flex flex-col items-center justify-center p-6 \
-                           border-2 rounded-lg cursor-pointer \
-                           transition-colors duration-200";
-                        ];
-                      Unsafe.string_attrib ":class"
-                        "deploy_mode === 'manual' ? 'border-primary-500 \
-                         bg-primary-100 text-primary-700' : 'border-gray-200 \
-                         hover:bg-gray-50 bg-white'";
-                    ]
-                  [
-                    input
-                      ~a:
-                        [
-                          a_class [ "sr-only" ];
-                          a_input_type `Radio;
-                          a_name "deploy_mode";
-                          a_value "manual";
-                          Unsafe.string_attrib "x-model" "deploy_mode";
-                        ]
-                      ();
-                    span
-                      ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
-                      [ txt "Manual Upload" ];
-                    span
-                      ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
-                      [ txt "Upload a local unikernel binary image." ];
-                  ];
-              ];
-            div
-              ~a:[ a_class [ "grid grid-cols-2 gap-3" ] ]
-              [
-                div
-                  [
-                    label ~a:[ a_class [ "block font-medium" ] ] [ txt "Name*" ];
-                    p
-                      ~a:[ a_class [ "text-xs text-gray-500 mb-1" ] ]
-                      [
-                        txt
-                          "Must be lowercase alphanumeric, dashes are allowed \
-                           (spaces are not).";
-                      ];
-                    input
-                      ~a:
-                        [
-                          a_input_type `Text;
-                          a_name "name";
-                          a_required ();
-                          a_id "unikernel-name";
-                          a_class [ input_classes ];
-                        ]
-                      ();
-                  ];
-                (* Type Selector *)
-                div
-                  [
-                    label ~a:[ a_class [ "block font-medium" ] ] [ txt "Type" ];
-                    p
-                      ~a:[ a_class [ "text-xs text-gray-500 mb-1" ] ]
-                      [
-                        txt
-                          "The type of unikernel to create (e.g. solo5 or \
-                           bhyve).";
-                      ];
-                    select
-                      ~a:
-                        [
-                          a_id "unikernel-type";
-                          a_name "typ";
-                          a_class [ input_classes ];
-                          Unsafe.string_attrib ":disabled"
-                            "deploy_mode === 'builder'";
-                          Unsafe.string_attrib "x-on:change"
-                            "solo5_options = ($event.target.value === 'solo5')";
-                        ]
-                      [
-                        option
-                          ~a:[ a_value "solo5"; a_selected () ]
-                          (txt "Solo5");
-                        option ~a:[ a_value "bhyve" ] (txt "BHyve");
-                      ];
-                  ];
-              ];
-            (* Builder Integration Container *)
-            div
-              ~a:
-                [
-                  a_id "builder-options";
-                  a_class [ "space-y-4 pt-4" ];
-                  Unsafe.string_attrib "x-show" "deploy_mode === 'builder'";
-                ]
-              [
-                div
-                  ~a:
-                    [
-                      a_id "builder-web-container";
-                      a_class [ "mt-4 p-4 border rounded bg-white" ];
-                    ]
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Select a reproducible build" ];
-                    select
-                      ~a:
-                        [
-                          a_id "builder-job-select";
-                          a_name "job";
-                          a_class [ input_classes ];
-                          Unsafe.string_attrib "hx-get"
-                            ("/api/deploy/manifest?instance="
-                            ^ Configuration.name_to_str albatross_instance);
-                          Unsafe.string_attrib "hx-indicator" "#manifest-loader";
-                          Unsafe.string_attrib "hx-swap" "afterend";
-                        ]
-                      (option ~a:[ a_value "" ] (txt "Select a build")
-                      :: List.map
-                           (fun job -> option ~a:[ a_value job ] (txt job))
-                           builder_jobs);
-                  ];
-                div
-                  ~a:
-                    [
-                      a_id "manifest-loader";
-                      a_class
-                        [ "htmx-indicator inline-block font-semibold mt-2" ];
-                    ]
-                  [
-                    txt "Fetching...";
-                    i
-                      ~a:
-                        [
-                          a_class
-                            [
-                              "fa-solid fa-spinner animate-spin \
-                               text-primary-800";
-                            ];
-                        ]
-                      [];
-                  ];
-              ];
-            div
-              ~a:[ Unsafe.string_attrib "x-show" "solo5_options" ]
-              [
-                label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
                 p
-                  ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
-                  [
-                    txt "Write arguments seperated by a whitespace e.g ";
-                    code [ txt "--ip=127.0.0.1 --port=8180" ];
-                  ];
-                textarea
-                  ~a:
-                    [
-                      a_rows 2;
-                      a_name "arguments";
-                      a_id "unikernel-arguments";
-                      a_class [ input_classes ];
-                    ]
-                  (txt "");
-              ];
-            (* Solo5 options moved to basic view *)
-            hr ();
-            div
-              [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Network Interfaces" ];
-                Utils.dynamic_dropdown_form
-                  (Vmm_core.String_set.elements user_policy.bridges)
-                  ~get_label:Fun.id ~get_value:Fun.id ~id:"network" ();
+                  ~a:[ a_class [ "font-bold text-gray-700" ] ]
+                  [ txt "Deploy a Unikernel" ];
               ];
             hr ();
             div
+              ~a:[ a_class [ "space-y-6 mt-8 p-6 max-w-5xl mx-auto" ] ]
               [
-                label
-                  ~a:[ a_class [ "block font-medium" ] ]
-                  [ txt "Block devices" ];
-                Utils.dynamic_dropdown_form blocks
-                  ~get_label:(fun (name, size, used) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name))
-                    ^ " - " ^ Int.to_string size ^ "MB (used: "
-                    ^ Bool.to_string used ^ ")")
-                  ~get_value:(fun (name, _, _) ->
-                    Option.value ~default:""
-                      (Option.map Vmm_core.Name.Label.to_string
-                         (Vmm_core.Name.name name)))
-                  ~id:"block" ~manual_entry:true ();
-              ];
-            hr ();
-            (* Solo5 options moved to basic view *)
-            div
-              ~a:
-                [
-                  a_id "solo5-options";
-                  a_class [ "space-y-4 pt-4" ];
-                  Unsafe.string_attrib "x-show" "deploy_mode === 'manual'";
-                ]
-              [
+                p ~a:[ a_id "form-alert"; a_class [ "my-4 hidden" ] ] [];
+                deploy_mode_toggles ();
+                type_and_name_section ();
+                builder_source_section builder_jobs available_networks
+                  free_space free_blocks_count;
+                manual_source_section ();
+                solo5_config_section ();
+                hr ();
                 div
                   [
                     label
                       ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Unikernel Image Binary*" ];
-                    input
-                      ~a:
-                        [
-                          a_input_type `File;
-                          a_name "binary";
-                          a_id "unikernel-binary";
-                          a_class [ input_classes; "bg-white" ];
-                          Unsafe.string_attrib ":required"
-                            "deploy_mode === 'manual'";
-                        ]
-                      ();
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Arguments" ];
-                    p
-                      ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
-                      [
-                        txt "Write arguments seperated by a whitespace e.g ";
-                        code [ txt "--ip=127.0.0.1 --port=8180" ];
-                      ];
-                    textarea
-                      ~a:
-                        [
-                          a_rows 2;
-                          a_required ();
-                          a_name "arguments";
-                          a_id "unikernel-arguments";
-                          a_class [ input_classes ];
-                        ]
-                      (txt "");
-                  ];
-              ];
-            div
-              ~a:
-                [
-                  a_class
-                    [
-                      "mt-4 bg-white border border-gray-200 rounded-lg \
-                       shadow-sm p-4 text-center mx-auto";
-                    ];
-                ]
-              [
-                h3
-                  ~a:[ a_class [ "text-lg font-bold text-gray-800" ] ]
-                  [ txt "Advanced Configuration" ];
-                p
-                  ~a:
-                    [
-                      a_class
-                        [ "text-sm text-gray-500 mt-2 mb-4 mx-auto max-w-xl" ];
-                    ]
-                  [
-                    txt
-                      "Configure network or block devices, customize hardware \
-                       allocation, or set failure recovery strategies.";
-                  ];
-                button
-                  ~a:
-                    [
-                      a_button_type `Button;
-                      a_class
-                        [
-                          "inline-flex items-center px-4 py-2 border \
-                           border-primary-300 shadow-sm text-sm font-medium \
-                           rounded-md text-primary-700 bg-primary-50 \
-                           hover:bg-primary-100 focus:outline-none \
-                           focus:ring-2 focus:ring-offset-2 \
-                           focus:ring-primary-500";
-                        ];
-                      Unsafe.string_attrib "x-on:click" "advanced = !advanced";
-                    ]
-                  [
-                    span
-                      ~a:
-                        [
-                          Unsafe.string_attrib "x-text"
-                            "advanced ? 'Hide Advanced Settings' : 'Show \
-                             Advanced Settings'";
-                        ]
-                      [];
-                  ];
-              ];
-            div
-              ~a:
-                [
-                  a_class
-                    [
-                      "space-y-6 mt-6 p-6 border border-gray-200 rounded-lg \
-                       bg-white";
-                    ];
-                  Unsafe.string_attrib "x-show" "advanced";
-                  Unsafe.string_attrib "x-transition" "";
-                  Unsafe.string_attrib "x-cloak" "";
-                ]
-              [
-                div
-                  ~a:[ a_class [ "grid grid-cols-3 gap-3" ] ]
-                  [
-                    cpu_multiselect cpu_usage_count;
-                    Utils.increment_or_decrement_ui ~id:"unikernel-memory"
-                      ~max_value:memory_left ~min_value:0 ~default_value:32
-                      ~figure_unit:"MB" ~step:32 ~label':"Memory" ();
-                    div
-                      [
-                        Utils.increment_or_decrement_ui ~id:"startup-priority"
-                          ~max_value:100 ~min_value:0 ~default_value:50
-                          ~label':"Startup Priority" ();
-                        small
-                          [
-                            txt
-                              "The order to start unkernels. Smallest number \
-                               is started first.";
-                          ];
-                      ];
-                  ];
-                (* BHyve Specific Options *)
-                div
-                  ~a:
-                    [
-                      a_id "bhyve-options";
-                      a_class [ "grid grid-cols-2 gap-3" ];
-                      Unsafe.string_attrib "x-show" "solo5_options === false";
-                    ]
-                  [
-                    Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
-                      ~min_value:1 ~default_value:1 ~label':"vCPUs" ();
-                    div
-                      [
-                        label
-                          ~a:[ a_class [ "block font-medium" ] ]
-                          [ txt "Linux Boot Partition" ];
-                        input
-                          ~a:
-                            [
-                              a_input_type `Text;
-                              a_name "linux_boot_partition";
-                              a_id "linux-boot-partition";
-                              a_placeholder "Optional (e.g. /dev/sda1)";
-                              a_class [ input_classes ];
-                            ]
-                          ();
-                      ];
+                      [ txt "Network Interfaces" ];
+                    Utils.dynamic_dropdown_form
+                      (Vmm_core.String_set.elements user_policy.bridges)
+                      ~get_label:Fun.id ~get_value:Fun.id ~id:"network" ();
                   ];
                 hr ();
                 div
-                  ~a:[ a_class [ "" ] ]
                   [
                     label
                       ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Fail Behaviour" ];
-                    div
-                      ~a:[ a_class [ "" ] ]
-                      [
-                        Utils.switch_button ~switch_id:"restart-on-fail"
-                          ~switch_label:"Restart" ~initial_state:true
-                          (div
-                             [
-                               label
-                                 ~a:
-                                   [
-                                     a_class [ "block text-sm font-medium" ];
-                                     a_label_for "restart_description";
-                                   ]
-                                 [
-                                   txt
-                                     "This unikernel will automatically \
-                                      restart on fail";
-                                 ];
-                             ]);
-                      ];
+                      [ txt "Block devices" ];
+                    Utils.dynamic_dropdown_form blocks
+                      ~get_label:(fun (name, size, used) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name))
+                        ^ " - " ^ Int.to_string size ^ "MB (used: "
+                        ^ Bool.to_string used ^ ")")
+                      ~get_value:(fun (name, _, _) ->
+                        Option.value ~default:""
+                          (Option.map Vmm_core.Name.Label.to_string
+                             (Vmm_core.Name.name name)))
+                      ~id:"block" ~manual_entry:true ();
                   ];
+                hr ();
+                advanced_config_section memory_left cpu_usage_count;
                 div
-                  ~a:[ a_class [ "" ] ]
-                  [
-                    label
-                      ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Force create" ];
-                    div
-                      ~a:[ a_class [ "" ] ]
-                      [
-                        Utils.switch_button ~initial_state:false
-                          ~switch_id:"force-create"
-                          ~switch_label:"Force create this unikernel"
-                          (div
-                             [
-                               label
-                                 ~a:
-                                   [
-                                     a_class [ "block text-sm font-medium" ];
-                                     a_label_for "restart_description";
-                                   ]
-                                 [
-                                   txt
-                                     "If a unikernel exist with this same \
-                                      name, it will be destroyed first and \
-                                      this one created.";
-                                 ];
-                             ]);
-                      ];
-                  ];
-              ];
-            div
-              ~a:[ a_class [ "pt-6 flex justify-items-center mx-auto w-64" ] ]
-              [
-                Utils.button_component
-                  ~attribs:
+                  ~a:
                     [
-                      a_id "deploy-button";
-                      a_onclick
-                        ("deployUnikernel('"
-                        ^ Configuration.name_to_str albatross_instance
-                        ^ "')");
+                      a_class [ "pt-6 flex justify-items-center mx-auto w-64" ];
                     ]
-                  ~content:(txt "Deploy") ~btn_type:`Primary_full ();
+                  [
+                    Utils.button_component
+                      ~attribs:
+                        [
+                          a_id "deploy-button";
+                          a_onclick
+                            ("deployUnikernel('"
+                            ^ Configuration.name_to_str albatross_instance
+                            ^ "')");
+                        ]
+                      ~content:(txt "Deploy") ~btn_type:`Primary_full ();
+                  ];
               ];
           ];
       ])

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -161,7 +161,8 @@ let builder_manifest_components (manifest : Builder_web.device_manifest) =
             networks_json blocks_json)))
 
 let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
-    (blocks : (Vmm_core.Name.t * int * bool) list) albatross_instance =
+    (blocks : (Vmm_core.Name.t * int * bool) list) albatross_instance
+    builder_jobs =
   let total_memory_used = Utils.total_memory_used unikernels in
   let cpu_usage_count = Utils.cpu_usage_count user_policy unikernels in
   let memory_left = user_policy.memory - total_memory_used in
@@ -169,8 +170,11 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
     section
       ~a:
         [
+          a_id "unikernel-create-form";
           a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
-          Unsafe.string_attrib "x-data" "{ advanced: false }";
+          Unsafe.string_attrib "x-data"
+            "{ advanced: false, deploy_mode: 'builder', solo5_options: true }";
+          Unsafe.string_attrib "@populate-manifest.window" "advanced = true;";
         ]
       [
         div
@@ -185,6 +189,74 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
           ~a:[ a_class [ "space-y-6 mt-8 p-6 max-w-5xl mx-auto" ] ]
           [
             p ~a:[ a_id "form-alert"; a_class [ "my-4 hidden" ] ] [];
+            div
+              ~a:[ a_class [ "grid grid-cols-2 gap-4 mb-6" ] ]
+              [
+                label
+                  ~a:
+                    [
+                      a_class
+                        [
+                          "flex flex-col items-center justify-center p-6 \
+                           border-2 rounded-lg cursor-pointer \
+                           transition-colors duration-200";
+                        ];
+                      Unsafe.string_attrib ":class"
+                        "deploy_mode === 'builder' ? 'border-primary-500 \
+                         bg-primary-100 text-primary-700' : 'border-gray-200 \
+                         hover:bg-gray-50 bg-white'";
+                    ]
+                  [
+                    input
+                      ~a:
+                        [
+                          a_class [ "sr-only" ];
+                          a_input_type `Radio;
+                          a_name "deploy_mode";
+                          a_value "builder";
+                          Unsafe.string_attrib "x-model" "deploy_mode";
+                        ]
+                      ();
+                    span
+                      ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
+                      [ txt "Robur Builder" ];
+                    span
+                      ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
+                      [ txt "Deploy directly from builds.robur.coop" ];
+                  ];
+                label
+                  ~a:
+                    [
+                      a_class
+                        [
+                          "flex flex-col items-center justify-center p-6 \
+                           border-2 rounded-lg cursor-pointer \
+                           transition-colors duration-200";
+                        ];
+                      Unsafe.string_attrib ":class"
+                        "deploy_mode === 'manual' ? 'border-primary-500 \
+                         bg-primary-100 text-primary-700' : 'border-gray-200 \
+                         hover:bg-gray-50 bg-white'";
+                    ]
+                  [
+                    input
+                      ~a:
+                        [
+                          a_class [ "sr-only" ];
+                          a_input_type `Radio;
+                          a_name "deploy_mode";
+                          a_value "manual";
+                          Unsafe.string_attrib "x-model" "deploy_mode";
+                        ]
+                      ();
+                    span
+                      ~a:[ a_class [ "font-bold text-lg mb-2" ] ]
+                      [ txt "Manual Upload" ];
+                    span
+                      ~a:[ a_class [ "text-sm text-center opacity-80" ] ]
+                      [ txt "Upload a local unikernel binary image." ];
+                  ];
+              ];
             div
               ~a:[ a_class [ "grid grid-cols-2 gap-3" ] ]
               [
@@ -213,13 +285,23 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                 div
                   [
                     label ~a:[ a_class [ "block font-medium" ] ] [ txt "Type" ];
+                    p
+                      ~a:[ a_class [ "text-xs text-gray-500 mb-1" ] ]
+                      [
+                        txt
+                          "The type of unikernel to create (e.g. solo5 or \
+                           bhyve).";
+                      ];
                     select
                       ~a:
                         [
                           a_id "unikernel-type";
                           a_name "typ";
                           a_class [ input_classes ];
-                          a_onchange "toggleType()";
+                          Unsafe.string_attrib ":disabled"
+                            "deploy_mode === 'builder'";
+                          Unsafe.string_attrib "x-on:change"
+                            "solo5_options = ($event.target.value === 'solo5')";
                         ]
                       [
                         option
@@ -229,32 +311,92 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ];
                   ];
               ];
-            (* Solo5 options moved to basic view *)
             div
-              ~a:[ a_id "solo5-options"; a_class [ "space-y-4 pt-4" ] ]
+              ~a:[ Unsafe.string_attrib "x-show" "solo5_options" ]
+              [
+                label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
+                p
+                  ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
+                  [
+                    txt "Write arguments seperated by a whitespace e.g ";
+                    code [ txt "--ip=127.0.0.1 --port=8180" ];
+                  ];
+                textarea
+                  ~a:
+                    [
+                      a_rows 2;
+                      a_name "arguments";
+                      a_id "unikernel-arguments";
+                      a_class [ input_classes ];
+                    ]
+                  (txt "");
+              ];
+            (* Builder Integration Container *)
+            div
+              ~a:
+                [
+                  a_id "builder-options";
+                  a_class [ "space-y-4 pt-4" ];
+                  Unsafe.string_attrib "x-show" "deploy_mode === 'builder'";
+                ]
               [
                 div
+                  ~a:
+                    [
+                      a_id "builder-web-container";
+                      a_class [ "mt-4 p-4 border rounded bg-white" ];
+                    ]
                   [
                     label
                       ~a:[ a_class [ "block font-medium" ] ]
-                      [ txt "Arguments" ];
-                    p
-                      ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
-                      [
-                        txt "Write arguments seperated by a whitespace e.g ";
-                        code [ txt "--ip=127.0.0.1 --port=8180" ];
-                      ];
-                    textarea
+                      [ txt "Select a reproducible build" ];
+                    select
                       ~a:
                         [
-                          a_rows 2;
-                          a_required ();
-                          a_name "arguments";
-                          a_id "unikernel-arguments";
+                          a_id "builder-job-select";
+                          a_name "job";
                           a_class [ input_classes ];
+                          Unsafe.string_attrib "hx-get"
+                            ("/api/deploy/manifest?instance="
+                            ^ Configuration.name_to_str albatross_instance);
+                          Unsafe.string_attrib "hx-indicator" "#manifest-loader";
+                          Unsafe.string_attrib "hx-swap" "afterend";
                         ]
-                      (txt "");
+                      (option ~a:[ a_value "" ] (txt "Select a build")
+                      :: List.map
+                           (fun job -> option ~a:[ a_value job ] (txt job))
+                           builder_jobs);
                   ];
+                div
+                  ~a:
+                    [
+                      a_id "manifest-loader";
+                      a_class
+                        [ "htmx-indicator inline-block font-semibold mt-2" ];
+                    ]
+                  [
+                    txt "Fetching...";
+                    i
+                      ~a:
+                        [
+                          a_class
+                            [
+                              "fa-solid fa-spinner animate-spin \
+                               text-primary-800";
+                            ];
+                        ]
+                      [];
+                  ];
+              ];
+            (* Solo5 options moved to basic view *)
+            div
+              ~a:
+                [
+                  a_id "solo5-options";
+                  a_class [ "space-y-4 pt-4" ];
+                  Unsafe.string_attrib "x-show" "deploy_mode === 'manual'";
+                ]
+              [
                 div
                   [
                     label
@@ -265,9 +407,10 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                         [
                           a_input_type `File;
                           a_name "binary";
-                          a_required ();
                           a_id "unikernel-binary";
                           a_class [ input_classes; "bg-white" ];
+                          Unsafe.string_attrib ":required"
+                            "deploy_mode === 'manual'";
                         ]
                       ();
                   ];
@@ -351,7 +494,8 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                   ~a:
                     [
                       a_id "bhyve-options";
-                      a_class [ "hidden grid grid-cols-2 gap-3" ];
+                      a_class [ "grid grid-cols-2 gap-3" ];
+                      Unsafe.string_attrib "x-show" "solo5_options === false";
                     ]
                   [
                     Utils.increment_or_decrement_ui ~id:"numcpus" ~max_value:16
@@ -477,21 +621,4 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                   ~content:(txt "Deploy") ~btn_type:`Primary_full ();
               ];
           ];
-        script
-          (txt
-             "function toggleType() { \n\
-             \  var type = document.getElementById('unikernel-type').value; \n\
-             \  var bhyveOpts = document.getElementById('bhyve-options'); \n\
-             \  var solo5Opts = document.getElementById('solo5-options'); \n\
-             \  var binInput = document.getElementById('unikernel-binary'); \n\n\
-             \  if (type === 'bhyve') { \n\
-             \    bhyveOpts.classList.remove('hidden'); \n\
-             \    solo5Opts.classList.add('hidden'); \n\
-             \    binInput.removeAttribute('required'); \n\
-             \  } else { \n\
-             \    bhyveOpts.classList.add('hidden'); \n\
-             \    solo5Opts.classList.remove('hidden'); \n\
-             \    binInput.setAttribute('required', ''); \n\
-             \  } \n\
-              }");
       ])

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -229,13 +229,13 @@ let builder_source_section builder_jobs available_networks free_space
                    let req_nets =
                      List.fold_left
                        (fun acc (d : Builder_web.device) ->
-                         if d.type_ = "NET_BASIC" then acc + 1 else acc)
+                         match d with Network _ -> acc + 1 | _ -> acc)
                        0 j.manifest.devices
                    in
                    let req_blocks =
                      List.fold_left
                        (fun acc (d : Builder_web.device) ->
-                         if d.type_ = "BLOCK_BASIC" then acc + 1 else acc)
+                         match d with Block _ -> acc + 1 | _ -> acc)
                        0 j.manifest.devices
                    in
                    let net_disabled = req_nets > available_networks in
@@ -576,19 +576,23 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
   in
   let available_networks = Vmm_core.String_set.cardinal user_policy.bridges in
   let builder_jobs_json =
-    let extract_names target_type devices =
+    let extract_networks devices =
       List.filter_map
         (fun (d : Builder_web.device) ->
-          if d.Builder_web.type_ = target_type then
-            Some (`String d.Builder_web.name)
-          else None)
+          match d with Network n -> Some (`String n) | _ -> None)
+        devices
+    in
+    let extract_blocks devices =
+      List.filter_map
+        (fun (d : Builder_web.device) ->
+          match d with Block b -> Some (`String b) | _ -> None)
         devices
     in
     let jobs =
       List.map
         (fun (j : Builder_web.job) ->
-          let networks = extract_names "NET_BASIC" j.manifest.devices in
-          let blocks = extract_names "BLOCK_BASIC" j.manifest.devices in
+          let networks = extract_networks j.manifest.devices in
+          let blocks = extract_blocks j.manifest.devices in
           ( j.name,
             `Assoc
               [

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -214,12 +214,14 @@ let builder_source_section builder_jobs available_networks free_space
                 a_class [ input_classes ];
                 Unsafe.string_attrib "@change"
                   "let job = window.builderJobs[$event.target.value]; if(job) \
-                   { selectedSynopsis = job.synopsis; let d = { network: \
-                   job.network, block: job.block, job_name: \
-                   $event.target.value }; window.dispatchEvent(new \
-                   CustomEvent('populate-manifest', {detail: d})); } else { \
-                   selectedSynopsis = ''; window.dispatchEvent(new \
-                   CustomEvent('populate-manifest', {detail: {}})); }";
+                   { selectedSynopsis = \
+                   job.synopsis;document.getElementById('unikernel-name').value \
+                   = $event.target.value;let d = { network: job.network, \
+                   block: job.block, job_name: $event.target.value }; \
+                   window.dispatchEvent(new CustomEvent('populate-manifest', \
+                   {detail: d})); } else { selectedSynopsis = ''; \
+                   window.dispatchEvent(new CustomEvent('populate-manifest', \
+                   {detail: {}})); }";
               ]
             (option ~a:[ a_value "" ] (txt "Select a build")
             :: List.map

--- a/unikernel_create.ml
+++ b/unikernel_create.ml
@@ -174,7 +174,6 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
           a_class [ "col-span-7 p-4 bg-gray-50 my-1" ];
           Unsafe.string_attrib "x-data"
             "{ advanced: false, deploy_mode: 'builder', solo5_options: true }";
-          Unsafe.string_attrib "@populate-manifest.window" "advanced = true;";
         ]
       [
         div
@@ -311,26 +310,6 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       ];
                   ];
               ];
-            div
-              ~a:[ Unsafe.string_attrib "x-show" "solo5_options" ]
-              [
-                label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
-                p
-                  ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
-                  [
-                    txt "Write arguments seperated by a whitespace e.g ";
-                    code [ txt "--ip=127.0.0.1 --port=8180" ];
-                  ];
-                textarea
-                  ~a:
-                    [
-                      a_rows 2;
-                      a_name "arguments";
-                      a_id "unikernel-arguments";
-                      a_class [ input_classes ];
-                    ]
-                  (txt "");
-              ];
             (* Builder Integration Container *)
             div
               ~a:
@@ -388,14 +367,27 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                       [];
                   ];
               ];
-            (* Solo5 options moved to basic view *)
             div
-              ~a:
-                [
-                  a_id "solo5-options";
-                  a_class [ "space-y-4 pt-4" ];
-                  Unsafe.string_attrib "x-show" "deploy_mode === 'manual'";
-                ]
+              ~a:[ Unsafe.string_attrib "x-show" "solo5_options" ]
+              [
+                label ~a:[ a_class [ "block font-medium" ] ] [ txt "Arguments" ];
+                p
+                  ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
+                  [
+                    txt "Write arguments seperated by a whitespace e.g ";
+                    code [ txt "--ip=127.0.0.1 --port=8180" ];
+                  ];
+                textarea
+                  ~a:
+                    [
+                      a_rows 2;
+                      a_name "arguments";
+                      a_id "unikernel-arguments";
+                      a_class [ input_classes ];
+                    ]
+                  (txt "");
+              ];
+            (* Solo5 options moved to basic view *)
             hr ();
             div
               [
@@ -428,7 +420,12 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
             hr ();
             (* Solo5 options moved to basic view *)
             div
-              ~a:[ a_id "solo5-options"; a_class [ "space-y-4 pt-4" ] ]
+              ~a:
+                [
+                  a_id "solo5-options";
+                  a_class [ "space-y-4 pt-4" ];
+                  Unsafe.string_attrib "x-show" "deploy_mode === 'manual'";
+                ]
               [
                 div
                   [
@@ -444,6 +441,10 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                           a_class [ input_classes; "bg-white" ];
                           Unsafe.string_attrib ":required"
                             "deploy_mode === 'manual'";
+                        ]
+                      ();
+                    label
+                      ~a:[ a_class [ "block font-medium" ] ]
                       [ txt "Arguments" ];
                     p
                       ~a:[ a_class [ "text-sm text-gray-500 mb-1" ] ]
@@ -460,7 +461,7 @@ let unikernel_create_layout ~(user_policy : Vmm_core.Policy.t) unikernels
                           a_id "unikernel-arguments";
                           a_class [ input_classes ];
                         ]
-                      ();
+                      (txt "");
                   ];
               ];
             div

--- a/update_flow.ml
+++ b/update_flow.ml
@@ -20,31 +20,9 @@ type success =
       (Vmm_core.Name.t * Vmm_core.Unikernel.info * Builder_web.compare)
   | No_update_needed of (Vmm_core.Name.t * string)
 
-let send_http_request ?(path = "") ~base_url http_client =
-  let url = base_url ^ path in
-  let body = "" in
-  let body_f _ acc chunk = Lwt.return (acc ^ chunk) in
-  Http_mirage_client.request http_client ~follow_redirect:true
-    ~headers:[ ("Accept", "application/json") ]
-    url body_f body
-  >>= function
-  | Error (`Msg err) -> Lwt.return (Error (`Msg err))
-  | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
-  | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
-  | Ok (resp, body) ->
-      if Http_mirage_client.Status.is_successful resp.Http_mirage_client.status
-      then Lwt.return (Ok body)
-      else
-        Lwt.return
-          (Error
-             (`Msg
-                ("accessing " ^ url ^ " resulted in an error: "
-                ^ Http_mirage_client.Status.to_string resp.status
-                ^ " " ^ resp.reason)))
-
 let fetch_json http_client ~base_url ~path parser ctx_msg =
   let* body =
-    send_http_request ~path ~base_url http_client
+    Utils.Http.send_http_request ~path ~base_url http_client
     |> Lwt_result.map_error (fun (`Msg e) ->
         Builder_req_err (Printf.sprintf "Network error during %s: %s" ctx_msg e))
   in

--- a/utils.ml
+++ b/utils.ml
@@ -383,6 +383,7 @@ let switch_button ~switch_id ~switch_label ?(initial_state = false) html_content
               ~a:
                 [
                   a_id switch_id;
+                  a_name switch_id;
                   a_input_type `Checkbox;
                   a_class [ "peer sr-only" ];
                   a_role [ "switch" ];

--- a/utils.ml
+++ b/utils.ml
@@ -19,6 +19,32 @@ module Json = struct
         Error (`Msg ("invalid json for " ^ field ^ ": " ^ to_string json))
 end
 
+module Http = struct
+  let send_http_request ?(path = "") ~base_url http_client =
+    let open Lwt.Infix in
+    let url = base_url ^ path in
+    let body = "" in
+    let body_f _ acc chunk = Lwt.return (acc ^ chunk) in
+    Http_mirage_client.request http_client ~follow_redirect:true
+      ~headers:[ ("Accept", "application/json") ]
+      url body_f body
+    >>= function
+    | Error (`Msg err) -> Lwt.return (Error (`Msg err))
+    | Error `Cycle -> Lwt.return (Error (`Msg "returned cycle"))
+    | Error `Not_found -> Lwt.return (Error (`Msg "returned not found"))
+    | Ok (resp, body) ->
+        if
+          Http_mirage_client.Status.is_successful resp.Http_mirage_client.status
+        then Lwt.return (Ok body)
+        else
+          Lwt.return
+            (Error
+               (`Msg
+                  ("accessing " ^ url ^ " resulted in an error: "
+                  ^ Http_mirage_client.Status.to_string resp.status
+                  ^ " " ^ resp.reason)))
+end
+
 module TimeHelper = struct
   let ptime_of_string (t_str : string) : (Ptime.t, [> `Msg of string ]) result =
     match Ptime.of_rfc3339 t_str with

--- a/utils.ml
+++ b/utils.ml
@@ -457,10 +457,9 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
             ("{ fields: [], options: " ^ alpine_options ^ ", field_id: '" ^ id
            ^ "' }");
           Unsafe.string_attrib "@populate-manifest.window"
-            "if ($event.detail[field_id]) fields = \
-             $event.detail[field_id].map(n => { const match = options.find(o \
-             => o.value === n || o.label === n); return { title: n, selected: \
-             match ? match.value : '' }; })";
+            "if (window.mapFields && $event.detail[field_id]) fields = \
+             window.mapFields(field_id, $event.detail, options); \
+             else if (!$event.detail[field_id]) fields = [];";
         ]
       [
         Unsafe.data "<template x-for='(field, index) in fields' :key='index'>";

--- a/utils.ml
+++ b/utils.ml
@@ -457,9 +457,9 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
             ("{ fields: [], options: " ^ alpine_options ^ ", field_id: '" ^ id
            ^ "' }");
           Unsafe.string_attrib "@populate-manifest.window"
-            "if (window.mapFields && $event.detail[field_id]) fields = \
-             window.mapFields(field_id, $event.detail, options); else if \
-             (!$event.detail[field_id]) fields = [];";
+            ("if (window.mapFields && $event.detail[field_id]) fields = \
+              window.mapFields(field_id, $event.detail, " ^ alpine_options
+           ^ "); else if (!$event.detail[field_id]) fields = [];");
         ]
       [
         Unsafe.data "<template x-for='(field, index) in fields' :key='index'>";
@@ -581,13 +581,12 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
                                 ];
                               Unsafe.string_attrib ":id"
                                 "field_id + '-select-' + index";
-                              Unsafe.string_attrib "x-model" "field.selected";
                             ]
                           [
                             Unsafe.data
                               {|
                     <template x-for="option in options" :key="option.value">
-                      <option :value="option.value" x-text="option.label"></option>
+                      <option :value="option.value" x-text="option.label" :selected="option.value === field.selected"></option>
                     </template>
                   |};
                           ];

--- a/utils.ml
+++ b/utils.ml
@@ -455,6 +455,9 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
           Unsafe.string_attrib "x-data"
             ("{ fields: [], options: " ^ alpine_options ^ ", field_id: '" ^ id
            ^ "' }");
+          Unsafe.string_attrib "@populate-manifest.window"
+            "if ($event.detail[field_id]) fields = \
+             $event.detail[field_id].map(n => ({ title: n, selected: '' }))";
         ]
       [
         Unsafe.data "<template x-for='(field, index) in fields' :key='index'>";

--- a/utils.ml
+++ b/utils.ml
@@ -458,8 +458,8 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
            ^ "' }");
           Unsafe.string_attrib "@populate-manifest.window"
             "if (window.mapFields && $event.detail[field_id]) fields = \
-             window.mapFields(field_id, $event.detail, options); \
-             else if (!$event.detail[field_id]) fields = [];";
+             window.mapFields(field_id, $event.detail, options); else if \
+             (!$event.detail[field_id]) fields = [];";
         ]
       [
         Unsafe.data "<template x-for='(field, index) in fields' :key='index'>";

--- a/utils.ml
+++ b/utils.ml
@@ -458,7 +458,9 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
            ^ "' }");
           Unsafe.string_attrib "@populate-manifest.window"
             "if ($event.detail[field_id]) fields = \
-             $event.detail[field_id].map(n => ({ title: n, selected: '' }))";
+             $event.detail[field_id].map(n => { const match = options.find(o \
+             => o.value === n || o.label === n); return { title: n, selected: \
+             match ? match.value : '' }; })";
         ]
       [
         Unsafe.data "<template x-for='(field, index) in fields' :key='index'>";
@@ -580,6 +582,7 @@ let dynamic_dropdown_form (items : 'a list) ~(get_label : 'a -> string)
                                 ];
                               Unsafe.string_attrib ":id"
                                 "field_id + '-select-' + index";
+                              Unsafe.string_attrib "x-model" "field.selected";
                             ]
                           [
                             Unsafe.data


### PR DESCRIPTION
This pr introduces direct deployment from builds.robur.coop. We use HTMX to perform background API calls and populate the DOM without refreshing the page.

Basically when the deployment form is opened:
- mollymawk attempts to query builds.robur.coop to get a list of available unikernels. This list is populated in a dropdown select on the deployment form.
- the user selects which vm (clicking on the job name) they want to deploy, mollymawk (via htmx) queries builds.robur.coop a second time to get it's manifest (which block devices and network devices are needed). this is then used to populated the form sections handling block devices and network devices.
- when the user clicks on deploy, mollymawk uses the job name to stream the latest binary from builds.robur.coop to deploy the unikernel.

### Deployment modes
We have two deployment modes:
- Robur builder: the default mode, which lets you select any unikernel from builds.robur.coop
- Manual mode: which lets you upload the unikernel binary manually on the form
<img width="2739" height="1593" alt="image" src="https://github.com/user-attachments/assets/a0f8ae88-0acc-4a6c-825e-ebda1a66ba5e" />


### VMs available
A dropdown with all available reproducible builds (only unikernels) from builds.robur.coop. Selecting any will query the specific vm to see what devices it nees

<img width="2739" height="1593" alt="image" src="https://github.com/user-attachments/assets/6ae042fa-6746-4986-975d-c0a6849f105d" />

### Configuring devices
Once the manifest devices are known, the advanced config panel opens and autofills this information for any network interfaces needed or block devices needed. Manual  intervention is needed to map the names to the correct hosts.

<img width="2739" height="1103" alt="image" src="https://github.com/user-attachments/assets/8f24174f-b4a4-4cb5-93ab-a5db38a35762" />
