### PR TITLE
Rename name value from molly-csrf-input  to molly_csrf

### DIFF
--- a/utils.ml
+++ b/utils.ml
@@ -232,7 +232,7 @@ let csrf_form_input csrf =
         [
           a_input_type `Hidden;
           a_id "molly-csrf";
-          a_name "molly-csrf-input";
+          a_name "molly_csrf";
           a_value csrf;
         ]
       ())


### PR DESCRIPTION
This change is needed so when we use htmx to send post request the right name for checking the csrf token on the backend is used.