### PR TITLE
Monitoring configuration in mollymawk

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -8,7 +8,8 @@ let management_stack, lease =
   generic_stackv4v6_with_lease ~group:"management" ~dhcp_requests
     (netif "management")
 
-let management_eyeballs = generic_happy_eyeballs ~group:"management" management_stack
+let management_eyeballs =
+  generic_happy_eyeballs ~group:"management" management_stack
 
 let management_dns =
   generic_dns_client ~group:"management" management_stack management_eyeballs

--- a/config.ml
+++ b/config.ml
@@ -8,7 +8,7 @@ let management_stack, lease =
   generic_stackv4v6_with_lease ~group:"management" ~dhcp_requests
     (netif "management")
 
-let management_eyeballs = generic_happy_eyeballs management_stack
+let management_eyeballs = generic_happy_eyeballs ~group:"management" management_stack
 
 let management_dns =
   generic_dns_client ~group:"management" management_stack management_eyeballs

--- a/config.ml
+++ b/config.ml
@@ -31,7 +31,8 @@ let mollymawk =
     ]
   in
   main ~packages "Unikernel.Main"
-    (stackv4v6 @-> stackv4v6 @-> kv_ro @-> block @-> http_client @-> job)
+    (stackv4v6 @-> stackv4v6 @-> dns_client @-> kv_ro @-> block @-> http_client
+   @-> job @-> job)
 
 let block = block_of_file "data"
 
@@ -45,13 +46,37 @@ let http_client =
     (tcpv4v6 @-> mimic @-> Mirage.http_client)
 
 let stack = generic_stackv4v6 default_network
-
-let management_stack =
-  generic_stackv4v6 ~group:"management" (netif "management")
-
 let eyeballs = generic_happy_eyeballs stack
 let dns = generic_dns_client stack eyeballs
 let tcp = tcpv4v6_of_stackv4v6 stack
+let dhcp_requests = make_dhcp_requests ()
+
+let management_stack, lease =
+  generic_stackv4v6_with_lease ~group:"management" ~dhcp_requests
+    (netif "management")
+
+let management_eyeballs = generic_happy_eyeballs management_stack
+
+let management_dns =
+  generic_dns_client ~group:"management" management_stack management_eyeballs
+
+let management_domain (dhcp_requests, lease) =
+  let () =
+    add_dhcp_request dhcp_requests 15
+    (* DOMAIN_NAME *)
+  in
+  let connect _ _ = function
+    | [ lease ] ->
+        (* TODO: sane default instead of None?! *)
+        code ~pos:__POS__
+          "Lwt.return @@@@@ match %s with None -> None@ | Some lease -> \
+           Dhcp_wire.find_domain_name lease"
+          lease
+    | _ -> assert false
+  in
+  impl ~connect ~extra_deps:[ dep lease ] "Dhcp_wire" job
+
+let management_domain_name = management_domain (dhcp_requests, lease)
 
 let http_client =
   let happy_eyeballs = mimic_happy_eyeballs stack eyeballs dns in
@@ -59,4 +84,7 @@ let http_client =
 
 let () =
   register "mollymawk"
-    [ mollymawk $ stack $ management_stack $ assets $ block $ http_client ]
+    [
+      mollymawk $ stack $ management_stack $ management_dns $ assets $ block
+      $ http_client $ management_domain_name;
+    ]

--- a/config.ml
+++ b/config.ml
@@ -2,53 +2,6 @@
 open Mirage
 
 let assets = crunch "assets"
-
-let mollymawk =
-  let packages =
-    [
-      package "logs";
-      package "x509";
-      package "tls-mirage";
-      package ~min:"2.7.0" "albatross";
-      package "yojson";
-      package "uri";
-      package "tyxml";
-      package "multipart_form";
-      package "mirage-crypto-rng";
-      package "uuidm";
-      package "emile";
-      package ~sublibs:[ "emile" ] ~min:"0.12.0" ~max:"0.13.0" "colombe";
-      package "sendmail";
-      package ~sublibs:[ "mirage" ] ~min:"0.5.0" "paf";
-      package "oneffs";
-      package "duration";
-      package ~min:"0.2.0" "ohex";
-      package "http-mirage-client";
-      package "multipart_form-lwt";
-      package "sendmail-mirage";
-      package "dns-client-mirage";
-      package "mrmime";
-    ]
-  in
-  main ~packages "Unikernel.Main"
-    (stackv4v6 @-> stackv4v6 @-> dns_client @-> kv_ro @-> block @-> http_client
-   @-> job @-> job)
-
-let block = block_of_file "data"
-
-let http_client =
-  let connect _ modname = function
-    | [ _tcpv4v6; ctx ] ->
-        code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
-    | _ -> assert false
-  in
-  impl ~connect "Http_mirage_client.Make"
-    (tcpv4v6 @-> mimic @-> Mirage.http_client)
-
-let stack = generic_stackv4v6 default_network
-let eyeballs = generic_happy_eyeballs stack
-let dns = generic_dns_client stack eyeballs
-let tcp = tcpv4v6_of_stackv4v6 stack
 let dhcp_requests = make_dhcp_requests ()
 
 let management_stack, lease =
@@ -78,6 +31,54 @@ let management_domain (dhcp_requests, lease) =
 
 let management_domain_name = management_domain (dhcp_requests, lease)
 
+let mollymawk =
+  let packages =
+    [
+      package "logs";
+      package "x509";
+      package "tls-mirage";
+      package ~min:"2.7.0" "albatross";
+      package "yojson";
+      package "uri";
+      package "tyxml";
+      package "multipart_form";
+      package "mirage-crypto-rng";
+      package "uuidm";
+      package "emile";
+      package ~sublibs:[ "emile" ] ~min:"0.12.0" ~max:"0.13.0" "colombe";
+      package "sendmail";
+      package ~sublibs:[ "mirage" ] ~min:"0.5.0" "paf";
+      package "oneffs";
+      package "duration";
+      package ~min:"0.2.0" "ohex";
+      package "http-mirage-client";
+      package "multipart_form-lwt";
+      package "sendmail-mirage";
+      package "dns-client-mirage";
+      package "mrmime";
+    ]
+  in
+  main ~packages "Unikernel.Main"
+    ~deps:[ dep management_domain_name ]
+    (stackv4v6 @-> stackv4v6 @-> dns_client @-> kv_ro @-> block @-> http_client
+   @-> job)
+
+let block = block_of_file "data"
+
+let http_client =
+  let connect _ modname = function
+    | [ _tcpv4v6; ctx ] ->
+        code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
+    | _ -> assert false
+  in
+  impl ~connect "Http_mirage_client.Make"
+    (tcpv4v6 @-> mimic @-> Mirage.http_client)
+
+let stack = generic_stackv4v6 default_network
+let eyeballs = generic_happy_eyeballs stack
+let dns = generic_dns_client stack eyeballs
+let tcp = tcpv4v6_of_stackv4v6 stack
+
 let http_client =
   let happy_eyeballs = mimic_happy_eyeballs stack eyeballs dns in
   http_client $ tcp $ happy_eyeballs
@@ -86,5 +87,5 @@ let () =
   register "mollymawk"
     [
       mollymawk $ stack $ management_stack $ management_dns $ assets $ block
-      $ http_client $ management_domain_name;
+      $ http_client;
     ]

--- a/config.ml
+++ b/config.ml
@@ -31,7 +31,7 @@ let mollymawk =
     ]
   in
   main ~packages "Unikernel.Main"
-    (stackv4v6 @-> kv_ro @-> block @-> http_client @-> job)
+    (stackv4v6 @-> stackv4v6 @-> kv_ro @-> block @-> http_client @-> job)
 
 let block = block_of_file "data"
 
@@ -45,6 +45,10 @@ let http_client =
     (tcpv4v6 @-> mimic @-> Mirage.http_client)
 
 let stack = generic_stackv4v6 default_network
+
+let management_stack =
+  generic_stackv4v6 ~group:"management" (netif "management")
+
 let eyeballs = generic_happy_eyeballs stack
 let dns = generic_dns_client stack eyeballs
 let tcp = tcpv4v6_of_stackv4v6 stack
@@ -54,4 +58,5 @@ let http_client =
   http_client $ tcp $ happy_eyeballs
 
 let () =
-  register "mollymawk" [ mollymawk $ stack $ assets $ block $ http_client ]
+  register "mollymawk"
+    [ mollymawk $ stack $ management_stack $ assets $ block $ http_client ]

--- a/header_layout.ml
+++ b/header_layout.ml
@@ -19,9 +19,24 @@ let header ?(page_title = "Mollymawk") ~icon () =
           ~a:
             [
               a_src
-                "https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js";
+                "https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js";
+              a_integrity
+                "sha384-H5SrcfygHmAuTDZphMHqBJLc3FhssKjG7w/CeCpFReSfwBWDTKpkzPP8c+cLsK+V";
+              a_crossorigin `Anonymous;
             ]
           (txt "");
+        (* by default htmx doesn't swap on error responses. 
+        this allows it to swap for any error code. 
+        we need this to display errors to the user
+        see: https://htmx.org/quirks/#by-default-4xx-5xx-responses-do-not-swap *)
+        meta
+          ~a:
+            [
+              a_name "htmx-config";
+              a_content
+                "{\"responseHandling\": [{\"code\":\"...\", \"swap\": true}]}";
+            ]
+          ();
         link ~rel:[ `Stylesheet ]
           ~href:"https://unpkg.com/aos@2.3.1/dist/aos.css" ();
         link ~rel:[ `Stylesheet ] ~href:"/style.css" ();

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -104,12 +104,8 @@ let render_metric_picker ~source ~value index =
     ]
 
 let monitoring_status_html ~name ~logs ~metrics =
-  let log_entries =
-    match logs with Error _ -> [] | Ok s -> parse_monitoring_response s
-  in
-  let metric_entries =
-    match metrics with Error _ -> [] | Ok s -> parse_monitoring_response s
-  in
+  let log_entries = parse_monitoring_response logs in
+  let metric_entries = parse_monitoring_response metrics in
   let default_log_level =
     match List.assoc_opt "*" log_entries with Some l -> l | None -> "info"
   in

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -1,0 +1,409 @@
+open Tyxml_html
+
+let parse_monitoring_response str =
+  let str = String.trim str in
+  let str =
+    if String.length str > 4 && String.sub str 0 4 = "ok: " then
+      String.sub str 4 (String.length str - 4)
+    else str
+  in
+  String.split_on_char ',' str
+  |> List.filter_map (fun s ->
+      match String.split_on_char ':' (String.trim s) with
+      | [ name; value ] -> Some (String.trim name, String.trim value)
+      | _ -> None)
+
+let log_levels = [ "debug"; "info"; "warning"; "error"; "app"; "quiet" ]
+
+let render_log_picker ~source ~default_level ~value =
+  div
+    ~a:
+      [
+        a_class
+          [
+            "flex items-center justify-between gap-3 px-3 py-2 rounded \
+             bg-gray-700 hover:bg-gray-600 transition-colors";
+          ];
+      ]
+    [
+      span
+        ~a:
+          [
+            a_class [ "font-mono truncate flex-1 font-semibold" ];
+            a_title source;
+          ]
+        [
+          txt (if String.equal source "*" then "Default Log level" else source);
+        ];
+      select
+        ~a:
+          [
+            Unsafe.string_attrib "x-model" value;
+            Unsafe.string_attrib ":style"
+              (Fmt.str
+                 "`background-color: ${getColor(%s)}; color: \
+                  ${getTextColor(%s)}`"
+                 value value);
+            a_class
+              [
+                "text-xs border border-gray-600 rounded px-2 py-1 \
+                 focus:outline-none cursor-pointer shrink-0 rounded-xl";
+              ];
+          ]
+        (List.map
+           (fun l ->
+             option
+               ~a:
+                 ([ a_value l ]
+                 @ if l = default_level then [ a_selected () ] else [])
+               (txt l))
+           log_levels);
+    ]
+
+let render_metric_picker ~source ~value index =
+  label
+    ~a:
+      [
+        a_class
+          [
+            "flex items-center gap-2 cursor-pointer px-3 py-2 rounded \
+             transition-colors";
+          ];
+        Unsafe.string_attrib ":class"
+          (Fmt.str "%s ? 'bg-primary-900' : 'bg-gray-700 hover:bg-gray-600'"
+             value);
+      ]
+    [
+      input
+        ~a:
+          [
+            a_input_type `Checkbox;
+            a_id (Fmt.str "metric-%d" index);
+            a_name (Fmt.str "metric-%s-%d" source index);
+            a_class [ "accent-primary-500 shrink-0 cursor-pointer" ];
+            Unsafe.string_attrib "x-model" value;
+          ]
+        ();
+      span
+        ~a:[ a_class [ "font-semibold font-mono px-2 truncate" ] ]
+        [ txt source ];
+      span
+        ~a:
+          [
+            Unsafe.string_attrib "x-show" value;
+            a_class [ "ml-auto font-mono text-primary-400 shrink-0" ];
+          ]
+        [ txt "enabled" ];
+      span
+        ~a:
+          [
+            Unsafe.string_attrib "x-show" (Fmt.str "!%s" value);
+            a_class [ "ml-auto font-mono text-gray-500 shrink-0" ];
+          ]
+        [ txt "disabled" ];
+    ]
+
+let monitoring_status_html ~name ~logs ~metrics =
+  let log_entries =
+    match logs with Error _ -> [] | Ok s -> parse_monitoring_response s
+  in
+  let metric_entries =
+    match metrics with Error _ -> [] | Ok s -> parse_monitoring_response s
+  in
+  let default_log_level =
+    match List.assoc_opt "*" log_entries with Some l -> l | None -> "info"
+  in
+  let other_logs = List.filter (fun (s, _) -> s <> "*") log_entries in
+  let other_metrics = List.filter (fun (s, _) -> s <> "*") metric_entries in
+  let logs_dict =
+    String.concat ", "
+      (List.map
+         (fun (s, l) ->
+           Printf.sprintf "'%s': '%s'" (String.escaped s) (String.escaped l))
+         other_logs)
+  in
+  let metrics_dict =
+    String.concat ", "
+      (List.map
+         (fun (s, l) ->
+           let is_en = if String.equal l "enabled" then "true" else "false" in
+           Printf.sprintf "'%s': %s" (String.escaped s) is_en)
+         other_metrics)
+  in
+  let log_data =
+    Printf.sprintf
+      "{ advancedLogs: false, defaultLevel: '%s', logs: { %s }, \
+       getColor(level) { const colors = {'info': '#166534', 'warning': \
+       '#854d0e', 'error': '#7f1d1d'}; return colors[level] || '#27272a'; }, \
+       getTextColor(level) { const colors = {'info': '#bbf7d0', 'warning': \
+       '#fef08a', 'error': '#fecaca'}; return colors[level] || '#a1a1aa'; }, \
+       getCommand() { let cmd = 'L*:' + this.defaultLevel; for (const [k, v] \
+       of Object.entries(this.logs)) { cmd += ',' + k + ':' + v; }  return \
+       cmd; } }"
+      default_log_level logs_dict
+  in
+  let metric_data =
+    Printf.sprintf
+      "{ metrics: { %s }, get allMetrics() { return \
+       Object.values(this.metrics).every(v => v); }, set allMetrics(value) { \
+       for (const k in this.metrics) { this.metrics[k] = value; } }, \
+       getCommand() { const values = Object.values(this.metrics); if \
+       (values.every(v => v)) { return 'M*:enable'; } if (values.every(v => \
+       !v)) { return 'M*:disable'; } let cmd = 'M*:disable'; for (const [k, v] \
+       of Object.entries(this.metrics)) { if (v) { cmd += ',' + k + ':enable'; \
+       } } return cmd; } }"
+      metrics_dict
+  in
+  div
+    ~a:[ a_id "monitoring-container"; a_class [ "space-y-6 py-4" ] ]
+    [
+      (if log_entries = [] && metric_entries = [] then
+         div
+           ~a:[ a_class [ "text-center py-8" ] ]
+           [
+             i
+               ~a:
+                 [
+                   a_class
+                     [
+                       "fa-solid fa-circle-exclamation text-gray-500 text-2xl \
+                        mb-2";
+                     ];
+                 ]
+               [];
+             p
+               ~a:[ a_class [ "text-gray-400 mt-2" ] ]
+               [ txt "Monitoring unavailable for this unikernel." ];
+           ]
+       else div []);
+      (if log_entries <> [] then
+         div
+           ~a:
+             [ a_class [ "space-y-3" ]; Unsafe.string_attrib "x-data" log_data ]
+           [
+             div
+               ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
+               [
+                 i
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "fa-solid fa-list-check text-primary-400 text-sm \
+                            px-2";
+                         ];
+                     ]
+                   [];
+                 p
+                   ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
+                   [ txt "Log Sources" ];
+                 span
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "ml-auto text-xs font-semibold px-2 py-0.5 \
+                            rounded-full";
+                         ];
+                     ]
+                   [ txt (Fmt.str "%d sources" (List.length log_entries)) ];
+               ];
+             form
+               ~a:
+                 [
+                   a_enctype "multipart/form-data";
+                   Unsafe.string_attrib "hx-post"
+                     "/api/unikernel/monitoring/update";
+                   Unsafe.string_attrib "hx-swap" "innerHTML";
+                   Unsafe.string_attrib "hx-include" "#molly-csrf";
+                   Unsafe.string_attrib "hx-target" "#monitoring-container";
+                 ]
+               [
+                 input
+                   ~a:
+                     [
+                       a_input_type `Hidden;
+                       a_name "unikernel_name";
+                       a_value name;
+                     ]
+                   ();
+                 input
+                   ~a:
+                     [
+                       a_input_type `Hidden;
+                       a_name "command";
+                       Unsafe.string_attrib ":value" "getCommand()";
+                     ]
+                   ();
+                 div
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 \
+                            gap-2 max-h-72 overflow-y-auto pr-1 scrollbar-thin";
+                         ];
+                     ]
+                   [
+                     render_log_picker ~source:"*"
+                       ~default_level:default_log_level ~value:"defaultLevel";
+                   ];
+                 (if other_logs <> [] then
+                    div
+                      [
+                        div
+                          ~a:[ a_class [ "mt-4 mb-2" ] ]
+                          [
+                            button
+                              ~a:
+                                [
+                                  a_button_type `Button;
+                                  a_class
+                                    [
+                                      "font-semibold text-primary-400 \
+                                       hover:text-primary-300";
+                                    ];
+                                  a_style
+                                    "cursor: pointer; text-decoration: \
+                                     underline;";
+                                  Unsafe.string_attrib "@click"
+                                    "advancedLogs = !advancedLogs";
+                                ]
+                              [
+                                span
+                                  ~a:
+                                    [
+                                      Unsafe.string_attrib "x-text"
+                                        "advancedLogs ? 'Less logging options' \
+                                         : 'More logging options'";
+                                    ]
+                                  [];
+                              ];
+                          ];
+                        div
+                          ~a:
+                            [
+                              Unsafe.string_attrib "x-show" "advancedLogs";
+                              a_class
+                                [
+                                  "grid grid-cols-1 md:grid-cols-2 \
+                                   lg:grid-cols-3 gap-2 max-h-72 \
+                                   overflow-y-auto pr-1 scrollbar-thin";
+                                ];
+                            ]
+                          (List.map
+                             (fun (s, l) ->
+                               render_log_picker ~source:s ~default_level:l
+                                 ~value:(Printf.sprintf "logs['%s']" s))
+                             other_logs);
+                      ]
+                  else div []);
+                 div
+                   ~a:[ a_class [ "mt-4" ] ]
+                   [
+                     Utils.button_component ~extra_css:"font-bold"
+                       ~btn_type:`Primary_full ~attribs:[]
+                       ~content:(txt "Update Logging") ();
+                   ];
+               ];
+           ]
+       else div []);
+      hr ();
+      (if metric_entries <> [] then
+         div
+           ~a:
+             [
+               a_class [ "space-y-3" ];
+               Unsafe.string_attrib "x-data" metric_data;
+             ]
+           [
+             div
+               ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
+               [
+                 i
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "fa-solid fa-chart-line text-primary-400 text-sm \
+                            px-2";
+                         ];
+                     ]
+                   [];
+                 p
+                   ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
+                   [ txt "Metrics Sources" ];
+                 span
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "ml-auto text-xs font-semibold px-2 py-0.5 \
+                            rounded-full";
+                         ];
+                     ]
+                   [
+                     txt
+                       (Fmt.str "%d/%d enabled"
+                          (List.length
+                             (List.filter
+                                (fun (_, s) -> String.equal s "enabled")
+                                metric_entries))
+                          (List.length metric_entries));
+                   ];
+               ];
+             form
+               ~a:
+                 [
+                   a_enctype "multipart/form-data";
+                   Unsafe.string_attrib "hx-post"
+                     "/api/unikernel/monitoring/update";
+                   Unsafe.string_attrib "hx-swap" "innerHTML";
+                   Unsafe.string_attrib "hx-include" "#molly-csrf";
+                   Unsafe.string_attrib "hx-target" "#monitoring-container";
+                 ]
+               [
+                 input
+                   ~a:
+                     [
+                       a_input_type `Hidden;
+                       a_name "unikernel_name";
+                       a_value name;
+                     ]
+                   ();
+                 input
+                   ~a:
+                     [
+                       a_input_type `Hidden;
+                       a_name "command";
+                       Unsafe.string_attrib ":value" "getCommand()";
+                     ]
+                   ();
+                 div
+                   ~a:
+                     [
+                       a_class
+                         [
+                           "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 \
+                            gap-2 max-h-72 overflow-y-auto pr-1 scrollbar-thin";
+                         ];
+                     ]
+                   (render_metric_picker ~source:"All metrics"
+                      ~value:"allMetrics" (-1)
+                   :: List.mapi
+                        (fun i (s, l) ->
+                          render_metric_picker ~source:s
+                            ~value:(Printf.sprintf "metrics['%s']" s)
+                            i)
+                        other_metrics);
+                 div
+                   ~a:[ a_class [ "mt-4" ] ]
+                   [
+                     Utils.button_component ~extra_css:"font-bold"
+                       ~btn_type:`Primary_full ~attribs:[]
+                       ~content:(txt "Update Metrics") ();
+                   ];
+               ];
+           ]
+       else div []);
+    ]

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -1,5 +1,61 @@
 open Tyxml_html
 
+let check_command command =
+  let command = String.trim command in
+  if String.length command < 2 then Error "Command is too short"
+  else
+    let kind = String.sub command 0 1 in
+    let rest = String.sub command 1 (String.length command - 1) in
+    let segments = String.split_on_char ',' rest in
+    let is_valid_level s =
+      match String.trim s with
+      | "debug" | "info" | "warning" | "error" | "app" | "quiet" -> true
+      | _ -> false
+    in
+
+    let is_valid_metric s =
+      match String.trim s with "enable" | "disable" -> true | _ -> false
+    in
+    let is_valid_source name =
+      let name = String.trim name in
+      String.length name > 0
+      &&
+      let rec loop i =
+        if i >= String.length name then true
+        else
+          match name.[i] with
+          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' | '*' ->
+              loop (i + 1)
+          | _ -> false
+      in
+      loop 0
+    in
+    let validate_segment is_valid_val segment =
+      let segment = String.trim segment in
+      if String.length segment = 0 then false
+      else if segment.[0] = '*' then
+        let value = String.sub segment 2 (String.length segment - 2) in
+        is_valid_val value
+      else
+        match String.split_on_char ':' segment with
+        | [ name; val_ ] -> is_valid_source name && is_valid_val val_
+        | _ -> false
+    in
+    match kind with
+    | "L" ->
+        if segments = [] || segments = [ "" ] then
+          Error "Empty logs command body"
+        else if List.for_all (validate_segment is_valid_level) segments then
+          Ok command
+        else Error "Invalid logs configuration formatting"
+    | "M" ->
+        if segments = [] || segments = [ "" ] then
+          Error "Empty metrics command body"
+        else if List.for_all (validate_segment is_valid_metric) segments then
+          Ok command
+        else Error "Invalid metrics configuration formatting"
+    | _ -> Error "Invalid command prefix (must be L or M)"
+
 let check_monitoring_response_format str =
   let str = String.trim str in
   if String.length str > 4 && String.sub str 0 4 = "ok: " then

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -1,17 +1,38 @@
 open Tyxml_html
 
-let parse_monitoring_response str =
+let check_monitoring_response_format str =
   let str = String.trim str in
-  let str =
-    if String.length str > 4 && String.sub str 0 4 = "ok: " then
-      String.sub str 4 (String.length str - 4)
-    else str
-  in
+  if String.length str > 4 && String.sub str 0 4 = "ok: " then
+    Ok (String.sub str 4 (String.length str - 4))
+  else
+    Error
+      (Fmt.str
+         "Response from monitoring does not start with \"ok: \". Received: %s"
+         str)
+
+let split_key_value_sources str =
   String.split_on_char ',' str
-  |> List.filter_map (fun s ->
-      match String.split_on_char ':' (String.trim s) with
-      | [ name; value ] -> Some (String.trim name, String.trim value)
-      | _ -> None)
+  |> List.fold_left
+       (fun acc s ->
+         match acc with
+         | Error err -> Error err
+         | Ok lst -> (
+             match String.split_on_char ':' (String.trim s) with
+             | [ name; value ] ->
+                 Ok ((String.trim name, String.trim value) :: lst)
+             | _ -> Error "Invalid key-value source format"))
+       (Ok [])
+  |> function
+  | Ok parsed_list -> Ok (List.rev parsed_list)
+  | Error err -> Error err
+
+let parse_monitoring_response str =
+  match check_monitoring_response_format str with
+  | Ok str -> (
+      match split_key_value_sources str with
+      | Ok lst -> Ok lst
+      | Error err -> Error err)
+  | Error err -> Error err
 
 let log_levels = [ "debug"; "info"; "warning"; "error"; "app"; "quiet" ]
 
@@ -103,28 +124,19 @@ let render_metric_picker ~source ~value index =
         [ txt "disabled" ];
     ]
 
-let monitoring_status_html ~name ~logs ~metrics =
-  let log_entries = parse_monitoring_response logs in
-  let metric_entries = parse_monitoring_response metrics in
+let render_log_sources log_entries unikernel_name =
   let default_log_level =
     match List.assoc_opt "*" log_entries with Some l -> l | None -> "info"
   in
-  let other_logs = List.filter (fun (s, _) -> s <> "*") log_entries in
-  let other_metrics = List.filter (fun (s, _) -> s <> "*") metric_entries in
+  let other_logs =
+    List.filter (fun (s, _) -> not (String.equal s "*")) log_entries
+  in
   let logs_dict =
     String.concat ", "
       (List.map
          (fun (s, l) ->
            Printf.sprintf "'%s': '%s'" (String.escaped s) (String.escaped l))
          other_logs)
-  in
-  let metrics_dict =
-    String.concat ", "
-      (List.map
-         (fun (s, l) ->
-           let is_en = if String.equal l "enabled" then "true" else "false" in
-           Printf.sprintf "'%s': %s" (String.escaped s) is_en)
-         other_metrics)
   in
   let log_data =
     Printf.sprintf
@@ -138,6 +150,146 @@ let monitoring_status_html ~name ~logs ~metrics =
        cmd; } }"
       default_log_level logs_dict
   in
+  match log_entries with
+  | [] -> div [ txt "No log sources available for this unikernel." ]
+  | _ ->
+      div
+        ~a:[ a_class [ "space-y-3" ]; Unsafe.string_attrib "x-data" log_data ]
+        [
+          div
+            ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
+            [
+              i
+                ~a:
+                  [
+                    a_class
+                      [ "fa-solid fa-list-check text-primary-400 text-sm px-2" ];
+                  ]
+                [];
+              p
+                ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
+                [ txt "Log Sources" ];
+              span
+                ~a:
+                  [
+                    a_class
+                      [
+                        "ml-auto text-xs font-semibold px-2 py-0.5 rounded-full";
+                      ];
+                  ]
+                [ txt (Fmt.str "%d sources" (List.length log_entries)) ];
+            ];
+          form
+            ~a:
+              [
+                a_enctype "multipart/form-data";
+                Unsafe.string_attrib "hx-post"
+                  "/api/unikernel/monitoring/update";
+                Unsafe.string_attrib "hx-swap" "innerHTML";
+                Unsafe.string_attrib "hx-include" "#molly-csrf";
+                Unsafe.string_attrib "hx-target" "#monitoring-container";
+              ]
+            [
+              input
+                ~a:
+                  [
+                    a_input_type `Hidden;
+                    a_name "unikernel_name";
+                    a_value unikernel_name;
+                  ]
+                ();
+              input
+                ~a:
+                  [
+                    a_input_type `Hidden;
+                    a_name "command";
+                    Unsafe.string_attrib ":value" "getCommand()";
+                  ]
+                ();
+              div
+                ~a:
+                  [
+                    a_class
+                      [
+                        "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 \
+                         max-h-72 overflow-y-auto pr-1 scrollbar-thin";
+                      ];
+                  ]
+                [
+                  render_log_picker ~source:"*" ~default_level:default_log_level
+                    ~value:"defaultLevel";
+                ];
+              (if other_logs <> [] then
+                 div
+                   [
+                     div
+                       ~a:[ a_class [ "mt-4 mb-2" ] ]
+                       [
+                         button
+                           ~a:
+                             [
+                               a_button_type `Button;
+                               a_class
+                                 [
+                                   "font-semibold text-primary-400 \
+                                    hover:text-primary-300";
+                                 ];
+                               a_style
+                                 "cursor: pointer; text-decoration: underline;";
+                               Unsafe.string_attrib "@click"
+                                 "advancedLogs = !advancedLogs";
+                             ]
+                           [
+                             span
+                               ~a:
+                                 [
+                                   Unsafe.string_attrib "x-text"
+                                     "advancedLogs ? 'Less logging options' : \
+                                      'More logging options'";
+                                 ]
+                               [];
+                           ];
+                       ];
+                     div
+                       ~a:
+                         [
+                           Unsafe.string_attrib "x-show" "advancedLogs";
+                           a_class
+                             [
+                               "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 \
+                                gap-2 max-h-72 overflow-y-auto pr-1 \
+                                scrollbar-thin";
+                             ];
+                         ]
+                       (List.map
+                          (fun (s, l) ->
+                            render_log_picker ~source:s ~default_level:l
+                              ~value:(Printf.sprintf "logs['%s']" s))
+                          other_logs);
+                   ]
+               else div []);
+              div
+                ~a:[ a_class [ "mt-4" ] ]
+                [
+                  Utils.button_component ~extra_css:"font-bold"
+                    ~btn_type:`Primary_full ~attribs:[]
+                    ~content:(txt "Update Logging") ();
+                ];
+            ];
+        ]
+
+let render_metric_sources metric_entries unikernel_name =
+  let other_metrics =
+    List.filter (fun (s, _) -> not (String.equal s "*")) metric_entries
+  in
+  let metrics_dict =
+    String.concat ", "
+      (List.map
+         (fun (s, l) ->
+           let is_en = if String.equal l "enabled" then "true" else "false" in
+           Printf.sprintf "'%s': %s" (String.escaped s) is_en)
+         other_metrics)
+  in
   let metric_data =
     Printf.sprintf
       "{ metrics: { %s }, get allMetrics() { return \
@@ -150,256 +302,128 @@ let monitoring_status_html ~name ~logs ~metrics =
        } } return cmd; } }"
       metrics_dict
   in
+  match metric_entries with
+  | [] -> div [ txt "No metric sources available for this unikernel." ]
+  | _ ->
+      div
+        ~a:
+          [ a_class [ "space-y-3" ]; Unsafe.string_attrib "x-data" metric_data ]
+        [
+          div
+            ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
+            [
+              i
+                ~a:
+                  [
+                    a_class
+                      [ "fa-solid fa-chart-line text-primary-400 text-sm px-2" ];
+                  ]
+                [];
+              p
+                ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
+                [ txt "Metrics Sources" ];
+              span
+                ~a:
+                  [
+                    a_class
+                      [
+                        "ml-auto text-xs font-semibold px-2 py-0.5 rounded-full";
+                      ];
+                  ]
+                [
+                  txt
+                    (Fmt.str "%d/%d enabled"
+                       (List.length
+                          (List.filter
+                             (fun (_, s) -> String.equal s "enabled")
+                             metric_entries))
+                       (List.length metric_entries));
+                ];
+            ];
+          form
+            ~a:
+              [
+                a_enctype "multipart/form-data";
+                Unsafe.string_attrib "hx-post"
+                  "/api/unikernel/monitoring/update";
+                Unsafe.string_attrib "hx-swap" "innerHTML";
+                Unsafe.string_attrib "hx-include" "#molly-csrf";
+                Unsafe.string_attrib "hx-target" "#monitoring-container";
+              ]
+            [
+              input
+                ~a:
+                  [
+                    a_input_type `Hidden;
+                    a_name "unikernel_name";
+                    a_value unikernel_name;
+                  ]
+                ();
+              input
+                ~a:
+                  [
+                    a_input_type `Hidden;
+                    a_name "command";
+                    Unsafe.string_attrib ":value" "getCommand()";
+                  ]
+                ();
+              div
+                ~a:
+                  [
+                    a_class
+                      [
+                        "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 \
+                         max-h-72 overflow-y-auto pr-1 scrollbar-thin";
+                      ];
+                  ]
+                (render_metric_picker ~source:"All metrics" ~value:"allMetrics"
+                   (-1)
+                :: List.mapi
+                     (fun i (s, l) ->
+                       render_metric_picker ~source:s
+                         ~value:(Printf.sprintf "metrics['%s']" s)
+                         i)
+                     other_metrics);
+              div
+                ~a:[ a_class [ "mt-4" ] ]
+                [
+                  Utils.button_component ~extra_css:"font-bold"
+                    ~btn_type:`Primary_full ~attribs:[]
+                    ~content:(txt "Update Metrics") ();
+                ];
+            ];
+        ]
+
+let monitoring_status_html ~name ~logs ~metrics =
+  let log_entries = parse_monitoring_response logs in
+  let metric_entries = parse_monitoring_response metrics in
   div
     ~a:[ a_id "monitoring-container"; a_class [ "space-y-6 py-4" ] ]
     [
-      (if log_entries = [] && metric_entries = [] then
-         div
-           ~a:[ a_class [ "text-center py-8" ] ]
-           [
-             i
-               ~a:
-                 [
-                   a_class
-                     [
-                       "fa-solid fa-circle-exclamation text-gray-500 text-2xl \
-                        mb-2";
-                     ];
-                 ]
-               [];
-             p
-               ~a:[ a_class [ "text-gray-400 mt-2" ] ]
-               [ txt "Monitoring unavailable for this unikernel." ];
-           ]
-       else div []);
-      (if log_entries <> [] then
-         div
-           ~a:
-             [ a_class [ "space-y-3" ]; Unsafe.string_attrib "x-data" log_data ]
-           [
-             div
-               ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
-               [
-                 i
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "fa-solid fa-list-check text-primary-400 text-sm \
-                            px-2";
-                         ];
-                     ]
-                   [];
-                 p
-                   ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
-                   [ txt "Log Sources" ];
-                 span
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "ml-auto text-xs font-semibold px-2 py-0.5 \
-                            rounded-full";
-                         ];
-                     ]
-                   [ txt (Fmt.str "%d sources" (List.length log_entries)) ];
-               ];
-             form
-               ~a:
-                 [
-                   a_enctype "multipart/form-data";
-                   Unsafe.string_attrib "hx-post"
-                     "/api/unikernel/monitoring/update";
-                   Unsafe.string_attrib "hx-swap" "innerHTML";
-                   Unsafe.string_attrib "hx-include" "#molly-csrf";
-                   Unsafe.string_attrib "hx-target" "#monitoring-container";
-                 ]
-               [
-                 input
-                   ~a:
-                     [
-                       a_input_type `Hidden;
-                       a_name "unikernel_name";
-                       a_value name;
-                     ]
-                   ();
-                 input
-                   ~a:
-                     [
-                       a_input_type `Hidden;
-                       a_name "command";
-                       Unsafe.string_attrib ":value" "getCommand()";
-                     ]
-                   ();
-                 div
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 \
-                            gap-2 max-h-72 overflow-y-auto pr-1 scrollbar-thin";
-                         ];
-                     ]
-                   [
-                     render_log_picker ~source:"*"
-                       ~default_level:default_log_level ~value:"defaultLevel";
-                   ];
-                 (if other_logs <> [] then
-                    div
+      (match (log_entries, metric_entries) with
+      | Error err, _ | _, Error err ->
+          div
+            ~a:[ a_class [ "text-center py-8" ] ]
+            [
+              i
+                ~a:
+                  [
+                    a_class
                       [
-                        div
-                          ~a:[ a_class [ "mt-4 mb-2" ] ]
-                          [
-                            button
-                              ~a:
-                                [
-                                  a_button_type `Button;
-                                  a_class
-                                    [
-                                      "font-semibold text-primary-400 \
-                                       hover:text-primary-300";
-                                    ];
-                                  a_style
-                                    "cursor: pointer; text-decoration: \
-                                     underline;";
-                                  Unsafe.string_attrib "@click"
-                                    "advancedLogs = !advancedLogs";
-                                ]
-                              [
-                                span
-                                  ~a:
-                                    [
-                                      Unsafe.string_attrib "x-text"
-                                        "advancedLogs ? 'Less logging options' \
-                                         : 'More logging options'";
-                                    ]
-                                  [];
-                              ];
-                          ];
-                        div
-                          ~a:
-                            [
-                              Unsafe.string_attrib "x-show" "advancedLogs";
-                              a_class
-                                [
-                                  "grid grid-cols-1 md:grid-cols-2 \
-                                   lg:grid-cols-3 gap-2 max-h-72 \
-                                   overflow-y-auto pr-1 scrollbar-thin";
-                                ];
-                            ]
-                          (List.map
-                             (fun (s, l) ->
-                               render_log_picker ~source:s ~default_level:l
-                                 ~value:(Printf.sprintf "logs['%s']" s))
-                             other_logs);
-                      ]
-                  else div []);
-                 div
-                   ~a:[ a_class [ "mt-4" ] ]
-                   [
-                     Utils.button_component ~extra_css:"font-bold"
-                       ~btn_type:`Primary_full ~attribs:[]
-                       ~content:(txt "Update Logging") ();
-                   ];
-               ];
-           ]
-       else div []);
-      hr ();
-      (if metric_entries <> [] then
-         div
-           ~a:
-             [
-               a_class [ "space-y-3" ];
-               Unsafe.string_attrib "x-data" metric_data;
-             ]
-           [
-             div
-               ~a:[ a_class [ "flex items-center gap-2 mb-2" ] ]
-               [
-                 i
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "fa-solid fa-chart-line text-primary-400 text-sm \
-                            px-2";
-                         ];
-                     ]
-                   [];
-                 p
-                   ~a:[ a_class [ "text-xl font-semibold text-primary-400" ] ]
-                   [ txt "Metrics Sources" ];
-                 span
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "ml-auto text-xs font-semibold px-2 py-0.5 \
-                            rounded-full";
-                         ];
-                     ]
-                   [
-                     txt
-                       (Fmt.str "%d/%d enabled"
-                          (List.length
-                             (List.filter
-                                (fun (_, s) -> String.equal s "enabled")
-                                metric_entries))
-                          (List.length metric_entries));
-                   ];
-               ];
-             form
-               ~a:
-                 [
-                   a_enctype "multipart/form-data";
-                   Unsafe.string_attrib "hx-post"
-                     "/api/unikernel/monitoring/update";
-                   Unsafe.string_attrib "hx-swap" "innerHTML";
-                   Unsafe.string_attrib "hx-include" "#molly-csrf";
-                   Unsafe.string_attrib "hx-target" "#monitoring-container";
-                 ]
-               [
-                 input
-                   ~a:
-                     [
-                       a_input_type `Hidden;
-                       a_name "unikernel_name";
-                       a_value name;
-                     ]
-                   ();
-                 input
-                   ~a:
-                     [
-                       a_input_type `Hidden;
-                       a_name "command";
-                       Unsafe.string_attrib ":value" "getCommand()";
-                     ]
-                   ();
-                 div
-                   ~a:
-                     [
-                       a_class
-                         [
-                           "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 \
-                            gap-2 max-h-72 overflow-y-auto pr-1 scrollbar-thin";
-                         ];
-                     ]
-                   (render_metric_picker ~source:"All metrics"
-                      ~value:"allMetrics" (-1)
-                   :: List.mapi
-                        (fun i (s, l) ->
-                          render_metric_picker ~source:s
-                            ~value:(Printf.sprintf "metrics['%s']" s)
-                            i)
-                        other_metrics);
-                 div
-                   ~a:[ a_class [ "mt-4" ] ]
-                   [
-                     Utils.button_component ~extra_css:"font-bold"
-                       ~btn_type:`Primary_full ~attribs:[]
-                       ~content:(txt "Update Metrics") ();
-                   ];
-               ];
-           ]
-       else div []);
+                        "fa-solid fa-circle-exclamation text-gray-500 text-2xl \
+                         mb-2";
+                      ];
+                  ]
+                [];
+              p
+                ~a:[ a_class [ "text-secondary-500 mt-2" ] ]
+                [ txt (Fmt.str "Monitoring parse error: %s" err) ];
+            ]
+      | Ok log_entries, Ok metric_entries ->
+          div
+            [
+              render_log_sources log_entries name;
+              hr ();
+              render_metric_sources metric_entries name;
+            ]);
     ]

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -14,7 +14,8 @@ let log_level_of_string s =
 
 let check_command command =
   let command = String.trim command in
-  if String.length command < 2 then Error "Command is too short"
+  if String.length command < 2 then
+    Error (Fmt.str "Command is too short. got %s" command)
   else
     let kind = String.sub command 0 1 in
     let rest = String.sub command 1 (String.length command - 1) in
@@ -50,18 +51,20 @@ let check_command command =
     in
     match kind with
     | "L" ->
-        if segments = [] || segments = [ "" ] then
-          Error "Empty logs command body"
+        if segments = [ "" ] then
+          Error (Fmt.str "Empty logs command body. got %s" command)
         else if List.for_all (validate_segment is_valid_level) segments then
           Ok command
-        else Error "Invalid logs configuration formatting"
+        else Error (Fmt.str "Invalid logs configuration. got %s" command)
     | "M" ->
-        if segments = [] || segments = [ "" ] then
-          Error "Empty metrics command body"
+        if segments = [ "" ] then
+          Error (Fmt.str "Empty metrics command body. got %s" command)
         else if List.for_all (validate_segment is_valid_metric) segments then
           Ok command
-        else Error "Invalid metrics configuration formatting"
-    | _ -> Error "Invalid command prefix (must be L or M)"
+        else Error (Fmt.str "Invalid metrics configuration. got %s" command)
+    | _ ->
+        Error
+          (Fmt.str "Invalid command prefix (must be L or M). got %s" command)
 
 let check_monitoring_response_format str =
   let str = String.trim str in
@@ -70,7 +73,7 @@ let check_monitoring_response_format str =
   else
     Error
       (Fmt.str
-         "Response from monitoring does not start with \"ok: \". Received: %s"
+         "Response from monitoring does not start with \"ok: \". Received: %S"
          str)
 
 let split_key_value_sources str =
@@ -80,10 +83,12 @@ let split_key_value_sources str =
          match acc with
          | Error err -> Error err
          | Ok lst -> (
-             match String.split_on_char ':' (String.trim s) with
-             | [ name; value ] ->
-                 Ok ((String.trim name, String.trim value) :: lst)
-             | _ -> Error "Invalid key-value source format"))
+             match String.split_on_char ':' s with
+             | [ name; value ] -> Ok ((name, value) :: lst)
+             | _ ->
+                 Error
+                   (Fmt.str "Invalid key-value source format. got %s"
+                      (String.escaped s))))
        (Ok [])
   |> function
   | Ok parsed_list -> Ok (List.rev parsed_list)

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -22,12 +22,11 @@ let check_command command =
     let segments = String.split_on_char ',' rest in
     let is_valid_level s = Result.is_ok (Logs.level_of_string s) in
     let is_valid_metric s =
-      match String.trim s with "enable" | "disable" -> true | _ -> false
+      match s with "enable" | "disable" -> true | _ -> false
     in
     (* currently source names can contain any characters: see https://github.com/dbuenzli/logs/issues/63*)
     let is_valid_source name = String.length name > 0 in
     let validate_segment is_valid_val segment =
-      let segment = String.trim segment in
       if String.length segment = 0 then false
       else if segment.[0] = '*' then
         let value = String.sub segment 2 (String.length segment - 2) in
@@ -213,10 +212,11 @@ let render_log_sources log_entries unikernel_name =
        '#854d0e', 'error': '#7f1d1d'}; return colors[level] || '#27272a'; }, \
        getTextColor(level) { const colors = {'info': '#bbf7d0', 'warning': \
        '#fef08a', 'error': '#fecaca'}; return colors[level] || '#a1a1aa'; }, \
-       getCommand() { let cmd = 'L*:' + this.defaultLevel; for (const [k, v] \
-       of Object.entries(this.logs)) { cmd += ',' + k + ':' + v; }  return \
-       cmd; } }"
-      default_log_level logs_dict
+       getCommand() { let cmd = 'L*:' + this.defaultLevel.trim(); for (const [k, v] \
+       of Object.entries(this.logs)) { cmd += ',' + k.trim() + ':' + v.trim(); }  return \
+       cmd.trim(); } }"
+      (Logs.level_to_string default_log_level)
+      logs_dict
   in
   match log_entries with
   | [] -> div [ txt "No log sources available for this unikernel." ]
@@ -366,8 +366,8 @@ let render_metric_sources metric_entries unikernel_name =
        getCommand() { const values = Object.values(this.metrics); if \
        (values.every(v => v)) { return 'M*:enable'; } if (values.every(v => \
        !v)) { return 'M*:disable'; } let cmd = 'M*:disable'; for (const [k, v] \
-       of Object.entries(this.metrics)) { if (v) { cmd += ',' + k + ':enable'; \
-       } } return cmd; } }"
+       of Object.entries(this.metrics)) { if (v) { cmd += ',' + k.trim() + ':enable'; \
+       } } return cmd.trim(); } }"
       metrics_dict
   in
   match metric_entries with

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -29,8 +29,10 @@ let check_command command =
     let validate_segment is_valid_val segment =
       if String.length segment = 0 then false
       else if segment.[0] = '*' then
-        let value = String.sub segment 2 (String.length segment - 2) in
-        is_valid_val value
+        if String.length segment >= 3 && segment.[1] = ':' then
+          let value = String.sub segment 2 (String.length segment - 2) in
+          is_valid_val value
+        else false
       else
         match String.split_on_char ':' segment with
         | [ name; val_ ] -> is_valid_source name && is_valid_val val_

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -214,9 +214,9 @@ let render_log_sources log_entries unikernel_name =
        '#854d0e', 'error': '#7f1d1d'}; return colors[level] || '#27272a'; }, \
        getTextColor(level) { const colors = {'info': '#bbf7d0', 'warning': \
        '#fef08a', 'error': '#fecaca'}; return colors[level] || '#a1a1aa'; }, \
-       getCommand() { let cmd = 'L*:' + this.defaultLevel.trim(); for (const [k, v] \
-       of Object.entries(this.logs)) { cmd += ',' + k.trim() + ':' + v.trim(); }  return \
-       cmd.trim(); } }"
+       getCommand() { let cmd = 'L*:' + this.defaultLevel.trim(); for (const \
+       [k, v] of Object.entries(this.logs)) { cmd += ',' + k.trim() + ':' + \
+       v.trim(); }  return cmd.trim(); } }"
       (Logs.level_to_string default_log_level)
       logs_dict
   in
@@ -368,8 +368,8 @@ let render_metric_sources metric_entries unikernel_name =
        getCommand() { const values = Object.values(this.metrics); if \
        (values.every(v => v)) { return 'M*:enable'; } if (values.every(v => \
        !v)) { return 'M*:disable'; } let cmd = 'M*:disable'; for (const [k, v] \
-       of Object.entries(this.metrics)) { if (v) { cmd += ',' + k.trim() + ':enable'; \
-       } } return cmd.trim(); } }"
+       of Object.entries(this.metrics)) { if (v) { cmd += ',' + k.trim() + \
+       ':enable'; } } return cmd.trim(); } }"
       metrics_dict
   in
   match metric_entries with

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -12,7 +12,6 @@ let check_command command =
       | "debug" | "info" | "warning" | "error" | "app" | "quiet" -> true
       | _ -> false
     in
-
     let is_valid_metric s =
       match String.trim s with "enable" | "disable" -> true | _ -> false
     in

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -9,13 +9,12 @@ let log_levels =
     Some Logs.App;
   ]
 
-let log_level_of_string s =
-  match Logs.level_of_string s with Ok v -> Ok v | Error err -> Error err
+let escape_string = String.escaped
 
 let check_command command =
   let command = String.trim command in
   if String.length command < 2 then
-    Error (Fmt.str "Command is too short. got %s" command)
+    Error (Fmt.str "Command is too short. got %s" (escape_string command))
   else
     let kind = String.sub command 0 1 in
     let rest = String.sub command 1 (String.length command - 1) in
@@ -41,19 +40,29 @@ let check_command command =
     match kind with
     | "L" ->
         if segments = [ "" ] then
-          Error (Fmt.str "Empty logs command body. got %s" command)
+          Error
+            (Fmt.str "Empty logs command body. got %s" (escape_string command))
         else if List.for_all (validate_segment is_valid_level) segments then
           Ok command
-        else Error (Fmt.str "Invalid logs configuration. got %s" command)
+        else
+          Error
+            (Fmt.str "Invalid logs configuration. got %s"
+               (escape_string command))
     | "M" ->
         if segments = [ "" ] then
-          Error (Fmt.str "Empty metrics command body. got %s" command)
+          Error
+            (Fmt.str "Empty metrics command body. got %s"
+               (escape_string command))
         else if List.for_all (validate_segment is_valid_metric) segments then
           Ok command
-        else Error (Fmt.str "Invalid metrics configuration. got %s" command)
+        else
+          Error
+            (Fmt.str "Invalid metrics configuration. got %s"
+               (escape_string command))
     | _ ->
         Error
-          (Fmt.str "Invalid command prefix (must be L or M). got %s" command)
+          (Fmt.str "Invalid command prefix (must be L or M). got %s"
+             (escape_string command))
 
 let check_monitoring_response_format str =
   let str = String.trim str in
@@ -62,8 +71,8 @@ let check_monitoring_response_format str =
   else
     Error
       (Fmt.str
-         "Response from monitoring does not start with \"ok: \". Received: %S"
-         str)
+         "Response from monitoring does not start with \"ok: \". Received: %s"
+         (escape_string str))
 
 let split_key_value_sources str =
   String.split_on_char ',' str
@@ -77,11 +86,9 @@ let split_key_value_sources str =
              | _ ->
                  Error
                    (Fmt.str "Invalid key-value source format. got %s"
-                      (String.escaped s))))
+                      (escape_string s))))
        (Ok [])
-  |> function
-  | Ok parsed_list -> Ok (List.rev parsed_list)
-  | Error err -> Error err
+  |> Result.map List.rev
 
 let parse_monitoring_response str =
   match check_monitoring_response_format str with
@@ -180,32 +187,22 @@ let render_metric_picker ~source ~value index =
     ]
 
 let render_log_sources log_entries unikernel_name =
-  let parsed_log_entries =
-    List.map
-      (fun (s, l) ->
-        let parsed_level =
-          match Logs.level_of_string l with
-          | Ok level -> level
-          | Error _ -> Some Logs.Info
-        in
-        (s, parsed_level))
-      log_entries
+  let default, other =
+    List.partition (fun (l, _) -> String.equal l "*") log_entries
   in
   let default_log_level =
-    match List.assoc_opt "*" parsed_log_entries with
-    | Some l -> l
-    | None -> Some Logs.Info
-  in
-  let other_logs =
-    List.filter (fun (s, _) -> not (String.equal s "*")) parsed_log_entries
+    match default with
+    | [] -> Some Logs.Info
+    | [ (_, l) ] -> l
+    | _ -> (* ?? *) Some Logs.Info
   in
   let logs_dict =
     String.concat ", "
       (List.map
          (fun (s, l) ->
-           Printf.sprintf "'%s': '%s'" (String.escaped s)
+           Printf.sprintf "'%s': '%s'" (escape_string s)
              (Logs.level_to_string l))
-         other_logs)
+         other)
   in
   let log_data =
     Printf.sprintf
@@ -289,7 +286,7 @@ let render_log_sources log_entries unikernel_name =
                   render_log_picker ~source:"*" ~default_level:default_log_level
                     ~value:"defaultLevel";
                 ];
-              (if other_logs <> [] then
+              (if other <> [] then
                  div
                    [
                      div
@@ -335,7 +332,7 @@ let render_log_sources log_entries unikernel_name =
                           (fun (s, l) ->
                             render_log_picker ~source:s ~default_level:l
                               ~value:(Printf.sprintf "logs['%s']" s))
-                          other_logs);
+                          other);
                    ]
                else div []);
               div
@@ -355,9 +352,7 @@ let render_metric_sources metric_entries unikernel_name =
   let metrics_dict =
     String.concat ", "
       (List.map
-         (fun (s, l) ->
-           let is_en = if String.equal l "enabled" then "true" else "false" in
-           Printf.sprintf "'%s': %s" (String.escaped s) is_en)
+         (fun (s, m) -> Printf.sprintf "'%s': %B" (escape_string s) m)
          other_metrics)
   in
   let metric_data =
@@ -404,10 +399,8 @@ let render_metric_sources metric_entries unikernel_name =
                   txt
                     (Fmt.str "%d/%d enabled"
                        (List.length
-                          (List.filter
-                             (fun (_, s) -> String.equal s "enabled")
-                             metric_entries))
-                       (List.length metric_entries));
+                          (List.filter (fun (_, m) -> m) other_metrics))
+                       (List.length other_metrics));
                 ];
             ];
           form
@@ -464,9 +457,39 @@ let render_metric_sources metric_entries unikernel_name =
             ];
         ]
 
+let parse_log_entries entries =
+  List.fold_left
+    (fun acc (s, l) ->
+      match acc with
+      | Error _ as e -> e
+      | Ok acc -> (
+          match Logs.level_of_string l with
+          | Ok level -> Ok ((s, level) :: acc)
+          | Error (`Msg e) -> Error e))
+    (Ok []) entries
+
+let parse_metrics_entries entries =
+  List.fold_left
+    (fun acc (s, m) ->
+      match acc with
+      | Error _ as e -> e
+      | Ok acc -> (
+          match m with
+          | "enabled" -> Ok ((s, true) :: acc)
+          | "disabled" -> Ok ((s, false) :: acc)
+          | x ->
+              Error
+                (Fmt.str "expected either enabled or disabled, got %s"
+                   (escape_string x))))
+    (Ok []) entries
+
 let monitoring_status_html ~name ~logs ~metrics =
-  let log_entries = parse_monitoring_response logs in
-  let metric_entries = parse_monitoring_response metrics in
+  let log_entries =
+    Result.bind (parse_monitoring_response logs) parse_log_entries
+  in
+  let metric_entries =
+    Result.bind (parse_monitoring_response metrics) parse_metrics_entries
+  in
   div
     ~a:[ a_id "monitoring-container"; a_class [ "space-y-6 py-4" ] ]
     [

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -24,20 +24,8 @@ let check_command command =
     let is_valid_metric s =
       match String.trim s with "enable" | "disable" -> true | _ -> false
     in
-    let is_valid_source name =
-      let name = String.trim name in
-      String.length name > 0
-      &&
-      let rec loop i =
-        if i >= String.length name then true
-        else
-          match name.[i] with
-          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' | '*' ->
-              loop (i + 1)
-          | _ -> false
-      in
-      loop 0
-    in
+    (* currently source names can contain any characters: see https://github.com/dbuenzli/logs/issues/63*)
+    let is_valid_source name = String.length name > 0 in
     let validate_segment is_valid_val segment =
       let segment = String.trim segment in
       if String.length segment = 0 then false

--- a/monitoring.ml
+++ b/monitoring.ml
@@ -1,5 +1,17 @@
 open Tyxml_html
 
+let log_levels =
+  [
+    Some Logs.Debug;
+    Some Logs.Info;
+    Some Logs.Warning;
+    Some Logs.Error;
+    Some Logs.App;
+  ]
+
+let log_level_of_string s =
+  match Logs.level_of_string s with Ok v -> Ok v | Error err -> Error err
+
 let check_command command =
   let command = String.trim command in
   if String.length command < 2 then Error "Command is too short"
@@ -7,11 +19,7 @@ let check_command command =
     let kind = String.sub command 0 1 in
     let rest = String.sub command 1 (String.length command - 1) in
     let segments = String.split_on_char ',' rest in
-    let is_valid_level s =
-      match String.trim s with
-      | "debug" | "info" | "warning" | "error" | "app" | "quiet" -> true
-      | _ -> false
-    in
+    let is_valid_level s = Result.is_ok (Logs.level_of_string s) in
     let is_valid_metric s =
       match String.trim s with "enable" | "disable" -> true | _ -> false
     in
@@ -89,8 +97,6 @@ let parse_monitoring_response str =
       | Error err -> Error err)
   | Error err -> Error err
 
-let log_levels = [ "debug"; "info"; "warning"; "error"; "app"; "quiet" ]
-
 let render_log_picker ~source ~default_level ~value =
   div
     ~a:
@@ -130,9 +136,9 @@ let render_log_picker ~source ~default_level ~value =
            (fun l ->
              option
                ~a:
-                 ([ a_value l ]
+                 ([ a_value (Logs.level_to_string l) ]
                  @ if l = default_level then [ a_selected () ] else [])
-               (txt l))
+               (txt (Logs.level_to_string l)))
            log_levels);
     ]
 
@@ -180,17 +186,31 @@ let render_metric_picker ~source ~value index =
     ]
 
 let render_log_sources log_entries unikernel_name =
+  let parsed_log_entries =
+    List.map
+      (fun (s, l) ->
+        let parsed_level =
+          match Logs.level_of_string l with
+          | Ok level -> level
+          | Error _ -> Some Logs.Info
+        in
+        (s, parsed_level))
+      log_entries
+  in
   let default_log_level =
-    match List.assoc_opt "*" log_entries with Some l -> l | None -> "info"
+    match List.assoc_opt "*" parsed_log_entries with
+    | Some l -> l
+    | None -> Some Logs.Info
   in
   let other_logs =
-    List.filter (fun (s, _) -> not (String.equal s "*")) log_entries
+    List.filter (fun (s, _) -> not (String.equal s "*")) parsed_log_entries
   in
   let logs_dict =
     String.concat ", "
       (List.map
          (fun (s, l) ->
-           Printf.sprintf "'%s': '%s'" (String.escaped s) (String.escaped l))
+           Printf.sprintf "'%s': '%s'" (String.escaped s)
+             (Logs.level_to_string l))
          other_logs)
   in
   let log_data =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -22,8 +22,7 @@ module Main
     (Management_Dns : Dns_client_mirage.S)
     (KV_ASSETS : Mirage_kv.RO)
     (BLOCK : Mirage_block.S)
-    (Http_client : Http_mirage_client.S)
-    (Management_Domain : sig end) =
+    (Http_client : Http_mirage_client.S) =
 struct
   module Paf = Paf_mirage.Make (S.TCP)
   module Liveliness = Liveliness_checks.Make (S)

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1269,6 +1269,101 @@ struct
     Middleware.http_response reqd ~title:"Unikernel Information"
       ~data:response_data `OK
 
+  let unikernel_monitoring_status happy_eyeballs management_hostname
+      unikernel_name _token_or_cookie _user reqd =
+    let open Lwt.Infix in
+    let target_r =
+      match
+        Domain_name.of_string
+          (Configuration.name_to_str unikernel_name ^ "." ^ management_hostname)
+      with
+      | Ok dn -> Ok (Domain_name.to_string dn)
+      | Error e -> Error e
+    in
+    match target_r with
+    | Error (`Msg err) ->
+        Middleware.http_response ~api_meth:true reqd ~title:"Monitoring Error"
+          ~data:(`String ("Invalid domain name or IP: " ^ err))
+          `Bad_request
+    | Ok target_str ->
+        let query cmd =
+          Management_HE.connect happy_eyeballs target_str [ 2323 ] >>= function
+          | Error (`Msg err) -> Lwt.return_error err
+          | Ok ((_ip, _port), flow) -> (
+              Management_S.TCP.write flow (Cstruct.of_string cmd) >>= function
+              | Error _ ->
+                  Management_S.TCP.close flow >>= fun () ->
+                  Lwt.return_error "Failed to write"
+              | Ok () -> (
+                  Management_S.TCP.read flow >>= function
+                  | Error _ ->
+                      Management_S.TCP.close flow >>= fun () ->
+                      Lwt.return_error "Failed to read"
+                  | Ok `Eof ->
+                      Management_S.TCP.close flow >>= fun () ->
+                      Lwt.return_error "EOF"
+                  | Ok (`Data cstruct) ->
+                      Management_S.TCP.close flow >>= fun () ->
+                      Lwt.return_ok (Cstruct.to_string cstruct)))
+        in
+        query "l*" >>= fun logs ->
+        query "m*" >>= fun metrics ->
+        let html =
+          Monitoring.monitoring_status_html
+            ~name:(Configuration.name_to_str unikernel_name)
+            ~logs ~metrics
+        in
+        let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
+        reply reqd body `OK
+
+  let unikernel_monitoring_update happy_eyeballs management_hostname _user
+      multipart_body reqd =
+    match
+      ( Map.find_opt "command" multipart_body,
+        Map.find_opt "unikernel_name" multipart_body )
+    with
+    | Some (_, command), Some (_, unikernel_name) -> (
+        let open Lwt.Infix in
+        let target_r =
+          match
+            Domain_name.of_string (unikernel_name ^ "." ^ management_hostname)
+          with
+          | Ok dn -> Ok (Domain_name.to_string dn)
+          | Error e -> Error e
+        in
+        match target_r with
+        | Error (`Msg err) ->
+            Middleware.http_response ~api_meth:false reqd
+              ~title:"Monitoring Error"
+              ~data:(`String ("Invalid domain name or IP: " ^ err))
+              `Bad_request
+        | Ok target_str -> (
+            Management_HE.connect happy_eyeballs target_str [ 2323 ]
+            >>= function
+            | Error (`Msg err) ->
+                Middleware.http_response ~api_meth:false reqd
+                  ~title:"Monitoring Unavailable" ~data:(`String err)
+                  `Bad_request
+            | Ok ((_ip, _port), flow) -> (
+                Logs.info (fun m -> m "Passing the command %s" command);
+                Management_S.TCP.write flow (Cstruct.of_string command)
+                >>= function
+                | Error e ->
+                    Management_S.TCP.close flow >>= fun () ->
+                    Middleware.http_response ~api_meth:false reqd
+                      ~title:"Monitoring Error"
+                      ~data:(`String "Failed to write to monitoring port")
+                      `Internal_server_error
+                | Ok () ->
+                    Management_S.TCP.close flow >>= fun () ->
+                    Middleware.http_response ~api_meth:false reqd
+                      ~title:"Monitoring Success"
+                      ~data:(`String "Updated successfully") `OK)))
+    | _ ->
+        Middleware.http_response ~api_meth:false reqd ~title:"Monitoring Error"
+          ~data:(`String "Missing unikernel name or command in request.")
+          `Bad_request
+
   let unikernel_info_one stack store albatross unikernel_name _
       (user : User_model.user) reqd =
     (* TODO use uuid in the future *)
@@ -3231,6 +3326,18 @@ struct
                 authenticate store reqd
                   (albatross_instance "/unikernel/deploy"
                      (deploy_form stack store http_client)))
+        | "/api/unikernel/monitoring/status" ->
+            check_meth `GET (fun () ->
+                authenticate store reqd ~check_token:true ~api_meth:true
+                  (unikernel
+                     (unikernel_monitoring_status management_happy_eyeballs
+                        management_hostname)))
+        | "/api/unikernel/monitoring/update" ->
+            check_meth `POST (fun () ->
+                authenticate ~check_token:true ~api_meth:true store reqd
+                  (extract_multipart_csrf_token
+                     (unikernel_monitoring_update management_happy_eyeballs
+                        management_hostname)))
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1261,30 +1261,51 @@ struct
     let target = target ^ "." ^ Domain_name.to_string management_domain in
     Management_HE.connect happy_eyeballs target [ port ] >>= function
     | Error (`Msg err) ->
-        Logs.info (fun m -> m "Failed to connect to %s:%d" target port);
-        Lwt.return_error err
+        Logs.info (fun m ->
+            m "Failed to connect to %s on port %d with error: %s" target port
+              err);
+        Lwt.return_error
+          (Fmt.str "Failed to connect to %s on port %d with error: %s" target
+             port err)
     | Ok ((_ip, _port), flow) -> (
         Management_S.TCP.write flow (Cstruct.of_string command) >>= function
-        | Error _ ->
+        | Error err ->
             Management_S.TCP.close flow >>= fun () ->
             Logs.info (fun m ->
-                m "Failed to write to %s:%d -> %s" target port command);
+                m
+                  "Failed to write to %s on port %d (command: %s) with error: \
+                   %a"
+                  target port command Management_S.TCP.pp_write_error err);
             Lwt.return_error
-              (Fmt.str "Failed to write to %s:%d -> %s" target port command)
+              (Fmt.str
+                 "Failed to write to %s on port %d (command: %s) with error: %a"
+                 target port command Management_S.TCP.pp_write_error err)
         | Ok () -> (
             Management_S.TCP.read flow >>= function
-            | Error _ ->
+            | Error err ->
                 Management_S.TCP.close flow >>= fun () ->
                 Logs.info (fun m ->
-                    m "Failed to read from %s:%d -> %s" target port command);
+                    m
+                      "Failed to read from %s on port %d (command: %s) with \
+                       error: %a"
+                      target port command Management_S.TCP.pp_error err);
                 Lwt.return_error
-                  (Fmt.str "Failed to read from %s:%d -> %s" target port command)
+                  (Fmt.str
+                     "Failed to read from %s on port %d (command: %s) with \
+                      error: %a"
+                     target port command Management_S.TCP.pp_error err)
             | Ok `Eof ->
                 Management_S.TCP.close flow >>= fun () ->
                 Logs.info (fun m ->
-                    m "Received eof while reading from %s:%d -> %s" target port
-                      command);
-                Lwt.return_error "EOF"
+                    m
+                      "Received eof while reading from %s on port %d (command: \
+                       %s)"
+                      target port command);
+                Lwt.return_error
+                  (Fmt.str
+                     "Received eof while reading from %s on port %d (command: \
+                      %s)"
+                     target port command)
             | Ok (`Data cstruct) ->
                 Management_S.TCP.close flow >>= fun () ->
                 Lwt.return_ok (Cstruct.to_string cstruct)))
@@ -1300,13 +1321,23 @@ struct
       ~target:(Configuration.name_to_str unikernel_name)
       management_domain
     >>= fun metrics ->
-    let html =
-      Monitoring.monitoring_status_html
-        ~name:(Configuration.name_to_str unikernel_name)
-        ~logs ~metrics
-    in
-    let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
-    reply reqd body `OK
+    match (logs, metrics) with
+    | Ok logs_data, Ok metrics_data ->
+        let html =
+          Monitoring.monitoring_status_html
+            ~name:(Configuration.name_to_str unikernel_name)
+            ~logs:logs_data ~metrics:metrics_data
+        in
+        let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
+        reply reqd body `OK
+    | Error err, _ ->
+        reply reqd
+          (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
+          `Bad_request
+    | _, Error err ->
+        reply reqd
+          (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
+          `Bad_request
 
   let unikernel_monitoring_update happy_eyeballs management_domain _user
       multipart_body reqd =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -14,10 +14,25 @@ module K = struct
   let port =
     let doc = Arg.info ~doc:"HTTP listen port." [ "port" ] in
     Mirage_runtime.register_arg Arg.(value & opt int 8080 doc)
+
+  let management_dns_server =
+    let doc =
+      Arg.info ~doc:"DNS server for the management network"
+        [ "management-dns-server" ]
+    in
+    Mirage_runtime.register_arg Arg.(required & opt (some string) None doc)
+
+  let management_host_name =
+    let doc =
+      Arg.info ~doc:"Host name for the management network"
+        [ "management-hostname" ]
+    in
+    Mirage_runtime.register_arg Arg.(required & opt (some string) None doc)
 end
 
 module Main
     (S : Tcpip.Stack.V4V6)
+    (Management_S : Tcpip.Stack.V4V6)
     (KV_ASSETS : Mirage_kv.RO)
     (BLOCK : Mirage_block.S)
     (Http_client : Http_mirage_client.S) =
@@ -28,6 +43,8 @@ struct
   module HE = Happy_eyeballs_mirage.Make (S)
   module Mailer = Sendmail_mirage.Make (S.TCP) (HE)
   module Dns = Dns_client_mirage.Make (S) (HE)
+  module Management_HE = Happy_eyeballs_mirage.Make (Management_S)
+  module Management_Dns = Dns_client_mirage.Make (Management_S) (Management_HE)
 
   let recipient email =
     match Colombe_emile.to_path email with
@@ -54,6 +71,28 @@ struct
         | Ok addr ->
             Logs.info (fun m ->
                 m "Resolved `AAAA record for %s to %a"
+                  (Domain_name.to_string destination)
+                  Ipaddr.V6.pp addr);
+            Ipaddr.Set.of_list [ Ipaddr.V6 addr ] |> Lwt.return_ok
+        | Error e -> Lwt.return_error e)
+
+  let getaddrinfo_management dns : Management_HE.getaddrinfo =
+   fun record_type destination ->
+    match record_type with
+    | `A -> (
+        Management_Dns.gethostbyname dns destination >>= function
+        | Ok addr ->
+            Logs.info (fun m ->
+                m "[Management] Resolved `A record for %s to %a"
+                  (Domain_name.to_string destination)
+                  Ipaddr.V4.pp addr);
+            Ipaddr.Set.of_list [ Ipaddr.V4 addr ] |> Lwt.return_ok
+        | Error e -> Lwt.return_error e)
+    | `AAAA -> (
+        Management_Dns.gethostbyname6 dns destination >>= function
+        | Ok addr ->
+            Logs.info (fun m ->
+                m "[Management] Resolved `AAAA record for %s to %a"
                   (Domain_name.to_string destination)
                   Ipaddr.V6.pp addr);
             Ipaddr.Set.of_list [ Ipaddr.V6 addr ] |> Lwt.return_ok
@@ -2877,8 +2916,9 @@ struct
     in
     Lwt.async loop
 
-  let request_handler stack albatross_instances js_file css_file imgs store
-      http_client happy_eyeballs flow (_ipaddr, _port) reqd =
+  let request_handler stack management_happy_eyeballs management_hostname
+      albatross_instances js_file css_file imgs store http_client happy_eyeballs
+      flow (_ipaddr, _port) reqd =
     Lwt.async (fun () ->
         let bad_request () =
           Middleware.http_response reqd
@@ -3252,7 +3292,7 @@ struct
           Fmt.(option ~none:(any "unknown") H1.Request.pp_hum)
           request)
 
-  let start stack assets storage http_client =
+  let start stack management_stack assets storage http_client =
     js_contents assets >>= fun js_file ->
     css_contents assets >>= fun css_file ->
     images assets >>= fun imgs ->
@@ -3261,6 +3301,19 @@ struct
     | Ok store ->
         let dns = Dns.create (stack, HE.create stack) in
         let happy_eyeballs = HE.create ~getaddrinfo:(getaddrinfo dns) stack in
+        let management_dns =
+          let nameserver =
+            `Plaintext (Ipaddr.of_string_exn (K.management_dns_server ()), 53)
+          in
+          Management_Dns.create ~nameservers:(`Udp, [ nameserver ])
+            (management_stack, Management_HE.create management_stack)
+        in
+        let management_happy_eyeballs =
+          Management_HE.create
+            ~getaddrinfo:(getaddrinfo_management management_dns)
+            management_stack
+        in
+        let management_hostname = K.management_host_name () in
         Albatross_state.init_all stack (Store.configurations store)
         >>= fun albatross_instances ->
         let albatross_instances = ref albatross_instances in
@@ -3268,8 +3321,9 @@ struct
         Logs.info (fun m ->
             m "Initialise an HTTP server (no HTTPS) on port %u" port);
         let request_handler =
-          request_handler stack albatross_instances js_file css_file imgs store
-            http_client happy_eyeballs
+          request_handler stack management_happy_eyeballs management_hostname
+            albatross_instances js_file css_file imgs store http_client
+            happy_eyeballs
         in
         Paf.init ~port (S.tcp stack) >>= fun service ->
         Lwt.pause () >>= fun () ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1347,23 +1347,35 @@ struct
     with
     | Some (_, command), Some (_, unikernel_name) -> (
         let open Lwt.Infix in
-        send_monitoring_tcp_command happy_eyeballs ~command
-          ~target:unikernel_name management_domain
-        >>= function
+        match Monitoring.check_command command with
+        | Ok command -> (
+            send_monitoring_tcp_command happy_eyeballs ~command
+              ~target:unikernel_name management_domain
+            >>= function
+            | Error err ->
+                reply reqd
+                  (Fmt.str
+                     "<p class=\"text-secondary-500\">An error occured: %s</p>"
+                     err)
+                  `Bad_request
+            | Ok response ->
+                reply reqd
+                  (Fmt.str
+                     "<p class=\"text-primary-500\">Updated successfully: \
+                      %s</p>"
+                     response)
+                  `OK)
         | Error err ->
+            Logs.info (fun m ->
+                m "Command is malformated. Command: %s, Received error: %s"
+                  command err);
             reply reqd
-              (Fmt.str
-                 "<p class=\"text-secondary-500\">An error occured: %s</p>" err)
-              `Bad_request
-        | Ok response ->
-            reply reqd
-              (Fmt.str
-                 "<p class=\"text-primary-500\">Updated successfully: %s</p>"
-                 response)
-              `OK)
+              (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
+              `Bad_request)
     | _ ->
-        Middleware.http_response ~api_meth:false reqd ~title:"Monitoring Error"
-          ~data:(`String "Missing unikernel name or command in request.")
+        reply reqd
+          "<p class=\"text-secondary-500\">Missing unikernel name or command \
+           in request.</p>"
           `Bad_request
 
   let unikernel_info_one stack store albatross unikernel_name _

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1261,51 +1261,45 @@ struct
     let target = target ^ "." ^ Domain_name.to_string management_domain in
     Management_HE.connect happy_eyeballs target [ port ] >>= function
     | Error (`Msg err) ->
-        Logs.info (fun m ->
-            m "Failed to connect to %s on port %d with error: %s" target port
-              err);
-        Lwt.return_error
-          (Fmt.str "Failed to connect to %s on port %d with error: %s" target
-             port err)
+        let msg =
+          Fmt.str "[monitoring] Failed to connect to %s:%d, error %s" target
+            port err
+        in
+        Logs.info (fun m -> m "%s" msg);
+        Lwt.return_error msg
     | Ok ((_ip, _port), flow) -> (
         Management_S.TCP.write flow (Cstruct.of_string command) >>= function
         | Error err ->
             Management_S.TCP.close flow >>= fun () ->
-            Logs.info (fun m ->
-                m
-                  "Failed to write to %s on port %d (command: %s) with error: \
-                   %a"
-                  target port command Management_S.TCP.pp_write_error err);
-            Lwt.return_error
-              (Fmt.str
-                 "Failed to write to %s on port %d (command: %s) with error: %a"
-                 target port command Management_S.TCP.pp_write_error err)
+            let msg =
+              Fmt.str
+                "[monitoring] Failed to write to %s:%d (command: %s), error %a"
+                target port command Management_S.TCP.pp_write_error err
+            in
+            Logs.info (fun m -> m "%s" msg);
+            Lwt.return_error msg
         | Ok () -> (
             Management_S.TCP.read flow >>= function
             | Error err ->
                 Management_S.TCP.close flow >>= fun () ->
-                Logs.info (fun m ->
-                    m
-                      "Failed to read from %s on port %d (command: %s) with \
-                       error: %a"
-                      target port command Management_S.TCP.pp_error err);
-                Lwt.return_error
-                  (Fmt.str
-                     "Failed to read from %s on port %d (command: %s) with \
-                      error: %a"
-                     target port command Management_S.TCP.pp_error err)
+                let msg =
+                  Fmt.str
+                    "[monitoring] Failed to read from %s:%d (command: %s), \
+                     error %a"
+                    target port command Management_S.TCP.pp_error err
+                in
+                Logs.info (fun m -> m "%s" msg);
+                Lwt.return_error msg
             | Ok `Eof ->
                 Management_S.TCP.close flow >>= fun () ->
-                Logs.info (fun m ->
-                    m
-                      "Received eof while reading from %s on port %d (command: \
-                       %s)"
-                      target port command);
-                Lwt.return_error
-                  (Fmt.str
-                     "Received eof while reading from %s on port %d (command: \
-                      %s)"
-                     target port command)
+                let msg =
+                  Fmt.str
+                    "[monitoring] Received eof while reading from %s:%d \
+                     (command: %s)"
+                    target port command
+                in
+                Logs.info (fun m -> m "%s" msg);
+                Lwt.return_error msg
             | Ok (`Data cstruct) ->
                 Management_S.TCP.close flow >>= fun () ->
                 Lwt.return_ok (Cstruct.to_string cstruct)))

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1351,11 +1351,15 @@ struct
           ~target:unikernel_name management_domain
         >>= function
         | Error err ->
-            Middleware.http_response ~api_meth:false reqd
-              ~title:"Monitoring Error" ~data:(`String err) `Bad_request
+            reply reqd
+              (Fmt.str
+                 "<p class=\"text-secondary-500\">An error occured: %s</p>" err)
+              `Bad_request
         | Ok response ->
-            Middleware.http_response ~api_meth:false reqd
-              ~title:"Monitoring Success" ~data:(`String "Updated successfully")
+            reply reqd
+              (Fmt.str
+                 "<p class=\"text-primary-500\">Updated successfully: %s</p>"
+                 response)
               `OK)
     | _ ->
         Middleware.http_response ~api_meth:false reqd ~title:"Monitoring Error"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -14,28 +14,16 @@ module K = struct
   let port =
     let doc = Arg.info ~doc:"HTTP listen port." [ "port" ] in
     Mirage_runtime.register_arg Arg.(value & opt int 8080 doc)
-
-  let management_dns_server =
-    let doc =
-      Arg.info ~doc:"DNS server for the management network"
-        [ "management-dns-server" ]
-    in
-    Mirage_runtime.register_arg Arg.(required & opt (some string) None doc)
-
-  let management_host_name =
-    let doc =
-      Arg.info ~doc:"Host name for the management network"
-        [ "management-hostname" ]
-    in
-    Mirage_runtime.register_arg Arg.(required & opt (some string) None doc)
 end
 
 module Main
     (S : Tcpip.Stack.V4V6)
     (Management_S : Tcpip.Stack.V4V6)
+    (Management_Dns : Dns_client_mirage.S)
     (KV_ASSETS : Mirage_kv.RO)
     (BLOCK : Mirage_block.S)
-    (Http_client : Http_mirage_client.S) =
+    (Http_client : Http_mirage_client.S)
+    (Management_Domain : sig end) =
 struct
   module Paf = Paf_mirage.Make (S.TCP)
   module Liveliness = Liveliness_checks.Make (S)
@@ -44,7 +32,6 @@ struct
   module Mailer = Sendmail_mirage.Make (S.TCP) (HE)
   module Dns = Dns_client_mirage.Make (S) (HE)
   module Management_HE = Happy_eyeballs_mirage.Make (Management_S)
-  module Management_Dns = Dns_client_mirage.Make (Management_S) (Management_HE)
 
   let recipient email =
     match Colombe_emile.to_path email with
@@ -3399,7 +3386,8 @@ struct
           Fmt.(option ~none:(any "unknown") H1.Request.pp_hum)
           request)
 
-  let start stack management_stack assets storage http_client =
+  let start stack management_stack management_dns assets storage http_client
+      management_domain_name =
     js_contents assets >>= fun js_file ->
     css_contents assets >>= fun css_file ->
     images assets >>= fun imgs ->
@@ -3408,19 +3396,17 @@ struct
     | Ok store ->
         let dns = Dns.create (stack, HE.create stack) in
         let happy_eyeballs = HE.create ~getaddrinfo:(getaddrinfo dns) stack in
-        let management_dns =
-          let nameserver =
-            `Plaintext (Ipaddr.of_string_exn (K.management_dns_server ()), 53)
-          in
-          Management_Dns.create ~nameservers:(`Udp, [ nameserver ])
-            (management_stack, Management_HE.create management_stack)
-        in
         let management_happy_eyeballs =
           Management_HE.create
             ~getaddrinfo:(getaddrinfo_management management_dns)
             management_stack
         in
-        let management_hostname = K.management_host_name () in
+        Logs.info (fun m ->
+            m "Domain from DHCP lease: %s"
+              (Option.value management_domain_name ~default:"none given"));
+        let management_hostname =
+          Option.value management_domain_name ~default:"management"
+        in
         Albatross_state.init_all stack (Store.configurations store)
         >>= fun albatross_instances ->
         let albatross_instances = ref albatross_instances in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1255,52 +1255,55 @@ struct
     Middleware.http_response reqd ~title:"Unikernel Information"
       ~data:response_data `OK
 
+  let send_management_tcp_command happy_eyeballs ~command ~target =
+    let port = 2323 in
+    Management_HE.connect happy_eyeballs target [ port ] >>= function
+    | Error (`Msg err) ->
+        Logs.info (fun m -> m "Failed to connect to %s:%d" target port);
+        Lwt.return_error err
+    | Ok ((_ip, _port), flow) -> (
+        Management_S.TCP.write flow (Cstruct.of_string command) >>= function
+        | Error _ ->
+            Management_S.TCP.close flow >>= fun () ->
+            Logs.info (fun m ->
+                m "Failed to write to %s:%d -> %s" target port command);
+            Lwt.return_error
+              (Fmt.str "Failed to write to %s:%d -> %s" target port command)
+        | Ok () -> (
+            Management_S.TCP.read flow >>= function
+            | Error _ ->
+                Management_S.TCP.close flow >>= fun () ->
+                Logs.info (fun m ->
+                    m "Failed to read from %s:%d -> %s" target port command);
+                Lwt.return_error
+                  (Fmt.str "Failed to read from %s:%d -> %s" target port command)
+            | Ok `Eof ->
+                Management_S.TCP.close flow >>= fun () ->
+                Logs.info (fun m ->
+                    m "Received eof while reading from %s:%d -> %s" target port
+                      command);
+                Lwt.return_error "EOF"
+            | Ok (`Data cstruct) ->
+                Management_S.TCP.close flow >>= fun () ->
+                Lwt.return_ok (Cstruct.to_string cstruct)))
+
   let unikernel_monitoring_status happy_eyeballs management_hostname
       unikernel_name _token_or_cookie _user reqd =
     let open Lwt.Infix in
-    let target_r =
-      match
-        Domain_name.of_string
-          (Configuration.name_to_str unikernel_name ^ "." ^ management_hostname)
-      with
-      | Ok dn -> Ok (Domain_name.to_string dn)
-      | Error e -> Error e
+    let target =
+      Configuration.name_to_str unikernel_name ^ "." ^ management_hostname
     in
-    match target_r with
-    | Error (`Msg err) ->
-        Middleware.http_response ~api_meth:true reqd ~title:"Monitoring Error"
-          ~data:(`String ("Invalid domain name or IP: " ^ err))
-          `Bad_request
-    | Ok target_str ->
-        let query cmd =
-          Management_HE.connect happy_eyeballs target_str [ 2323 ] >>= function
-          | Error (`Msg err) -> Lwt.return_error err
-          | Ok ((_ip, _port), flow) -> (
-              Management_S.TCP.write flow (Cstruct.of_string cmd) >>= function
-              | Error _ ->
-                  Management_S.TCP.close flow >>= fun () ->
-                  Lwt.return_error "Failed to write"
-              | Ok () -> (
-                  Management_S.TCP.read flow >>= function
-                  | Error _ ->
-                      Management_S.TCP.close flow >>= fun () ->
-                      Lwt.return_error "Failed to read"
-                  | Ok `Eof ->
-                      Management_S.TCP.close flow >>= fun () ->
-                      Lwt.return_error "EOF"
-                  | Ok (`Data cstruct) ->
-                      Management_S.TCP.close flow >>= fun () ->
-                      Lwt.return_ok (Cstruct.to_string cstruct)))
-        in
-        query "l*" >>= fun logs ->
-        query "m*" >>= fun metrics ->
-        let html =
-          Monitoring.monitoring_status_html
-            ~name:(Configuration.name_to_str unikernel_name)
-            ~logs ~metrics
-        in
-        let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
-        reply reqd body `OK
+    send_management_tcp_command happy_eyeballs ~command:"l*" ~target
+    >>= fun logs ->
+    send_management_tcp_command happy_eyeballs ~command:"m*" ~target
+    >>= fun metrics ->
+    let html =
+      Monitoring.monitoring_status_html
+        ~name:(Configuration.name_to_str unikernel_name)
+        ~logs ~metrics
+    in
+    let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
+    reply reqd body `OK
 
   let unikernel_monitoring_update happy_eyeballs management_hostname _user
       multipart_body reqd =
@@ -1310,41 +1313,15 @@ struct
     with
     | Some (_, command), Some (_, unikernel_name) -> (
         let open Lwt.Infix in
-        let target_r =
-          match
-            Domain_name.of_string (unikernel_name ^ "." ^ management_hostname)
-          with
-          | Ok dn -> Ok (Domain_name.to_string dn)
-          | Error e -> Error e
-        in
-        match target_r with
-        | Error (`Msg err) ->
+        let target = unikernel_name ^ "." ^ management_hostname in
+        send_management_tcp_command happy_eyeballs ~command ~target >>= function
+        | Error err ->
             Middleware.http_response ~api_meth:false reqd
-              ~title:"Monitoring Error"
-              ~data:(`String ("Invalid domain name or IP: " ^ err))
-              `Bad_request
-        | Ok target_str -> (
-            Management_HE.connect happy_eyeballs target_str [ 2323 ]
-            >>= function
-            | Error (`Msg err) ->
-                Middleware.http_response ~api_meth:false reqd
-                  ~title:"Monitoring Unavailable" ~data:(`String err)
-                  `Bad_request
-            | Ok ((_ip, _port), flow) -> (
-                Logs.debug (fun m -> m "Passing the command %s" command);
-                Management_S.TCP.write flow (Cstruct.of_string command)
-                >>= function
-                | Error e ->
-                    Management_S.TCP.close flow >>= fun () ->
-                    Middleware.http_response ~api_meth:false reqd
-                      ~title:"Monitoring Error"
-                      ~data:(`String "Failed to write to monitoring port")
-                      `Internal_server_error
-                | Ok () ->
-                    Management_S.TCP.close flow >>= fun () ->
-                    Middleware.http_response ~api_meth:false reqd
-                      ~title:"Monitoring Success"
-                      ~data:(`String "Updated successfully") `OK)))
+              ~title:"Monitoring Error" ~data:(`String err) `Bad_request
+        | Ok response ->
+            Middleware.http_response ~api_meth:false reqd
+              ~title:"Monitoring Success" ~data:(`String "Updated successfully")
+              `OK)
     | _ ->
         Middleware.http_response ~api_meth:false reqd ~title:"Monitoring Error"
           ~data:(`String "Missing unikernel name or command in request.")

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1325,14 +1325,8 @@ struct
         in
         let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
         reply reqd body `OK
-    | Error err, _ ->
-        reply reqd
-          (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
-          `Bad_request
-    | _, Error err ->
-        reply reqd
-          (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
-          `Bad_request
+    | Error err, _ -> reply reqd (Utils.display_alert err `Error) `Bad_request
+    | _, Error err -> reply reqd (Utils.display_alert err `Error) `Bad_request
 
   let unikernel_monitoring_update happy_eyeballs management_domain _user
       multipart_body reqd =
@@ -1349,28 +1343,25 @@ struct
             >>= function
             | Error err ->
                 reply reqd
-                  (Fmt.str
-                     "<p class=\"text-secondary-500\">An error occured: %s</p>"
-                     err)
+                  (Utils.display_alert ("An error occured: " ^ err) `Error)
                   `Bad_request
             | Ok response ->
                 reply reqd
-                  (Fmt.str
-                     "<p class=\"text-primary-500\">Updated successfully: \
-                      %s</p>"
-                     response)
+                  (Utils.display_alert
+                     ("Updated succesfully: " ^ response)
+                     `Success)
                   `OK)
         | Error err ->
-            Logs.info (fun m ->
-                m "Command is malformated. Command: %s, Received error: %s"
-                  command err);
-            reply reqd
-              (Fmt.str "<p class=\"text-secondary-500\">%s</p>" err)
-              `Bad_request)
+            let msg =
+              Fmt.str "Command is malformated. Command: %s, Received error: %s"
+                command err
+            in
+            Logs.info (fun m -> m "%s" msg);
+            reply reqd (Utils.display_alert msg `Error) `Bad_request)
     | _ ->
         reply reqd
-          "<p class=\"text-secondary-500\">Missing unikernel name or command \
-           in request.</p>"
+          (Utils.display_alert "Missing unikernel name or command in request."
+             `Error)
           `Bad_request
 
   let unikernel_info_one stack store albatross unikernel_name _

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -1255,8 +1255,10 @@ struct
     Middleware.http_response reqd ~title:"Unikernel Information"
       ~data:response_data `OK
 
-  let send_management_tcp_command happy_eyeballs ~command ~target =
+  let send_monitoring_tcp_command happy_eyeballs ~command ~target
+      management_domain =
     let port = 2323 in
+    let target = target ^ "." ^ Domain_name.to_string management_domain in
     Management_HE.connect happy_eyeballs target [ port ] >>= function
     | Error (`Msg err) ->
         Logs.info (fun m -> m "Failed to connect to %s:%d" target port);
@@ -1287,15 +1289,16 @@ struct
                 Management_S.TCP.close flow >>= fun () ->
                 Lwt.return_ok (Cstruct.to_string cstruct)))
 
-  let unikernel_monitoring_status happy_eyeballs management_hostname
+  let unikernel_monitoring_status happy_eyeballs management_domain
       unikernel_name _token_or_cookie _user reqd =
     let open Lwt.Infix in
-    let target =
-      Configuration.name_to_str unikernel_name ^ "." ^ management_hostname
-    in
-    send_management_tcp_command happy_eyeballs ~command:"l*" ~target
+    send_monitoring_tcp_command happy_eyeballs ~command:"l*"
+      ~target:(Configuration.name_to_str unikernel_name)
+      management_domain
     >>= fun logs ->
-    send_management_tcp_command happy_eyeballs ~command:"m*" ~target
+    send_monitoring_tcp_command happy_eyeballs ~command:"m*"
+      ~target:(Configuration.name_to_str unikernel_name)
+      management_domain
     >>= fun metrics ->
     let html =
       Monitoring.monitoring_status_html
@@ -1305,7 +1308,7 @@ struct
     let body = Format.asprintf "%a" (Tyxml_html.pp_elt ()) html in
     reply reqd body `OK
 
-  let unikernel_monitoring_update happy_eyeballs management_hostname _user
+  let unikernel_monitoring_update happy_eyeballs management_domain _user
       multipart_body reqd =
     match
       ( Map.find_opt "command" multipart_body,
@@ -1313,8 +1316,9 @@ struct
     with
     | Some (_, command), Some (_, unikernel_name) -> (
         let open Lwt.Infix in
-        let target = unikernel_name ^ "." ^ management_hostname in
-        send_management_tcp_command happy_eyeballs ~command ~target >>= function
+        send_monitoring_tcp_command happy_eyeballs ~command
+          ~target:unikernel_name management_domain
+        >>= function
         | Error err ->
             Middleware.http_response ~api_meth:false reqd
               ~title:"Monitoring Error" ~data:(`String err) `Bad_request
@@ -2974,7 +2978,7 @@ struct
     in
     Lwt.async loop
 
-  let request_handler stack management_happy_eyeballs management_hostname
+  let request_handler stack management_happy_eyeballs management_domain
       albatross_instances js_file css_file imgs store http_client happy_eyeballs
       flow (_ipaddr, _port) reqd =
     Lwt.async (fun () ->
@@ -3294,13 +3298,13 @@ struct
                 authenticate store reqd ~check_token:true ~api_meth:true
                   (unikernel
                      (unikernel_monitoring_status management_happy_eyeballs
-                        management_hostname)))
+                        management_domain)))
         | "/api/unikernel/monitoring/update" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (extract_multipart_csrf_token
                      (unikernel_monitoring_update management_happy_eyeballs
-                        management_hostname)))
+                        management_domain)))
         | "/api/unikernel/destroy" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
@@ -3377,11 +3381,12 @@ struct
             ~getaddrinfo:(getaddrinfo_management management_dns)
             management_stack
         in
-        Logs.info (fun m ->
-            m "Domain from DHCP lease: %s"
-              (Option.value management_domain_name ~default:"none given"));
-        let management_hostname =
-          Option.value management_domain_name ~default:"management"
+        let management_domain =
+          match management_domain_name with
+          | None -> failwith "No domain name from DHCP lease"
+          | Some domain_name ->
+              Logs.info (fun m -> m "Domain from DHCP lease: %s" domain_name);
+              Domain_name.of_string_exn domain_name
         in
         Albatross_state.init_all stack (Store.configurations store)
         >>= fun albatross_instances ->
@@ -3390,7 +3395,7 @@ struct
         Logs.info (fun m ->
             m "Initialise an HTTP server (no HTTPS) on port %u" port);
         let request_handler =
-          request_handler stack management_happy_eyeballs management_hostname
+          request_handler stack management_happy_eyeballs management_domain
             albatross_instances js_file css_file imgs store http_client
             happy_eyeballs
         in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -466,6 +466,7 @@ struct
               `Internal_server_error
         | Ok () -> f `Cookie user reqd)
 
+  (* reply can send html. useMiddleware.http_response when you want to return json *)
   let reply reqd ?(content_type = "text/plain") ?(header_list = []) data status
       =
     let h =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -47,7 +47,7 @@ struct
     | `A -> (
         Dns.gethostbyname dns destination >>= function
         | Ok addr ->
-            Logs.info (fun m ->
+            Logs.debug (fun m ->
                 m "Resolved `A record for %s to %a"
                   (Domain_name.to_string destination)
                   Ipaddr.V4.pp addr);
@@ -56,7 +56,7 @@ struct
     | `AAAA -> (
         Dns.gethostbyname6 dns destination >>= function
         | Ok addr ->
-            Logs.info (fun m ->
+            Logs.debug (fun m ->
                 m "Resolved `AAAA record for %s to %a"
                   (Domain_name.to_string destination)
                   Ipaddr.V6.pp addr);
@@ -69,7 +69,7 @@ struct
     | `A -> (
         Management_Dns.gethostbyname dns destination >>= function
         | Ok addr ->
-            Logs.info (fun m ->
+            Logs.debug (fun m ->
                 m "[Management] Resolved `A record for %s to %a"
                   (Domain_name.to_string destination)
                   Ipaddr.V4.pp addr);
@@ -78,7 +78,7 @@ struct
     | `AAAA -> (
         Management_Dns.gethostbyname6 dns destination >>= function
         | Ok addr ->
-            Logs.info (fun m ->
+            Logs.debug (fun m ->
                 m "[Management] Resolved `AAAA record for %s to %a"
                   (Domain_name.to_string destination)
                   Ipaddr.V6.pp addr);
@@ -1332,7 +1332,7 @@ struct
                   ~title:"Monitoring Unavailable" ~data:(`String err)
                   `Bad_request
             | Ok ((_ip, _port), flow) -> (
-                Logs.info (fun m -> m "Passing the command %s" command);
+                Logs.debug (fun m -> m "Passing the command %s" command);
                 Management_S.TCP.write flow (Cstruct.of_string command)
                 >>= function
                 | Error e ->

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -308,8 +308,7 @@ let unikernel_single_layout ~unikernel_name ~instance_name
                                    Unsafe.string_attrib "hx-get"
                                      ("/api/unikernel/monitoring/status?unikernel="
                                     ^ unikernel_name_str);
-                                   Unsafe.string_attrib "hx-trigger"
-                                     "intersect once";
+                                   Unsafe.string_attrib "hx-trigger" "intersect";
                                    Unsafe.string_attrib "hx-swap" "innerHTML";
                                  ]
                                [

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -272,6 +272,74 @@ let unikernel_single_layout ~unikernel_name ~instance_name
                       ];
                   ];
                 div
+                  ~a:
+                    [
+                      a_class
+                        [
+                          "rounded my-4 text-white p-4 border \
+                           border-primary-700 bg-gray-800";
+                        ];
+                    ]
+                  [
+                    div
+                      ~a:
+                        [ a_class [ "flex justify-between items-center mb-4" ] ]
+                      [
+                        p
+                          ~a:[ a_class [ "text-xl font-semibold" ] ]
+                          [ txt "Monitoring & Diagnostics" ];
+                        Modal_dialog.modal_dialog
+                          ~modal_title:"Configure Monitoring"
+                          ~button_content:
+                            (span
+                               ~a:[ a_class [ "flex items-center gap-2" ] ]
+                               [
+                                 i
+                                   ~a:[ a_class [ "fa-solid fa-sliders px-2" ] ]
+                                   [];
+                                 txt "Configure Monitoring";
+                               ])
+                          ~button_type:`Primary_outlined
+                          ~content:
+                            (div
+                               ~a:
+                                 [
+                                   a_class [ "w-full min-w-96" ];
+                                   Unsafe.string_attrib "hx-get"
+                                     ("/api/unikernel/monitoring/status?unikernel="
+                                    ^ unikernel_name_str);
+                                   Unsafe.string_attrib "hx-trigger"
+                                     "intersect once";
+                                   Unsafe.string_attrib "hx-swap" "innerHTML";
+                                 ]
+                               [
+                                 div
+                                   ~a:
+                                     [
+                                       a_class
+                                         [
+                                           "flex items-center gap-2 \
+                                            text-gray-400 text-sm py-4";
+                                         ];
+                                     ]
+                                   [
+                                     i
+                                       ~a:
+                                         [
+                                           a_class
+                                             [
+                                               "fa-solid fa-circle-notch \
+                                                fa-spin";
+                                             ];
+                                         ]
+                                       [];
+                                     txt "Loading monitoring status...";
+                                   ];
+                               ])
+                          ();
+                      ];
+                  ];
+                div
                   ~a:[ a_class [ "grid grid-cols-2" ] ]
                   [
                     div

--- a/utils.ml
+++ b/utils.ml
@@ -710,3 +710,15 @@ let user_policy_usage policy unikernels blocks : user_policy_usage =
     cpu_usage_count;
     bridge_usage_count;
   }
+
+let display_alert text alert_type =
+  let open Tyxml_html in
+  let class_ =
+    match alert_type with
+    | `Error -> "border-secondary-400 text-secondary-500"
+    | `Success -> "border-primary-400 text-primary-500"
+  in
+  Format.asprintf "%a" (Tyxml_html.pp_elt ())
+    (div
+       [ p [ txt text ] ]
+       ~a:[ a_class [ "my-4 p-4 border rounded-lg " ^ class_ ] ])


### PR DESCRIPTION
In this PR we add a new network stack to mollymawk: called management.
To ensure names can resolve well, we have two new flags: 
- `management-dns-server`: which can be the ip of which dnsvizor is running on the management network as well, and
-  `management-host-name`: the hostname given to this dnsvizor

We then have two main api endpoints:
- `/api/unikernel/monitoring/status`: which checks if monitoring is available for the vm, and what log options and metrics are available
- `/api/unikernel/monitoring/update`: which allows mollymawk to send tcp commands to update the log options and metrics

We have a new file `monitoring.ml` which contains all the html and javascript needed to render the logs and metrics to the UI and also to call the two API endpoints above. We use `htmx` so we don't have to refresh the page.

The main functions contained here are:

* **`getColor(level)`**: Returns a background hex color code matching the specified log severity level (`info`, `warning`, `error`), falling back to dark gray.
* **`getTextColor(level)`**: Returns a high-contrast light text hex color code tailored to fit on top of the corresponding log level background.
* **`getCommand()` [Log version]**:  Generates the log configurations into a single, comma-separated command string (e.g., `L*:info,source:debug`).
* **`get allMetrics()`**: Evaluates to `true` if every single tracked metric in the dictionary is currently enabled, otherwise returns `false`.
* **`set allMetrics(value)`**: Simultaneously sets all individual metric toggles to either `true` or `false` when a master global switch is flipped.
* **`getCommand()` [Metric version]**: Generates the metrics configurations into a single comman-separated command string.


## Screenshots

<img width="2259" height="844" alt="image" src="https://github.com/user-attachments/assets/48edf8bb-bbcf-4a78-9ead-3961d43f3eb9" />

<img width="2259" height="1186" alt="image" src="https://github.com/user-attachments/assets/45de2729-23b8-4ea9-99b7-5dc8dfed2d7c" />

<img width="2259" height="1463" alt="image" src="https://github.com/user-attachments/assets/3e5cc5fb-3154-4a0e-814c-805307c42e22" />

<img width="768" height="548" alt="image" src="https://github.com/user-attachments/assets/61642e3e-0eed-4af5-b109-f00ed7a66fa7" />
