### PR TITLE
revert part of #234, use older colombe -- to avoid opam-monorepo failures

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -17,9 +17,9 @@ let mollymawk =
       package "mirage-crypto-rng";
       package "uuidm";
       package "emile";
-      package ~sublibs:[ "emile" ] "colombe" ~min:"0.13.0";
+      package ~sublibs:[ "emile" ] ~min:"0.12.0" ~max:"0.13.0" "colombe";
       package "sendmail";
-      package "paf" ~sublibs:[ "mirage" ] ~min:"0.5.0";
+      package ~sublibs:[ "mirage" ] ~min:"0.5.0" "paf";
       package "oneffs";
       package "duration";
       package ~min:"0.2.0" "ohex";

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -31,8 +31,8 @@ struct
 
   let recipient email =
     match Colombe_emile.to_path email with
-    | path -> [ Colombe.Forward_path.Forward_path path ]
-    | exception Invalid_argument e ->
+    | Ok path -> [ Colombe.Forward_path.Forward_path path ]
+    | Error (`Msg e) ->
         Logs.err (fun m ->
             m "Type conversion failed for %s: %s" (Emile.to_string email) e);
         []
@@ -71,8 +71,8 @@ struct
     in
     let sender =
       match Colombe_emile.to_path email_config.from_email with
-      | path -> Some path
-      | exception Invalid_argument _ -> None
+      | Ok path -> Some path
+      | Error _ -> None
     in
     let streamer =
       let s = Mrmime.Mt.to_stream email in


### PR DESCRIPTION
I've no clue why opam-monorepo otherwise fails... :/