### PR TITLE
unikernel_update: rephrase "Current Build" to "Deployed Unikernel" to make it obvious

### DIFF
--- a/unikernel_update.ml
+++ b/unikernel_update.ml
@@ -387,7 +387,7 @@ let opam_version_table (packages : Builder_web.package_version_diff list) =
                             text-primary-600 uppercase";
                          ];
                      ]
-                   [ txt "Current Build" ];
+                   [ txt "Deployed Unikernel" ];
                  th
                    ~a:
                      [
@@ -555,7 +555,7 @@ let unikernel_update_layout ~unikernel_name ~instance_name unikernel
                           [
                             p
                               ~a:[ a_class [ "text-xl font-semibold mt-4" ] ]
-                              [ txt "Current Build" ];
+                              [ txt "Deployed Unikernel" ];
                             build_table build_comparison.left;
                             hr ();
                             p


### PR DESCRIPTION
The distinction is between what we have currently deployed and what is the latest build on our reproducible build infrastructure.

The previous terminology "Current Build" vs "Latest Build" is not obvious to me, but "Deployed Unikernel" is very obvious.