### PR TITLE
Get unikernel usage stats and metrics

### DIFF
--- a/albatross.ml
+++ b/albatross.ml
@@ -345,6 +345,26 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     in
     continue_reading name dec d tls_flow
 
+  let stats_data name f tls_flow d =
+    let dec = function
+      | Error s ->
+          Logs.err (fun m ->
+              m "albatross stop reading stats data %a: error %s"
+                Vmm_core.Name.pp name s);
+          Error ()
+      | Ok (hdr, `Data (`Stats_data d)) -> f hdr.Vmm_commands.name d
+      | Ok (_, `Success (`String _)) ->
+          (* ignore the success subscribed *)
+          Ok ()
+      | Ok w ->
+          Logs.warn (fun m ->
+              m "albatross unexpected reply, need stats data, got %a"
+                (Vmm_commands.pp_wire ~verbose:false)
+                w);
+          Ok ()
+    in
+    continue_reading name dec d tls_flow
+
   let raw_query (stack : S.t) t ?(name = Vmm_core.Name.root) certificates cmd
       ?push f =
     let open Lwt.Infix in
@@ -593,6 +613,14 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     | Ok (vmm_name, certificates) ->
         raw_query stack t ~name:vmm_name certificates cmd
           (block_data vmm_name f)
+
+  let query_stats stack t ~domain f =
+    let cmd = `Stats_cmd `Stats_subscribe in
+    match certs t domain dot_name cmd with
+    | Error str -> Lwt.return (Error str)
+    | Ok (vmm_name, certificates) ->
+        raw_query stack t ~name:vmm_name certificates cmd
+          (stats_data vmm_name f)
 
   let set_policy stack t ~domain policy =
     let open Lwt.Infix in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -591,7 +591,9 @@ struct
         in
         update_albatross_status state (`Incompatible, reply, "unikernel info");
         Error message
+
   let stats_src = Logs.Src.create "albatross-stats"
+
   let unikernels_stats stack state user_name =
     (* TODO: change this callback to the scaling callback later *)
     let cb name st =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -614,15 +614,6 @@ struct
              err)
     | Ok () -> Ok ()
 
-  let all_unikernels_stats stack albatross_instances users =
-    Lwt_list.map_p
-      (fun (_instance_name, (instance : Albatross.t)) ->
-        Lwt.all
-          (List.map
-             (fun user -> unikernels_stats stack instance user.User_model.name)
-             users))
-      (Albatross.Albatross_map.bindings albatross_instances)
-
   let sign_up reqd =
     let now = Mirage_ptime.now () in
     let csrf = Middleware.generate_csrf_cookie now reqd in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3203,7 +3203,7 @@ struct
           Albatross.Albatross_map.iter
             (fun instance_name instance ->
               let key = (user.User_model.name, instance_name) in
-              Hashtbl.add valid_keys key ();
+              Hashtbl.replace valid_keys key ();
               if not (Hashtbl.mem active_streams key) then begin
                 Logs.debug ~src:stats_src (fun m ->
                     m "Spawning new stats stream for %s on %s"
@@ -3212,7 +3212,7 @@ struct
                 let p =
                   spawn_stats_stream user.User_model.name instance_name instance
                 in
-                Hashtbl.add active_streams key p
+                Hashtbl.replace active_streams key p
               end)
             current_instances)
         current_users;

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3619,7 +3619,6 @@ struct
         Lwt.pause () >>= fun () ->
         start_background_scheduler happy_eyeballs stack store
           albatross_instances http_client;
-        Lwt.pause () >>= fun () ->
         start_background_scaler_scheduler stack store albatross_instances;
         th
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3159,18 +3159,75 @@ struct
     Lwt.async loop
 
   let start_background_scaler_scheduler stack store albatross_instances_ref =
+    let active_streams = Hashtbl.create 5 in
+    let spawn_stats_stream user_name instance_name instance =
+      let rec stream_loop () =
+        let open Lwt.Infix in
+        Lwt.catch
+          (fun () ->
+            unikernels_stats stack instance user_name >>= function
+            | Ok () -> Lwt.return_unit
+            | Error err ->
+                Logs.debug ~src:stats_src (fun m ->
+                    m "Stats stream for %s on %s failed: %s"
+                      (Configuration.name_to_str user_name)
+                      (Configuration.name_to_str instance_name)
+                      err);
+                Lwt.return_unit)
+          (function
+            | Lwt.Canceled ->
+                Logs.debug ~src:stats_src (fun m ->
+                    m "Stats stream for %s on %s cancelled (user deleted)."
+                      (Configuration.name_to_str user_name)
+                      (Configuration.name_to_str instance_name));
+                Lwt.return_unit
+            | exn ->
+                Logs.info ~src:stats_src (fun m ->
+                    m "Exception in stats stream for %s on %s: %s"
+                      (Configuration.name_to_str user_name)
+                      (Configuration.name_to_str instance_name)
+                      (Printexc.to_string exn));
+                Lwt.return_unit)
+        >>= fun () -> Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop
+      in
+      stream_loop ()
+    in
     let rec loop () =
-      Lwt.catch
-        (fun () ->
-          Logs.info (fun m -> m "Starting CPU memory checks...");
-          all_unikernels_stats stack !albatross_instances_ref
-            (Store.users store))
-        (fun exn ->
-          Logs.err (fun m ->
-              m "CPU memory checks failed: %s" (Printexc.to_string exn));
-          Lwt.return [])
-      (* TODO: change 5 minutes here to a value from a dedicated scaler module later*)
-      >>= fun _ -> Mirage_sleep.ns (Duration.of_min 5) >>= loop
+      Lwt.pause () >>= fun () ->
+      let current_users = Store.users store in
+      let current_instances = !albatross_instances_ref in
+      let valid_keys = Hashtbl.create 7 in
+      let open Lwt.Infix in
+      List.iter
+        (fun user ->
+          Albatross.Albatross_map.iter
+            (fun instance_name instance ->
+              let key = (user.User_model.name, instance_name) in
+              Hashtbl.add valid_keys key ();
+              if not (Hashtbl.mem active_streams key) then begin
+                Logs.debug ~src:stats_src (fun m ->
+                    m "Spawning new stats stream for %s on %s"
+                      (Configuration.name_to_str user.User_model.name)
+                      (Configuration.name_to_str instance_name));
+                let p =
+                  spawn_stats_stream user.User_model.name instance_name instance
+                in
+                Hashtbl.add active_streams key p
+              end)
+            current_instances)
+        current_users;
+      let to_remove =
+        Hashtbl.fold
+          (fun key p acc ->
+            if not (Hashtbl.mem valid_keys key) then begin
+              Lwt.cancel p;
+              key :: acc
+            end
+            else acc)
+          active_streams []
+      in
+      List.iter (fun key -> Hashtbl.remove active_streams key) to_remove;
+      Mirage_sleep.ns (Duration.of_sec 30) >>= loop
     in
     Lwt.async loop
 

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -591,11 +591,11 @@ struct
         in
         update_albatross_status state (`Incompatible, reply, "unikernel info");
         Error message
-
+  let stats_src = Logs.Src.create "albatross-stats"
   let unikernels_stats stack state user_name =
     (* TODO: change this callback to the scaling callback later *)
     let cb name st =
-      Logs.info (fun m ->
+      Logs.debug ~src:stats_src (fun m ->
           m "Got stats for VM %s (user %s): %a"
             (Vmm_core.Name.to_string name)
             (Configuration.name_to_str user_name)

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3162,7 +3162,6 @@ struct
     let active_streams = Hashtbl.create 5 in
     let spawn_stats_stream user_name instance_name instance =
       let rec stream_loop () =
-        let open Lwt.Infix in
         Lwt.catch
           (fun () ->
             unikernels_stats stack instance user_name >>= function
@@ -3196,8 +3195,7 @@ struct
       Lwt.pause () >>= fun () ->
       let current_users = Store.users store in
       let current_instances = !albatross_instances_ref in
-      let valid_keys = Hashtbl.create 7 in
-      let open Lwt.Infix in
+      let valid_keys = Hashtbl.create 5 in
       List.iter
         (fun user ->
           Albatross.Albatross_map.iter

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3187,6 +3187,7 @@ struct
                       (Configuration.name_to_str user_name)
                       (Configuration.name_to_str instance_name)
                       (Printexc.to_string exn));
+                Hashtbl.remove active_streams (user_name, instance_name);
                 Lwt.return_unit)
       in
       stream_loop ()

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3165,6 +3165,22 @@ struct
     in
     Lwt.async loop
 
+  let start_background_scaler_scheduler stack store albatross_instances_ref =
+    let rec loop () =
+      Lwt.catch
+        (fun () ->
+          Logs.info (fun m -> m "Starting CPU memory checks...");
+          all_unikernels_stats stack !albatross_instances_ref
+            (Store.users store))
+        (fun exn ->
+          Logs.err (fun m ->
+              m "CPU memory checks failed: %s" (Printexc.to_string exn));
+          Lwt.return [])
+      (* TODO: change 5 minutes here to a value from a dedicated scaler module later*)
+      >>= fun _ -> Mirage_sleep.ns (Duration.of_min 5) >>= loop
+    in
+    Lwt.async loop
+
   let request_handler stack management_happy_eyeballs management_domain
       albatross_instances js_file css_file imgs store http_client happy_eyeballs
       flow (_ipaddr, _port) reqd =
@@ -3601,5 +3617,7 @@ struct
         Lwt.pause () >>= fun () ->
         start_background_scheduler happy_eyeballs stack store
           albatross_instances http_client;
+        Lwt.pause () >>= fun () ->
+        start_background_scaler_scheduler stack store albatross_instances;
         th
 end

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3166,8 +3166,7 @@ struct
         Lwt.catch
           (fun () ->
             unikernels_stats stack instance user_name >>= function
-            | Ok () ->
-                Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop
+            | Ok () -> Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop
             | Error err ->
                 Logs.debug ~src:stats_src (fun m ->
                     m "Stats stream for %s on %s failed: %s"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -592,6 +592,35 @@ struct
         update_albatross_status state (`Incompatible, reply, "unikernel info");
         Error message
 
+  let unikernels_stats stack state user_name =
+    (* TODO: change this callback to the scaling callback later *)
+    let cb name st =
+      Logs.info (fun m ->
+          m "Got stats for VM %s (user %s): %a"
+            (Vmm_core.Name.to_string name)
+            (Configuration.name_to_str user_name)
+            Vmm_core.Stats.pp st);
+      Ok ()
+    in
+    Albatross_state.query_stats stack state ~domain:user_name cb >|= function
+    | Error err ->
+        Error
+          (Fmt.str
+             "Error fetching stats for user %s, with albatross instance %s: %s"
+             (Configuration.name_to_str user_name)
+             (Configuration.name_to_str state.configuration.name)
+             err)
+    | Ok () -> Ok ()
+
+  let all_unikernels_stats stack albatross_instances users =
+    Lwt_list.map_p
+      (fun (_instance_name, (instance : Albatross.t)) ->
+        Lwt.all
+          (List.map
+             (fun user -> unikernels_stats stack instance user.User_model.name)
+             users))
+      (Albatross.Albatross_map.bindings albatross_instances)
+
   let sign_up reqd =
     let now = Mirage_ptime.now () in
     let csrf = Middleware.generate_csrf_cookie now reqd in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3166,14 +3166,15 @@ struct
         Lwt.catch
           (fun () ->
             unikernels_stats stack instance user_name >>= function
-            | Ok () -> Lwt.return_unit
+            | Ok () ->
+                Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop
             | Error err ->
                 Logs.debug ~src:stats_src (fun m ->
                     m "Stats stream for %s on %s failed: %s"
                       (Configuration.name_to_str user_name)
                       (Configuration.name_to_str instance_name)
                       err);
-                Lwt.return_unit)
+                Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop)
           (function
             | Lwt.Canceled ->
                 Logs.debug ~src:stats_src (fun m ->
@@ -3187,8 +3188,7 @@ struct
                       (Configuration.name_to_str user_name)
                       (Configuration.name_to_str instance_name)
                       (Printexc.to_string exn));
-                Lwt.return_unit)
-        >>= fun () -> Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop
+                Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop)
       in
       stream_loop ()
     in

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3187,7 +3187,7 @@ struct
                       (Configuration.name_to_str user_name)
                       (Configuration.name_to_str instance_name)
                       (Printexc.to_string exn));
-                Mirage_sleep.ns (Duration.of_sec 10) >>= stream_loop)
+                Lwt.return_unit)
       in
       stream_loop ()
     in


### PR DESCRIPTION
In this PR we just print the stats to console, but this should change in the upcoming PRs that actually use this data to scale up or down the unikernel. We get stats like this:

```
2026-05-28T21:43:31-00:00: [INFO] [application] Got stats for VM :unipi-2 (user robur): utime 2.010000 stime 0.790000 maxrss 11393 ixrss 0 idrss 0 isrss 0 minflt 11098 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 11524 nivcsw 94
virtual-size 137240576 rss 11393 text-size 5 data-size 89 stack-size 89 runtime 2800000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 308 input_errors 0 output_packets 206 output_errors 0 collisions 0 input_bytes 20196 output_bytes 51583 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1219 input_errors 0 output_packets 5709 output_errors 0 collisions 0 input_bytes 66019 output_bytes 7899635 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:31-00:00: [INFO] [application] Got stats for VM :unipi (user robur): utime 1.000000 stime 0.310000 maxrss 11425 ixrss 0 idrss 0 isrss 0 minflt 11127 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 10774 nivcsw 67
virtual-size 137240576 rss 11425 text-size 5 data-size 89 stack-size 89 runtime 1310000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 7 input_errors 0 output_packets 515 output_errors 0 collisions 0 input_bytes 1550 output_bytes 71861 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1026 input_errors 0 output_packets 5906 output_errors 0 collisions 0 input_bytes 56792 output_bytes 8206464 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:31-00:00: [INFO] [application] Got stats for VM :ny-hello (user robur): utime 0.000000 stime 0.000000 maxrss 1057 ixrss 0 idrss 0 isrss 0 minflt 794 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 2 nivcsw 1
virtual-size 36577280 rss 1057 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004611.318651
no vmm stats

2026-05-28T21:43:31-00:00: [INFO] [application] Got stats for VM :hello-test-arg (user robur): utime 0.000000 stime 0.000000 maxrss 1075 ixrss 0 idrss 0 isrss 0 minflt 781 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 4 nivcsw 2
virtual-size 170795008 rss 1075 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004611.318651
no vmm stats

2026-05-28T21:43:31-00:00: [INFO] [application] Got stats for VM :dnsvizor-management (user robur): utime 1.290000 stime 0.480000 maxrss 4161 ixrss 0 idrss 0 isrss 0 minflt 3860 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 21510 nivcsw 94
virtual-size 36577280 rss 4161 text-size 5 data-size 89 stack-size 89 runtime 1770000 cow 0 start 1779999026.051737
no vmm stats
bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 112 input_errors 0 output_packets 541 output_errors 0 collisions 0 input_bytes 15298 output_bytes 63766 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:41-00:00: [INFO] [application] Got stats for VM :unipi-2 (user robur): utime 2.020000 stime 0.790000 maxrss 11393 ixrss 0 idrss 0 isrss 0 minflt 11098 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 11542 nivcsw 94
virtual-size 137240576 rss 11393 text-size 5 data-size 89 stack-size 89 runtime 2810000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 309 input_errors 0 output_packets 206 output_errors 0 collisions 0 input_bytes 20258 output_bytes 51583 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1219 input_errors 0 output_packets 5709 output_errors 0 collisions 0 input_bytes 66019 output_bytes 7899635 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:41-00:00: [INFO] [application] Got stats for VM :unipi (user robur): utime 1.000000 stime 0.310000 maxrss 11425 ixrss 0 idrss 0 isrss 0 minflt 11127 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 10792 nivcsw 67
virtual-size 137240576 rss 11425 text-size 5 data-size 89 stack-size 89 runtime 1310000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 7 input_errors 0 output_packets 516 output_errors 0 collisions 0 input_bytes 1550 output_bytes 71923 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1026 input_errors 0 output_packets 5906 output_errors 0 collisions 0 input_bytes 56792 output_bytes 8206464 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:41-00:00: [INFO] [application] Got stats for VM :ny-hello (user robur): utime 0.000000 stime 0.000000 maxrss 1075 ixrss 0 idrss 0 isrss 0 minflt 804 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 4 nivcsw 3
virtual-size 36577280 rss 1075 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004621.317651
no vmm stats

2026-05-28T21:43:41-00:00: [INFO] [application] Got stats for VM :hello-test-arg (user robur): utime 0.000000 stime 0.000000 maxrss 1043 ixrss 0 idrss 0 isrss 0 minflt 769 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 2 nivcsw 1
virtual-size 170795008 rss 1043 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004621.317651
no vmm stats

2026-05-28T21:43:41-00:00: [INFO] [application] Got stats for VM :dnsvizor-management (user robur): utime 1.290000 stime 0.480000 maxrss 4161 ixrss 0 idrss 0 isrss 0 minflt 3860 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 21549 nivcsw 94
virtual-size 36577280 rss 4161 text-size 5 data-size 89 stack-size 89 runtime 1770000 cow 0 start 1779999026.051737
no vmm stats
bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 112 input_errors 0 output_packets 542 output_errors 0 collisions 0 input_bytes 15298 output_bytes 63828 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:51-00:00: [INFO] [application] Got stats for VM :unipi-2 (user robur): utime 2.020000 stime 0.790000 maxrss 11393 ixrss 0 idrss 0 isrss 0 minflt 11098 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 11560 nivcsw 94
virtual-size 137240576 rss 11393 text-size 5 data-size 89 stack-size 89 runtime 2810000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 309 input_errors 0 output_packets 206 output_errors 0 collisions 0 input_bytes 20258 output_bytes 51583 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1219 input_errors 0 output_packets 5709 output_errors 0 collisions 0 input_bytes 66019 output_bytes 7899635 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:51-00:00: [INFO] [application] Got stats for VM :unipi (user robur): utime 1.000000 stime 0.310000 maxrss 11425 ixrss 0 idrss 0 isrss 0 minflt 11127 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 10808 nivcsw 67
virtual-size 137240576 rss 11425 text-size 5 data-size 89 stack-size 89 runtime 1310000 cow 0 start 1779999026.051737
no vmm stats
bridge management flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 7 input_errors 0 output_packets 516 output_errors 0 collisions 0 input_bytes 1550 output_bytes 71923 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0

bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 1026 input_errors 0 output_packets 5906 output_errors 0 collisions 0 input_bytes 56792 output_bytes 8206464 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
2026-05-28T21:43:51-00:00: [INFO] [application] Got stats for VM :ny-hello (user robur): utime 0.000000 stime 0.000000 maxrss 1057 ixrss 0 idrss 0 isrss 0 minflt 795 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 3 nivcsw 4
virtual-size 36577280 rss 1057 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004631.319651
no vmm stats

2026-05-28T21:43:51-00:00: [INFO] [application] Got stats for VM :hello-test-arg (user robur): utime 0.000000 stime 0.000000 maxrss 1075 ixrss 0 idrss 0 isrss 0 minflt 780 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 3 nivcsw 4
virtual-size 170795008 rss 1075 text-size 5 data-size 89 stack-size 89 runtime 0 cow 0 start 1780004631.318651
no vmm stats

2026-05-28T21:43:51-00:00: [INFO] [application] Got stats for VM :dnsvizor-management (user robur): utime 1.300000 stime 0.480000 maxrss 4161 ixrss 0 idrss 0 isrss 0 minflt 3860 majflt 0 nswap 0 inblock 0 outblock 0 msgsnd 0 msgrcv 0 signals 0 nvcsw 21587 nivcsw 94
virtual-size 36577280 rss 4161 text-size 5 data-size 89 stack-size 89 runtime 1780000 cow 0 start 1779999026.051737
no vmm stats
bridge service flags 11043 send_length 0 max_send_length 0 send_drops 0 mtu 1500 baudrate 0 input_packets 112 input_errors 0 output_packets 542 output_errors 0 collisions 0 input_bytes 15298 output_bytes 63828 input_mcast 0 output_mcast 0 input_dropped 0 output_dropped 0
```