### PR TITLE
cirrus: udpate to OCaml 4.14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
 
 freebsd_task:
   pkg_install_script: pkg install -y ocaml-opam gmake bash
-  ocaml_script: opam init -a --comp=4.14.2
+  ocaml_script: opam init -a --comp=4.14.3
   mirage_script: eval `opam env` && opam install --confirm-level=unsafe-yes "mirage>=4.9.0"
   configure_script: eval `opam env` && mirage configure -t hvt
   depend_script: eval `opam env` && gmake depend


### PR DESCRIPTION
I'm keeping this separate to figure out whether I can reproduce the issue that the CI for some reason insists on OCaml 5.4.1...