### PR TITLE
Add autoscaling module

### DIFF
--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -142,17 +142,22 @@ module Cluster_manager = struct
       g.next_id <- max g.next_id (clone_id + 1)
     end
 
-  let register_clone ~user_name clone =
+  let register_clone user_name clone =
     match extract_name_and_clone_id (fst clone) with
-    | None -> Error (Fmt.str "Invalid clone name '%s'." (fst clone))
-    | Some (primary_name, clone_id) -> (
+    | Some (primary_name, _) -> (
         match find_group_by_name ~user_name ~unikernel_name:primary_name with
         | Some g ->
-            add_clone_to_group g clone clone_id;
+            g.next_id <- g.next_id + 1;
+            let new_name = Fmt.str "%s-clone-%d" primary_name g.next_id in
+            add_clone_to_group g (new_name, snd clone) g.next_id;
             g.last_scale_action <- Some (Mirage_ptime.now ());
-            Ok ()
+            Ok new_name
         | None ->
             Error (Fmt.str "No primary group found for '%s'." primary_name))
+    | None ->
+        let g = get_or_create ~user_name clone in
+        g.next_id <- g.next_id + 1;
+        Ok (fst clone)
 
   let find_or_create_group ~user_name ~unikernel_name t =
     match extract_name_and_clone_id unikernel_name with
@@ -172,26 +177,6 @@ module Cluster_manager = struct
         | None ->
             let g = get_or_create ~user_name (unikernel_name, t) in
             Ok g)
-
-  let next_clone_name user_name vm =
-    match extract_name_and_clone_id (fst vm) with
-    | Some (primary_name, _) -> (
-        match find_group_by_name ~user_name ~unikernel_name:primary_name with
-        | Some g ->
-            let id = g.next_id in
-            g.next_id <- g.next_id + 1;
-            Ok (Fmt.str "%s-clone-%d" primary_name id)
-        | None ->
-            Error
-              (Fmt.str
-                 "No primary group found for primary '%s' (derived from clone \
-                  '%s')."
-                 primary_name (fst vm)))
-    | None ->
-        let g = get_or_create ~user_name vm in
-        let id = g.next_id in
-        g.next_id <- g.next_id + 1;
-        Ok (Fmt.str "%s-clone-%d" (fst g.primary) id)
 
   let remove_clone ~user_name clone =
     match extract_name_and_clone_id (fst clone) with

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,0 +1,326 @@
+(** how long to wait before checking the unikernel *)
+let poll_interval = Duration.of_min 5
+
+(** number of times a unikernel is checked before deciding if it's overloaded.
+*)
+let scale_up_trigger_ticks = 3
+
+(** if CPU usage >= 90% for [trigger_ticks] consercutive checks then this vm can
+    be cloned. *)
+let scale_up_threshold_percent = 90.0
+
+let scale_down_threshold_percent = 40.0
+let scale_down_trigger_ticks = 5
+
+(** after spawning a new vm, wait [cooldown_period] before checking that vm
+    again. *)
+let cooldown_period = 600.0
+
+(** if no stats are gotten for a particular vm after [death_timeout] then
+    consider the vm destroyed and prune it *)
+let death_timeout = 900.0
+
+module Cpu_monitor = struct
+  let rusage_to_float (sec, usec) =
+    let s = Int64.to_float sec in
+    let u = float_of_int usec in
+    s +. (u /. 1_000_000.0)
+
+  let get_total_cpu_time (r : Vmm_core.Stats.rusage) =
+    let user_t = rusage_to_float r.utime in
+    let sys_t = rusage_to_float r.stime in
+    user_t +. sys_t
+
+  type t = { last_cpu_time : float; last_wall_time : Ptime.t }
+
+  let create now (initial_rusage : Vmm_core.Stats.rusage) =
+    { last_cpu_time = get_total_cpu_time initial_rusage; last_wall_time = now }
+
+  let measure t now (current_rusage : Vmm_core.Stats.rusage) =
+    let curr_cpu_time = get_total_cpu_time current_rusage in
+    let curr_wall_time = now in
+    let cpu_delta = curr_cpu_time -. t.last_cpu_time in
+    let wall_span = Ptime.diff curr_wall_time t.last_wall_time in
+    let wall_delta = Ptime.Span.to_float_s wall_span in
+    { last_cpu_time = curr_cpu_time; last_wall_time = curr_wall_time }
+    |> fun t ->
+    if wall_delta <= 0.000001 then 0.0
+    else if cpu_delta < 0.0 then 0.0
+    else
+      let pct = cpu_delta /. wall_delta *. 100.0 in
+      Float.min 100.0 pct
+end
+
+type t = {
+  mutable monitor : Cpu_monitor.t;
+  mutable last_cpu_usage : float;
+  mutable last_stats_received : Ptime.t;
+}
+
+type status =
+  | Overloaded of
+      t (* the usage of the clone or vm that is checked in the group *)
+  | Pending of int * t
+    (* We have a high load but waiting for required number of polls to complete*)
+  | Pending_down of int * t
+  | Underloaded of string * t
+  | Cooldown of t
+  | Normal of t
+
+let create now initial_rusage =
+  {
+    monitor = Cpu_monitor.create now initial_rusage;
+    last_cpu_usage =
+      Cpu_monitor.measure
+        (Cpu_monitor.create now initial_rusage)
+        now initial_rusage;
+    last_stats_received = now;
+  }
+
+module Cluster_manager = struct
+  type group = {
+    primary : string * t;
+    mutable clones : (string * t) list;
+    mutable last_scale_action : Ptime.t option;
+    mutable last_stats_received : Ptime.t;
+    mutable next_id : int;
+    mutable consecutive_high_ticks : int;
+    mutable consecutive_low_ticks : int;
+  }
+
+  let clusters : (string, group) Hashtbl.t = Hashtbl.create 10
+
+  let in_cooldown now = function
+    | { last_scale_action = None; _ } -> false
+    | { last_scale_action = Some t; _ } ->
+        let span = Ptime.diff now t in
+        Ptime.Span.to_float_s span < cooldown_period
+
+  let get_or_create primary =
+    match Hashtbl.find_opt clusters (fst primary) with
+    | Some g -> g
+    | None ->
+        let g =
+          {
+            primary;
+            clones = [];
+            consecutive_high_ticks = 0;
+            consecutive_low_ticks = 0;
+            last_scale_action = None;
+            last_stats_received = Mirage_ptime.now ();
+            next_id = 1;
+          }
+        in
+        Hashtbl.add clusters (fst primary) g;
+        g
+
+  let find_group_by_name primary_name = Hashtbl.find_opt clusters primary_name
+
+  let extract_primary name =
+    match List.rev (String.split_on_char '-' name) with
+    | _id_str :: "clone" :: primary_parts_rev ->
+        Some (String.concat "-" (List.rev primary_parts_rev))
+    | _ -> None
+
+  let find_or_create_group ~name ~key t =
+    match extract_primary name with
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g -> Ok (g, name)
+        | None ->
+            Error
+              (Fmt.str
+                 "No primary group found for primary '%s' (derived from clone \
+                  '%s')."
+                 primary_name name))
+    | None -> (
+        match find_group_by_name key with
+        | Some g -> Ok (g, key)
+        | None -> get_or_create (key, t) |> fun g -> Ok (g, key))
+
+  let next_clone_name vm =
+    match extract_primary (fst vm) with
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g ->
+            let id = g.next_id in
+            g.next_id <- g.next_id + 1;
+            Ok (Fmt.str "%s-clone-%d" primary_name id)
+        | None ->
+            Error
+              (Fmt.str
+                 "No primary group found for primary '%s' (derived from clone \
+                  '%s')."
+                 primary_name (fst vm)))
+    | None ->
+        let g = get_or_create vm in
+        let id = g.next_id in
+        g.next_id <- g.next_id + 1;
+        Ok (Fmt.str "%s-clone-%d" (fst g.primary) id)
+
+  let register_clone clone =
+    match extract_primary (fst clone) with
+    | None ->
+        Error
+          (Fmt.str "Invalid clone name '%s'. Cannot extract primary name."
+             (fst clone))
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g ->
+            g.clones <- clone :: g.clones;
+            g.last_scale_action <- Some (Mirage_ptime.now ());
+            Ok ()
+        | None ->
+            Error
+              (Fmt.str
+                 "No primary group found for primary '%s' (derived from clone \
+                  '%s')."
+                 primary_name (fst clone)))
+
+  let remove_clone clone =
+    match extract_primary (fst clone) with
+    | Some primary_name -> (
+        match find_group_by_name primary_name with
+        | Some g ->
+            g.clones <- List.filter (fun c -> fst c <> fst clone) g.clones;
+            let max_id =
+              List.fold_left
+                (fun acc (name, _) ->
+                  match List.rev (String.split_on_char '-' name) with
+                  | id_str :: _ -> (
+                      match int_of_string_opt id_str with
+                      | Some id -> max acc id
+                      | None -> acc)
+                  | _ -> acc)
+                0 g.clones
+            in
+            g.next_id <- max_id + 1;
+            g.last_scale_action <- Some (Mirage_ptime.now ());
+            Ok ()
+        | None ->
+            Logs.err (fun m ->
+                m
+                  "[Cluster Manager] No primary group found during removal for \
+                   primary '%s' (derived from clone '%s')."
+                  primary_name (fst clone));
+            Error "Primary group not found during removal")
+    | None ->
+        Logs.err (fun m ->
+            m "[Cluster Manager] Could not derive primary name for removal %s"
+              (fst clone));
+        Error "Could not derive primary name for removal"
+
+  let record_action primary =
+    let g = get_or_create primary in
+    g.last_scale_action <- Some (Mirage_ptime.now ())
+
+  let check_group_average group key now rusage =
+    let all_instances = group.primary :: group.clones in
+    match
+      List.find_opt (fun (name, _) -> String.equal name key) all_instances
+    with
+    | None -> Error "Current VM not found in group during average check"
+    | Some (_, vm) ->
+        let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
+        let new_monitor = Cpu_monitor.create now rusage in
+        let current_vm_state =
+          {
+            monitor = new_monitor;
+            last_cpu_usage = current_vm_usage;
+            last_stats_received = now;
+          }
+        in
+        vm.monitor <- new_monitor;
+        vm.last_cpu_usage <- current_vm_usage;
+        vm.last_stats_received <- now;
+        let total_usage =
+          List.fold_left
+            (fun acc (_, vm) -> acc +. vm.last_cpu_usage)
+            0.0 all_instances
+        in
+        let average_usage =
+          total_usage /. float_of_int (List.length all_instances)
+        in
+        Ok (average_usage, current_vm_state)
+
+  let check_group_status group key now rusage =
+    match check_group_average group key now rusage with
+    | Error e -> Error e
+    | Ok (average_usage, current_vm_state) ->
+        if in_cooldown now group then (
+          group.consecutive_high_ticks <- 0;
+          group.consecutive_low_ticks <- 0;
+          Ok (Cooldown current_vm_state))
+        else if average_usage > scale_up_threshold_percent then (
+          group.consecutive_low_ticks <- 0;
+          group.consecutive_high_ticks <- group.consecutive_high_ticks + 1;
+          if group.consecutive_high_ticks >= scale_up_trigger_ticks then (
+            group.consecutive_high_ticks <- 0;
+            group.last_scale_action <- Some now;
+            Ok (Overloaded current_vm_state))
+          else Ok (Pending (group.consecutive_high_ticks, current_vm_state)))
+        else if
+          average_usage < scale_down_threshold_percent
+          && List.length group.clones > 0
+        then (
+          group.consecutive_high_ticks <- 0;
+          group.consecutive_low_ticks <- group.consecutive_low_ticks + 1;
+          if group.consecutive_low_ticks >= scale_down_trigger_ticks then (
+            group.consecutive_low_ticks <- 0;
+            group.last_scale_action <- Some now;
+            (* LIFO approach: kill the last clone added to the group *)
+            let clone_to_kill = fst (List.hd (List.rev group.clones)) in
+            Ok (Underloaded (clone_to_kill, current_vm_state)))
+          else Ok (Pending_down (group.consecutive_low_ticks, current_vm_state)))
+        else (
+          group.consecutive_high_ticks <- 0;
+          group.consecutive_low_ticks <- 0;
+          Ok (Normal current_vm_state))
+
+  let prune_dead_clusters now =
+    let dead_keys =
+      Hashtbl.fold
+        (fun primary_name group acc ->
+          let primary_span =
+            Ptime.diff now (snd group.primary : t).last_stats_received
+          in
+          if Ptime.Span.to_float_s primary_span > death_timeout then
+            primary_name :: acc
+          else
+            let alive_clones, dead_clones =
+              List.partition
+                (fun (_, clone_vm) ->
+                  let clone_span =
+                    Ptime.diff now (clone_vm : t).last_stats_received
+                  in
+                  Ptime.Span.to_float_s clone_span <= death_timeout)
+                group.clones
+            in
+            if List.length dead_clones > 0 then (
+              List.iter
+                (fun (c_name, _) ->
+                  Logs.debug (fun m ->
+                      m "[Cluster Manager] Pruning dead clone: %s" c_name))
+                dead_clones;
+              group.clones <- alive_clones;
+              let max_id =
+                List.fold_left
+                  (fun acc (name, _) ->
+                    match List.rev (String.split_on_char '-' name) with
+                    | id_str :: _ -> (
+                        match int_of_string_opt id_str with
+                        | Some id -> max acc id
+                        | None -> acc)
+                    | _ -> acc)
+                  0 group.clones
+              in
+              group.next_id <- max_id + 1);
+            acc)
+        clusters []
+    in
+    List.iter
+      (fun key ->
+        Logs.debug (fun m -> m "[Cluster Manager] Pruning dead cluster: %s" key);
+        Hashtbl.remove clusters key)
+      dead_keys
+end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -57,11 +57,11 @@ type t = {
   mutable last_stats_received : Ptime.t;
 }
 
-type scale_type = [ `Up | `Down ]
+type scale_action = [ `Spawn | `Prune ]
 
 type status =
   | Overloaded of t
-  | Pending of scale_type * int * t
+  | Pending of scale_action * int * t
   | Underloaded of string * t
   | Cooldown of t
   | Normal of t
@@ -273,9 +273,9 @@ module Cluster_manager = struct
           let clone_to_kill = fst (List.hd group.clones) in
           trigger (Underloaded (clone_to_kill, current_vm_state))
         else if is_high then
-          Ok (Pending (`Up, group.consecutive_high_ticks, current_vm_state))
+          Ok (Pending (`Spawn, group.consecutive_high_ticks, current_vm_state))
         else if is_low then
-          Ok (Pending (`Down, group.consecutive_low_ticks, current_vm_state))
+          Ok (Pending (`Prune, group.consecutive_low_ticks, current_vm_state))
         else Ok (Normal current_vm_state)
 
   let is_dead now (vm : t) =

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,12 +1,11 @@
-(** how long to wait before checking the unikernel *)
+let a_logs = Logs.Src.create "autoscaling-logs"
 let poll_interval = Duration.of_min 5
 
-(** number of times a unikernel is checked before deciding if it's overloaded.
-*)
+(** number of times a cluster is checked before deciding if it's overloaded. *)
 let scale_up_trigger_ticks = 3
 
-(** if CPU usage >= 90% for [trigger_ticks] consercutive checks then this vm can
-    be cloned. *)
+(** if CPU usage >= 90% for [scale_up_trigger_ticks] consecutive checks then
+    this vm can be cloned. *)
 let scale_up_threshold_percent = 90.0
 
 let scale_down_threshold_percent = 40.0
@@ -21,33 +20,34 @@ let cooldown_period = 600.0
 let death_timeout = 900.0
 
 module Cpu_monitor = struct
-  let rusage_to_float (sec, usec) =
+  type t = { last_cpu_time : float; last_wall_time : Ptime.t }
+
+  let timeval_to_float (sec, usec) =
     let s = Int64.to_float sec in
     let u = float_of_int usec in
     s +. (u /. 1_000_000.0)
 
   let get_total_cpu_time (r : Vmm_core.Stats.rusage) =
-    let user_t = rusage_to_float r.utime in
-    let sys_t = rusage_to_float r.stime in
+    let user_t = timeval_to_float r.utime in
+    let sys_t = timeval_to_float r.stime in
     user_t +. sys_t
-
-  type t = { last_cpu_time : float; last_wall_time : Ptime.t }
 
   let create now (initial_rusage : Vmm_core.Stats.rusage) =
     { last_cpu_time = get_total_cpu_time initial_rusage; last_wall_time = now }
 
   let measure t now (current_rusage : Vmm_core.Stats.rusage) =
     let curr_cpu_time = get_total_cpu_time current_rusage in
-    let curr_wall_time = now in
     let cpu_delta = curr_cpu_time -. t.last_cpu_time in
-    let wall_span = Ptime.diff curr_wall_time t.last_wall_time in
-    let wall_delta = Ptime.Span.to_float_s wall_span in
-    { last_cpu_time = curr_cpu_time; last_wall_time = curr_wall_time }
-    |> fun t ->
-    if wall_delta <= 0.000001 then 0.0
+    let elasped_time_difference = Ptime.diff now t.last_wall_time in
+    let elasped_time_in_seconds =
+      Ptime.Span.to_float_s elasped_time_difference
+    in
+    if elasped_time_in_seconds <= 0.000001 then 0.0
     else if cpu_delta < 0.0 then 0.0
     else
-      let pct = cpu_delta /. wall_delta *. 100.0 in
+      let pct = cpu_delta /. elasped_time_in_seconds *. 100.0 in
+      (* TODO: use numcpus to cap it at 100.0% if the vm has more than 1 cpu. Now most
+         vms use 1 cpu, so capping at 100% is fine. *)
       Float.min 100.0 pct
 end
 
@@ -57,12 +57,11 @@ type t = {
   mutable last_stats_received : Ptime.t;
 }
 
+type scale_type = [ `Up | `Down ]
+
 type status =
-  | Overloaded of
-      t (* the usage of the clone or vm that is checked in the group *)
-  | Pending of int * t
-    (* We have a high load but waiting for required number of polls to complete*)
-  | Pending_down of int * t
+  | Overloaded of t
+  | Pending of scale_type * int * t
   | Underloaded of string * t
   | Cooldown of t
   | Normal of t
@@ -78,11 +77,13 @@ let create now initial_rusage =
   }
 
 module Cluster_manager = struct
+  type vm = string * t
+
   type group = {
-    primary : string * t;
-    mutable clones : (string * t) list;
+    primary : vm;
+    mutable clones : vm list;
     mutable last_scale_action : Ptime.t option;
-    mutable last_stats_received : Ptime.t;
+    mutable last_tick_update : Ptime.t option;
     mutable next_id : int;
     mutable consecutive_high_ticks : int;
     mutable consecutive_low_ticks : int;
@@ -96,52 +97,86 @@ module Cluster_manager = struct
         let span = Ptime.diff now t in
         Ptime.Span.to_float_s span < cooldown_period
 
-  let get_or_create primary =
-    match Hashtbl.find_opt clusters (fst primary) with
+  let should_tick now group =
+    match group.last_tick_update with
+    | None -> true
+    | Some t ->
+        let span = Ptime.diff now t in
+        Ptime.Span.to_float_s span >= Duration.to_f poll_interval
+
+  let key ~user_name ~unikernel_name = Fmt.str "%s-%s" user_name unikernel_name
+
+  let find_group_by_name ~user_name ~unikernel_name =
+    Hashtbl.find_opt clusters (key ~user_name ~unikernel_name)
+
+  let get_or_create ~user_name primary =
+    match find_group_by_name ~user_name ~unikernel_name:(fst primary) with
     | Some g -> g
     | None ->
         let g =
           {
             primary;
             clones = [];
+            last_scale_action = None;
             consecutive_high_ticks = 0;
             consecutive_low_ticks = 0;
-            last_scale_action = None;
-            last_stats_received = Mirage_ptime.now ();
+            last_tick_update = None;
             next_id = 1;
           }
         in
-        Hashtbl.add clusters (fst primary) g;
+        Hashtbl.add clusters (key ~user_name ~unikernel_name:(fst primary)) g;
         g
 
-  let find_group_by_name primary_name = Hashtbl.find_opt clusters primary_name
-
-  let extract_primary name =
+  (* TODO: in unikernel_create, forbid users from creating unikernels which end with [-clone-ID] *)
+  let extract_name_and_clone_id name =
     match List.rev (String.split_on_char '-' name) with
-    | _id_str :: "clone" :: primary_parts_rev ->
-        Some (String.concat "-" (List.rev primary_parts_rev))
+    | id_str :: "clone" :: primary_parts_rev -> (
+        match int_of_string_opt id_str with
+        | Some id -> Some (String.concat "-" (List.rev primary_parts_rev), id)
+        | None -> None)
     | _ -> None
 
-  let find_or_create_group ~name ~key t =
-    match extract_primary name with
-    | Some primary_name -> (
-        match find_group_by_name primary_name with
-        | Some g -> Ok (g, name)
+  let add_clone_to_group g clone clone_id =
+    if not (List.mem_assoc (fst clone) g.clones) then begin
+      g.clones <- clone :: g.clones;
+      g.next_id <- max g.next_id (clone_id + 1)
+    end
+
+  let register_clone ~user_name clone =
+    match extract_name_and_clone_id (fst clone) with
+    | None -> Error (Fmt.str "Invalid clone name '%s'." (fst clone))
+    | Some (primary_name, clone_id) -> (
+        match find_group_by_name ~user_name ~unikernel_name:primary_name with
+        | Some g ->
+            add_clone_to_group g clone clone_id;
+            g.last_scale_action <- Some (Mirage_ptime.now ());
+            Ok ()
+        | None ->
+            Error (Fmt.str "No primary group found for '%s'." primary_name))
+
+  let find_or_create_group ~user_name ~unikernel_name t =
+    match extract_name_and_clone_id unikernel_name with
+    | Some (primary_name, clone_id) -> (
+        match find_group_by_name ~user_name ~unikernel_name:primary_name with
+        | Some g ->
+            (* stats arrived before register_clone was called, recover silently *)
+            add_clone_to_group g (unikernel_name, t) clone_id;
+            Ok g
         | None ->
             Error
-              (Fmt.str
-                 "No primary group found for primary '%s' (derived from clone \
-                  '%s')."
-                 primary_name name))
+              (Fmt.str "No primary group found for '%s' (derived from '%s')."
+                 primary_name unikernel_name))
     | None -> (
-        match find_group_by_name key with
-        | Some g -> Ok (g, key)
-        | None -> get_or_create (key, t) |> fun g -> Ok (g, key))
+        match find_group_by_name ~user_name ~unikernel_name with
+        | Some g -> Ok g
+        | None ->
+            let g = get_or_create ~user_name (unikernel_name, t) in
+            Ok g)
 
-  let next_clone_name vm =
-    match extract_primary (fst vm) with
-    | Some primary_name -> (
-        match find_group_by_name primary_name with
+  let next_clone_name user_name vm =
+    match extract_name_and_clone_id (fst vm) with
+    | Some (primary_name, _) -> (
+        match find_group_by_name ~user_name ~unikernel_name:primary_name with
         | Some g ->
             let id = g.next_id in
             g.next_id <- g.next_id + 1;
@@ -153,174 +188,124 @@ module Cluster_manager = struct
                   '%s')."
                  primary_name (fst vm)))
     | None ->
-        let g = get_or_create vm in
+        let g = get_or_create ~user_name vm in
         let id = g.next_id in
         g.next_id <- g.next_id + 1;
         Ok (Fmt.str "%s-clone-%d" (fst g.primary) id)
 
-  let register_clone clone =
-    match extract_primary (fst clone) with
-    | None ->
-        Error
-          (Fmt.str "Invalid clone name '%s'. Cannot extract primary name."
-             (fst clone))
-    | Some primary_name -> (
-        match find_group_by_name primary_name with
+  let remove_clone ~user_name clone =
+    match extract_name_and_clone_id (fst clone) with
+    | Some (primary_name, _) -> (
+        match find_group_by_name ~user_name ~unikernel_name:primary_name with
         | Some g ->
-            g.clones <- clone :: g.clones;
+            g.clones <-
+              List.filter
+                (fun c -> not (String.equal (fst c) (fst clone)))
+                g.clones;
             g.last_scale_action <- Some (Mirage_ptime.now ());
             Ok ()
         | None ->
-            Error
-              (Fmt.str
-                 "No primary group found for primary '%s' (derived from clone \
-                  '%s')."
-                 primary_name (fst clone)))
-
-  let remove_clone clone =
-    match extract_primary (fst clone) with
-    | Some primary_name -> (
-        match find_group_by_name primary_name with
-        | Some g ->
-            g.clones <- List.filter (fun c -> fst c <> fst clone) g.clones;
-            let max_id =
-              List.fold_left
-                (fun acc (name, _) ->
-                  match List.rev (String.split_on_char '-' name) with
-                  | id_str :: _ -> (
-                      match int_of_string_opt id_str with
-                      | Some id -> max acc id
-                      | None -> acc)
-                  | _ -> acc)
-                0 g.clones
-            in
-            g.next_id <- max_id + 1;
-            g.last_scale_action <- Some (Mirage_ptime.now ());
-            Ok ()
-        | None ->
-            Logs.err (fun m ->
+            Logs.debug ~src:a_logs (fun m ->
                 m
                   "[Cluster Manager] No primary group found during removal for \
                    primary '%s' (derived from clone '%s')."
                   primary_name (fst clone));
             Error "Primary group not found during removal")
     | None ->
-        Logs.err (fun m ->
-            m "[Cluster Manager] Could not derive primary name for removal %s"
-              (fst clone));
-        Error "Could not derive primary name for removal"
-
-  let record_action primary =
-    let g = get_or_create primary in
-    g.last_scale_action <- Some (Mirage_ptime.now ())
+        Logs.debug ~src:a_logs (fun m ->
+            m "[Cluster Manager] Invalid clone name '%s'." (fst clone));
+        Error "Invalid clone name"
 
   let check_group_average group key now rusage =
     let all_instances = group.primary :: group.clones in
-    match
-      List.find_opt (fun (name, _) -> String.equal name key) all_instances
-    with
+    let current_vm_state = ref None in
+    let total_usage =
+      List.fold_left
+        (fun acc (name, vm) ->
+          if String.equal name key then begin
+            let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
+            let new_monitor = Cpu_monitor.create now rusage in
+            vm.monitor <- new_monitor;
+            vm.last_cpu_usage <- current_vm_usage;
+            vm.last_stats_received <- now;
+            current_vm_state := Some vm;
+            acc +. current_vm_usage
+          end
+          else acc +. vm.last_cpu_usage)
+        0.0 all_instances
+    in
+    match !current_vm_state with
     | None -> Error "Current VM not found in group during average check"
-    | Some (_, vm) ->
-        let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
-        let new_monitor = Cpu_monitor.create now rusage in
-        let current_vm_state =
-          {
-            monitor = new_monitor;
-            last_cpu_usage = current_vm_usage;
-            last_stats_received = now;
-          }
-        in
-        vm.monitor <- new_monitor;
-        vm.last_cpu_usage <- current_vm_usage;
-        vm.last_stats_received <- now;
-        let total_usage =
-          List.fold_left
-            (fun acc (_, vm) -> acc +. vm.last_cpu_usage)
-            0.0 all_instances
-        in
+    | Some state ->
         let average_usage =
           total_usage /. float_of_int (List.length all_instances)
         in
-        Ok (average_usage, current_vm_state)
+        Ok (average_usage, state)
 
   let check_group_status group key now rusage =
     match check_group_average group key now rusage with
     | Error e -> Error e
     | Ok (average_usage, current_vm_state) ->
-        if in_cooldown now group then (
+        let is_cooldown = in_cooldown now group in
+        let is_high = average_usage > scale_up_threshold_percent in
+        let is_low =
+          average_usage < scale_down_threshold_percent && group.clones <> []
+        in
+        if should_tick now group then begin
+          group.last_tick_update <- Some now;
+          group.consecutive_high_ticks <-
+            (if is_high && not is_cooldown then group.consecutive_high_ticks + 1
+             else 0);
+          group.consecutive_low_ticks <-
+            (if is_low && not is_cooldown then group.consecutive_low_ticks + 1
+             else 0)
+        end;
+        let trigger state =
           group.consecutive_high_ticks <- 0;
           group.consecutive_low_ticks <- 0;
-          Ok (Cooldown current_vm_state))
-        else if average_usage > scale_up_threshold_percent then (
-          group.consecutive_low_ticks <- 0;
-          group.consecutive_high_ticks <- group.consecutive_high_ticks + 1;
-          if group.consecutive_high_ticks >= scale_up_trigger_ticks then (
-            group.consecutive_high_ticks <- 0;
-            group.last_scale_action <- Some now;
-            Ok (Overloaded current_vm_state))
-          else Ok (Pending (group.consecutive_high_ticks, current_vm_state)))
-        else if
-          average_usage < scale_down_threshold_percent
-          && List.length group.clones > 0
-        then (
-          group.consecutive_high_ticks <- 0;
-          group.consecutive_low_ticks <- group.consecutive_low_ticks + 1;
-          if group.consecutive_low_ticks >= scale_down_trigger_ticks then (
-            group.consecutive_low_ticks <- 0;
-            group.last_scale_action <- Some now;
-            (* LIFO approach: kill the last clone added to the group *)
-            let clone_to_kill = fst (List.hd (List.rev group.clones)) in
-            Ok (Underloaded (clone_to_kill, current_vm_state)))
-          else Ok (Pending_down (group.consecutive_low_ticks, current_vm_state)))
-        else (
-          group.consecutive_high_ticks <- 0;
-          group.consecutive_low_ticks <- 0;
-          Ok (Normal current_vm_state))
+          group.last_scale_action <- Some now;
+          Ok state
+        in
+        if is_cooldown then Ok (Cooldown current_vm_state)
+        else if group.consecutive_high_ticks >= scale_up_trigger_ticks then
+          trigger (Overloaded current_vm_state)
+        else if group.consecutive_low_ticks >= scale_down_trigger_ticks then
+          let clone_to_kill = fst (List.hd group.clones) in
+          trigger (Underloaded (clone_to_kill, current_vm_state))
+        else if is_high then
+          Ok (Pending (`Up, group.consecutive_high_ticks, current_vm_state))
+        else if is_low then
+          Ok (Pending (`Down, group.consecutive_low_ticks, current_vm_state))
+        else Ok (Normal current_vm_state)
+
+  let is_dead now (vm : t) =
+    Ptime.Span.to_float_s (Ptime.diff now vm.last_stats_received)
+    > death_timeout
 
   let prune_dead_clusters now =
     let dead_keys =
       Hashtbl.fold
         (fun primary_name group acc ->
-          let primary_span =
-            Ptime.diff now (snd group.primary : t).last_stats_received
-          in
-          if Ptime.Span.to_float_s primary_span > death_timeout then
-            primary_name :: acc
-          else
+          if is_dead now (snd group.primary) then primary_name :: acc
+          else begin
             let alive_clones, dead_clones =
-              List.partition
-                (fun (_, clone_vm) ->
-                  let clone_span =
-                    Ptime.diff now (clone_vm : t).last_stats_received
-                  in
-                  Ptime.Span.to_float_s clone_span <= death_timeout)
-                group.clones
+              List.partition (fun (_, vm) -> not (is_dead now vm)) group.clones
             in
-            if List.length dead_clones > 0 then (
-              List.iter
-                (fun (c_name, _) ->
-                  Logs.debug (fun m ->
-                      m "[Cluster Manager] Pruning dead clone: %s" c_name))
-                dead_clones;
-              group.clones <- alive_clones;
-              let max_id =
-                List.fold_left
-                  (fun acc (name, _) ->
-                    match List.rev (String.split_on_char '-' name) with
-                    | id_str :: _ -> (
-                        match int_of_string_opt id_str with
-                        | Some id -> max acc id
-                        | None -> acc)
-                    | _ -> acc)
-                  0 group.clones
-              in
-              group.next_id <- max_id + 1);
-            acc)
+            match dead_clones with
+            | [] -> acc
+            | _ ->
+                Logs.debug ~src:a_logs (fun m ->
+                    m "[Cluster Manager] Pruning %d dead clones"
+                      (List.length dead_clones));
+                group.clones <- alive_clones;
+                acc
+          end)
         clusters []
     in
     List.iter
       (fun key ->
-        Logs.debug (fun m -> m "[Cluster Manager] Pruning dead cluster: %s" key);
+        Logs.debug ~src:a_logs (fun m ->
+            m "[Cluster Manager] Pruning dead cluster: %s" key);
         Hashtbl.remove clusters key)
       dead_keys
 end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -103,7 +103,6 @@ module Cluster_manager = struct
     let span = Ptime.diff now group.last_scale_action in
     Ptime.Span.compare span cooldown_period < 0
 
-
   let extract_name_and_clone_id name =
     match List.rev (String.split_on_char '-' name) with
     | id_str :: "clone" :: primary_parts_rev -> (
@@ -234,20 +233,17 @@ module Cluster_manager = struct
     let is_cooldown = in_cooldown now group in
     let is_high = average_usage > scale_up_threshold_percent in
     let is_low =
-      average_usage < scale_down_threshold_percent
-      && group.clones <> []
+      average_usage < scale_down_threshold_percent && group.clones <> []
     in
     let updated_group =
       {
         group with
         last_tick_update = now;
         consecutive_high_ticks =
-          (if is_high && not is_cooldown then
-             group.consecutive_high_ticks + 1
+          (if is_high && not is_cooldown then group.consecutive_high_ticks + 1
            else 0);
         consecutive_low_ticks =
-          (if is_low && not is_cooldown then
-             group.consecutive_low_ticks + 1
+          (if is_low && not is_cooldown then group.consecutive_low_ticks + 1
            else 0);
       }
     in
@@ -264,21 +260,18 @@ module Cluster_manager = struct
     in
     let primary_state = snd group.primary in
     if is_cooldown then Ok (Cooldown primary_state, updated_group)
-    else if updated_group.consecutive_high_ticks >= scale_up_trigger_ticks
-    then trigger (Overloaded primary_state) updated_group
-    else if updated_group.consecutive_low_ticks >= scale_down_trigger_ticks
-    then
+    else if updated_group.consecutive_high_ticks >= scale_up_trigger_ticks then
+      trigger (Overloaded primary_state) updated_group
+    else if updated_group.consecutive_low_ticks >= scale_down_trigger_ticks then
       let clone_to_kill = fst (List.hd updated_group.clones) in
       trigger (Underloaded (clone_to_kill, primary_state)) updated_group
     else if is_high then
       Ok
-        ( Pending
-            (`Spawn, updated_group.consecutive_high_ticks, primary_state),
+        ( Pending (`Spawn, updated_group.consecutive_high_ticks, primary_state),
           updated_group )
     else if is_low then
       Ok
-        ( Pending
-            (`Prune, updated_group.consecutive_low_ticks, primary_state),
+        ( Pending (`Prune, updated_group.consecutive_low_ticks, primary_state),
           updated_group )
     else Ok (Normal primary_state, updated_group)
 

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -104,36 +104,9 @@ module Cluster_manager = struct
     Ptime.Span.compare span cooldown_period < 0
 
   let should_tick now group =
-    match group.last_tick_update with
-    | None -> true
-    | Some t ->
-        let span = Ptime.diff now t in
-        Ptime.Span.to_float_s span >= Duration.to_f poll_interval
+    let span = Ptime.diff now group.last_tick_update in
+    Ptime.Span.compare span poll_interval_span >= 0
 
-  let key ~user_name ~unikernel_name = Fmt.str "%s-%s" user_name unikernel_name
-
-  let find_group_by_name ~user_name ~unikernel_name =
-    Hashtbl.find_opt clusters (key ~user_name ~unikernel_name)
-
-  let get_or_create ~user_name primary =
-    match find_group_by_name ~user_name ~unikernel_name:(fst primary) with
-    | Some g -> g
-    | None ->
-        let g =
-          {
-            primary;
-            clones = [];
-            last_scale_action = None;
-            consecutive_high_ticks = 0;
-            consecutive_low_ticks = 0;
-            last_tick_update = None;
-            next_id = 1;
-          }
-        in
-        Hashtbl.add clusters (key ~user_name ~unikernel_name:(fst primary)) g;
-        g
-
-  (* TODO: in unikernel_create, forbid users from creating unikernels which end with [-clone-ID] *)
   let extract_name_and_clone_id name =
     match List.rev (String.split_on_char '-' name) with
     | id_str :: "clone" :: primary_parts_rev -> (

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -52,7 +52,8 @@ module Cpu_monitor = struct
     let elapsed_time_in_seconds =
       Ptime.Span.to_float_s elapsed_time_difference
     in
-    if elasped_time_in_seconds <= 0.000001 then 0.0
+    if elapsed_time_in_seconds <= 0.0 then 0.0
+      (* cpu_delta can be negative if the VM was rebooted or stats counter reset *)
     else if cpu_delta < 0.0 then 0.0
     else
       let pct = cpu_delta /. elasped_time_in_seconds *. 100.0 in

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -56,7 +56,7 @@ module Cpu_monitor = struct
       (* cpu_delta can be negative if the VM was rebooted or stats counter reset *)
     else if cpu_delta < 0.0 then 0.0
     else
-      let pct = cpu_delta /. elasped_time_in_seconds *. 100.0 in
+      let pct = cpu_delta /. elapsed_time_in_seconds *. 100.0 in
       (* TODO: use numcpus to cap it at 100.0% if the vm has more than 1 cpu. Now most
          vms use 1 cpu, so capping at 100% is fine. *)
       Float.min 100.0 pct

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -11,11 +11,11 @@ let scale_up_trigger_ticks = 3
 
 (** if CPU usage >= 90% for [scale_up_trigger_ticks] consecutive checks then
     this vm can be cloned. *)
-let scale_up_threshold_percent = 90.0
+let scale_up_threshold_percent = 90
 
 (** if average CPU usage < 40% for [scale_down_trigger_ticks] consecutive
     checks, one of the clone VMs can be pruned. *)
-let scale_down_threshold_percent = 40.0
+let scale_down_threshold_percent = 40
 
 (** number of times a cluster is checked before deciding if it's underloaded. *)
 let scale_down_trigger_ticks = 5
@@ -29,41 +29,38 @@ let cooldown_period = Ptime.Span.of_int_s 600
 let death_timeout = Ptime.Span.of_int_s 900
 
 module Cpu_monitor = struct
-  type t = { last_cpu_time : float; last_wall_time : Ptime.t }
+  type t = { last_cpu_time : int; last_wall_time : Ptime.t }
 
-  let timeval_to_float (sec, usec) =
-    let s = Int64.to_float sec in
-    let u = float_of_int usec in
-    s +. (u /. 1_000_000.0)
+  let timeval (sec, usec) = Int64.to_int sec + (usec / 1_000_000)
 
   let get_total_cpu_time (r : Vmm_core.Stats.rusage) =
-    let user_t = timeval_to_float r.utime in
-    let sys_t = timeval_to_float r.stime in
-    user_t +. sys_t
+    let user_t = timeval r.utime in
+    let sys_t = timeval r.stime in
+    user_t + sys_t
 
   let create now (initial_rusage : Vmm_core.Stats.rusage) =
     { last_cpu_time = get_total_cpu_time initial_rusage; last_wall_time = now }
 
   let measure t now (current_rusage : Vmm_core.Stats.rusage) =
     let curr_cpu_time = get_total_cpu_time current_rusage in
-    let cpu_delta = curr_cpu_time -. t.last_cpu_time in
+    let cpu_delta = curr_cpu_time - t.last_cpu_time in
     let elapsed_time_difference = Ptime.diff now t.last_wall_time in
     let elapsed_time_in_seconds =
-      Ptime.Span.to_float_s elapsed_time_difference
+      Option.value ~default:0 (Ptime.Span.to_int_s elapsed_time_difference)
     in
-    if elapsed_time_in_seconds <= 0.0 then 0.0
+    if elapsed_time_in_seconds <= 0 then 0
       (* cpu_delta can be negative if the VM was rebooted or stats counter reset *)
-    else if cpu_delta < 0.0 then 0.0
+    else if cpu_delta < 0 then 0
     else
-      let pct = cpu_delta /. elapsed_time_in_seconds *. 100.0 in
+      let pct = cpu_delta / elapsed_time_in_seconds * 100 in
       (* TODO: use numcpus to cap it at 100.0% if the vm has more than 1 cpu. Now most
          vms use 1 cpu, so capping at 100% is fine. *)
-      Float.min 100.0 pct
+      Int.min 100 pct
 end
 
 type t = {
   monitor : Cpu_monitor.t;
-  last_cpu_usage : float;
+  last_cpu_usage : int;
   last_stats_received : Ptime.t;
 }
 
@@ -223,13 +220,9 @@ module Cluster_manager = struct
   let evaluate_scaling group now =
     let all_instances = group.primary :: group.clones in
     let total_usage =
-      List.fold_left
-        (fun acc (_, v) -> acc +. v.last_cpu_usage)
-        0.0 all_instances
+      List.fold_left (fun acc (_, v) -> acc + v.last_cpu_usage) 0 all_instances
     in
-    let average_usage =
-      total_usage /. float_of_int (List.length all_instances)
-    in
+    let average_usage = total_usage / List.length all_instances in
     let is_cooldown = in_cooldown now group in
     let is_high = average_usage > scale_up_threshold_percent in
     let is_low =

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -103,9 +103,6 @@ module Cluster_manager = struct
     let span = Ptime.diff now group.last_scale_action in
     Ptime.Span.compare span cooldown_period < 0
 
-  let should_tick now group =
-    let span = Ptime.diff now group.last_tick_update in
-    Ptime.Span.compare span poll_interval_span >= 0
 
   let extract_name_and_clone_id name =
     match List.rev (String.split_on_char '-' name) with
@@ -189,17 +186,14 @@ module Cluster_manager = struct
                (fst group.primary))
     | None -> Error (Fmt.str "Clone name '%s' is not a valid format" clone_name)
 
-  (** [check_group_average group key now rusage] calculates the average CPU
-      usage across all instances in the [group] (primary and clones). Since
-      stats arrive for a single VM at a time (identified by [key]), we: 1.
-      Calculate the current CPU usage for the VM [key] using the new [rusage].
-      2. Use the last cached CPU usage for all other VMs in the group. 3. Update
-      the state of VM [key] with the new measurements. 4. Return the computed
-      average, the updated VM state, and the updated group. *)
-  let check_group_average group key now rusage =
+  (** [update_vm_metrics group key now rusage] calculates the CPU usage for the
+      VM [key] using [rusage] at time [now]. It updates the cached state of VM
+      [key] in the [group] (either primary or one of the clones). Returns the
+      newly updated VM state and the updated group. *)
+  let update_vm_metrics group key now rusage =
     let all_instances = group.primary :: group.clones in
     match List.assoc_opt key all_instances with
-    | None -> Error "Current VM not found in group during average check"
+    | None -> Error "Current VM not found in group during update"
     | Some vm ->
         let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
         let state =
@@ -209,17 +203,6 @@ module Cluster_manager = struct
             last_stats_received = now;
           }
         in
-        let total_usage =
-          List.fold_left
-            (fun acc (name, v) ->
-              if String.equal name key then acc +. current_vm_usage
-              else acc +. v.last_cpu_usage)
-            0.0 all_instances
-        in
-        let average_usage =
-          total_usage /. float_of_int (List.length all_instances)
-        in
-        (* Construct the new updated group state *)
         let updated_group =
           if String.equal key (fst group.primary) then
             { group with primary = (key, state) }
@@ -232,68 +215,72 @@ module Cluster_manager = struct
             in
             { group with clones = new_clones }
         in
-        Ok (average_usage, state, updated_group)
+        Ok (state, updated_group)
 
-  (** [check_group_status group key now rusage] evaluates the scaling status of
-      the [group] when new stats [rusage] at time [now] arrive for the VM [key].
-      It updates the average load of the group, ticks the consecutive high/low
-      counters, and determines if a scaling action (spawn or prune) is
-      triggered. *)
-  let check_group_status group key now rusage =
-    match check_group_average group key now rusage with
-    | Error e -> Error e
-    | Ok (average_usage, current_vm_state, updated_group) ->
-        let is_cooldown = in_cooldown now updated_group in
-        let is_high = average_usage > scale_up_threshold_percent in
-        let is_low =
-          average_usage < scale_down_threshold_percent
-          && updated_group.clones <> []
-        in
-        let updated_group =
-          if should_tick now updated_group then
-            {
-              updated_group with
-              last_tick_update = now;
-              consecutive_high_ticks =
-                (if is_high && not is_cooldown then
-                   updated_group.consecutive_high_ticks + 1
-                 else 0);
-              consecutive_low_ticks =
-                (if is_low && not is_cooldown then
-                   updated_group.consecutive_low_ticks + 1
-                 else 0);
-            }
-          else updated_group
-        in
-        let trigger state updated_group =
-          let final_group =
-            {
-              updated_group with
-              consecutive_high_ticks = 0;
-              consecutive_low_ticks = 0;
-              last_scale_action = now;
-            }
-          in
-          Ok (state, final_group)
-        in
-        if is_cooldown then Ok (Cooldown current_vm_state, updated_group)
-        else if updated_group.consecutive_high_ticks >= scale_up_trigger_ticks
-        then trigger (Overloaded current_vm_state) updated_group
-        else if updated_group.consecutive_low_ticks >= scale_down_trigger_ticks
-        then
-          let clone_to_kill = fst (List.hd updated_group.clones) in
-          trigger (Underloaded (clone_to_kill, current_vm_state)) updated_group
-        else if is_high then
-          Ok
-            ( Pending
-                (`Spawn, updated_group.consecutive_high_ticks, current_vm_state),
-              updated_group )
-        else if is_low then
-          Ok
-            ( Pending
-                (`Prune, updated_group.consecutive_low_ticks, current_vm_state),
-              updated_group )
-        else Ok (Normal current_vm_state, updated_group)
+  (** [evaluate_scaling group now] calculates the average CPU usage across all
+      instances in the [group] (primary and clones). It increments/resets the
+      consecutive ticks counters and evaluates the scaling status of the group.
+      Returns the scaling status and the updated group. *)
+  let evaluate_scaling group now =
+    let all_instances = group.primary :: group.clones in
+    let total_usage =
+      List.fold_left
+        (fun acc (_, v) -> acc +. v.last_cpu_usage)
+        0.0 all_instances
+    in
+    let average_usage =
+      total_usage /. float_of_int (List.length all_instances)
+    in
+    let is_cooldown = in_cooldown now group in
+    let is_high = average_usage > scale_up_threshold_percent in
+    let is_low =
+      average_usage < scale_down_threshold_percent
+      && group.clones <> []
+    in
+    let updated_group =
+      {
+        group with
+        last_tick_update = now;
+        consecutive_high_ticks =
+          (if is_high && not is_cooldown then
+             group.consecutive_high_ticks + 1
+           else 0);
+        consecutive_low_ticks =
+          (if is_low && not is_cooldown then
+             group.consecutive_low_ticks + 1
+           else 0);
+      }
+    in
+    let trigger state updated_group =
+      let final_group =
+        {
+          updated_group with
+          consecutive_high_ticks = 0;
+          consecutive_low_ticks = 0;
+          last_scale_action = now;
+        }
+      in
+      Ok (state, final_group)
+    in
+    let primary_state = snd group.primary in
+    if is_cooldown then Ok (Cooldown primary_state, updated_group)
+    else if updated_group.consecutive_high_ticks >= scale_up_trigger_ticks
+    then trigger (Overloaded primary_state) updated_group
+    else if updated_group.consecutive_low_ticks >= scale_down_trigger_ticks
+    then
+      let clone_to_kill = fst (List.hd updated_group.clones) in
+      trigger (Underloaded (clone_to_kill, primary_state)) updated_group
+    else if is_high then
+      Ok
+        ( Pending
+            (`Spawn, updated_group.consecutive_high_ticks, primary_state),
+          updated_group )
+    else if is_low then
+      Ok
+        ( Pending
+            (`Prune, updated_group.consecutive_low_ticks, primary_state),
+          updated_group )
+    else Ok (Normal primary_state, updated_group)
 
   (** [sync_group group active_vm_names] checks if the primary is still alive
       and prunes any clones that are no longer present in [active_vm_names].

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -1,5 +1,11 @@
 let a_logs = Logs.Src.create "autoscaling-logs"
+
+(** The interval at which a cluster's metrics are evaluated for scaling. *)
 let poll_interval = Duration.of_min 5
+
+(** A span representation of [poll_interval]. *)
+let poll_interval_span =
+  Ptime.Span.of_int_s (Int64.to_int (Duration.to_sec poll_interval))
 
 (** number of times a cluster is checked before deciding if it's overloaded. *)
 let scale_up_trigger_ticks = 3
@@ -8,16 +14,20 @@ let scale_up_trigger_ticks = 3
     this vm can be cloned. *)
 let scale_up_threshold_percent = 90.0
 
+(** if average CPU usage < 40% for [scale_down_trigger_ticks] consecutive
+    checks, one of the clone VMs can be pruned. *)
 let scale_down_threshold_percent = 40.0
+
+(** number of times a cluster is checked before deciding if it's underloaded. *)
 let scale_down_trigger_ticks = 5
 
 (** after spawning a new vm, wait [cooldown_period] before checking that vm
     again. *)
-let cooldown_period = 600.0
+let cooldown_period = Ptime.Span.of_int_s 600
 
 (** if no stats are gotten for a particular vm after [death_timeout] then
     consider the vm destroyed and prune it *)
-let death_timeout = 900.0
+let death_timeout = Ptime.Span.of_int_s 900
 
 module Cpu_monitor = struct
   type t = { last_cpu_time : float; last_wall_time : Ptime.t }

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -48,9 +48,9 @@ module Cpu_monitor = struct
   let measure t now (current_rusage : Vmm_core.Stats.rusage) =
     let curr_cpu_time = get_total_cpu_time current_rusage in
     let cpu_delta = curr_cpu_time -. t.last_cpu_time in
-    let elasped_time_difference = Ptime.diff now t.last_wall_time in
-    let elasped_time_in_seconds =
-      Ptime.Span.to_float_s elasped_time_difference
+    let elapsed_time_difference = Ptime.diff now t.last_wall_time in
+    let elapsed_time_in_seconds =
+      Ptime.Span.to_float_s elapsed_time_difference
     in
     if elasped_time_in_seconds <= 0.000001 then 0.0
     else if cpu_delta < 0.0 then 0.0

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -99,13 +99,9 @@ module Cluster_manager = struct
     consecutive_low_ticks : int;
   }
 
-  let clusters : (string, group) Hashtbl.t = Hashtbl.create 10
-
-  let in_cooldown now = function
-    | { last_scale_action = None; _ } -> false
-    | { last_scale_action = Some t; _ } ->
-        let span = Ptime.diff now t in
-        Ptime.Span.to_float_s span < cooldown_period
+  let in_cooldown now group =
+    let span = Ptime.diff now group.last_scale_action in
+    Ptime.Span.compare span cooldown_period < 0
 
   let should_tick now group =
     match group.last_tick_update with

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -63,9 +63,9 @@ module Cpu_monitor = struct
 end
 
 type t = {
-  mutable monitor : Cpu_monitor.t;
-  mutable last_cpu_usage : float;
-  mutable last_stats_received : Ptime.t;
+  monitor : Cpu_monitor.t;
+  last_cpu_usage : float;
+  last_stats_received : Ptime.t;
 }
 
 type scale_action = [ `Spawn | `Prune ]
@@ -92,12 +92,12 @@ module Cluster_manager = struct
 
   type group = {
     primary : vm;
-    mutable clones : vm list;
-    mutable last_scale_action : Ptime.t option;
-    mutable last_tick_update : Ptime.t option;
-    mutable next_id : int;
-    mutable consecutive_high_ticks : int;
-    mutable consecutive_low_ticks : int;
+    clones : vm list;
+    last_scale_action : Ptime.t;
+    last_tick_update : Ptime.t;
+    next_id : int;
+    consecutive_high_ticks : int;
+    consecutive_low_ticks : int;
   }
 
   let clusters : (string, group) Hashtbl.t = Hashtbl.create 10

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -115,161 +115,199 @@ module Cluster_manager = struct
         | None -> None)
     | _ -> None
 
+  let update_next_id clones =
+    let max_id =
+      List.fold_left
+        (fun acc (name, _) ->
+          match extract_name_and_clone_id name with
+          | Some (_, id) -> max acc id
+          | None -> acc)
+        0 clones
+    in
+    max_id + 1
+
+  let create_group primary =
+    {
+      primary;
+      clones = [];
+      last_scale_action = Ptime.epoch;
+      consecutive_high_ticks = 0;
+      consecutive_low_ticks = 0;
+      last_tick_update = Ptime.epoch;
+      next_id = 1;
+    }
+
+  let next_clone_name group =
+    let primary_name = fst group.primary in
+    Fmt.str "%s-clone-%d" primary_name group.next_id
+
   let add_clone_to_group g clone clone_id =
-    if not (List.mem_assoc (fst clone) g.clones) then begin
-      g.clones <- clone :: g.clones;
-      g.next_id <- max g.next_id (clone_id + 1)
-    end
+    if not (List.mem_assoc (fst clone) g.clones) then
+      let new_clones = clone :: g.clones in
+      { g with clones = new_clones; next_id = max g.next_id (clone_id + 1) }
+    else g
 
-  let register_clone user_name clone =
-    match extract_name_and_clone_id (fst clone) with
-    | Some (primary_name, _) -> (
-        match find_group_by_name ~user_name ~unikernel_name:primary_name with
-        | Some g ->
-            g.next_id <- g.next_id + 1;
-            let new_name = Fmt.str "%s-clone-%d" primary_name g.next_id in
-            add_clone_to_group g (new_name, snd clone) g.next_id;
-            g.last_scale_action <- Some (Mirage_ptime.now ());
-            Ok new_name
-        | None ->
-            Error (Fmt.str "No primary group found for '%s'." primary_name))
-    | None ->
-        let g = get_or_create ~user_name clone in
-        g.next_id <- g.next_id + 1;
-        Ok (fst clone)
-
-  let find_or_create_group ~user_name ~unikernel_name t =
-    match extract_name_and_clone_id unikernel_name with
-    | Some (primary_name, clone_id) -> (
-        match find_group_by_name ~user_name ~unikernel_name:primary_name with
-        | Some g ->
-            (* stats arrived before register_clone was called, recover silently *)
-            add_clone_to_group g (unikernel_name, t) clone_id;
-            Ok g
-        | None ->
+  let register_clone group clone =
+    let name = fst clone in
+    if String.length name > 63 then
+      Error (Fmt.str "Clone name '%s' exceeds the 63-character limit" name)
+    else
+      match extract_name_and_clone_id name with
+      | Some (primary_name, clone_id) ->
+          if String.equal primary_name (fst group.primary) then
+            Ok
+              {
+                (add_clone_to_group group clone clone_id) with
+                last_scale_action = Mirage_ptime.now ();
+              }
+          else
             Error
-              (Fmt.str "No primary group found for '%s' (derived from '%s')."
-                 primary_name unikernel_name))
-    | None -> (
-        match find_group_by_name ~user_name ~unikernel_name with
-        | Some g -> Ok g
-        | None ->
-            let g = get_or_create ~user_name (unikernel_name, t) in
-            Ok g)
+              (Fmt.str "Clone '%s' does not match group primary '%s'" name
+                 (fst group.primary))
+      | None -> Error (Fmt.str "Clone name '%s' is not a valid format" name)
 
-  let remove_clone ~user_name clone =
-    match extract_name_and_clone_id (fst clone) with
-    | Some (primary_name, _) -> (
-        match find_group_by_name ~user_name ~unikernel_name:primary_name with
-        | Some g ->
-            g.clones <-
-              List.filter
-                (fun c -> not (String.equal (fst c) (fst clone)))
-                g.clones;
-            g.last_scale_action <- Some (Mirage_ptime.now ());
-            Ok ()
-        | None ->
-            Logs.debug ~src:a_logs (fun m ->
-                m
-                  "[Cluster Manager] No primary group found during removal for \
-                   primary '%s' (derived from clone '%s')."
-                  primary_name (fst clone));
-            Error "Primary group not found during removal")
-    | None ->
-        Logs.debug ~src:a_logs (fun m ->
-            m "[Cluster Manager] Invalid clone name '%s'." (fst clone));
-        Error "Invalid clone name"
+  let remove_clone group clone_name =
+    match extract_name_and_clone_id clone_name with
+    | Some (primary_name, _) ->
+        if String.equal primary_name (fst group.primary) then
+          let new_clones =
+            List.filter
+              (fun (n, _) -> not (String.equal n clone_name))
+              group.clones
+          in
+          let next_id = update_next_id new_clones in
+          Ok
+            {
+              group with
+              clones = new_clones;
+              next_id;
+              last_scale_action = Mirage_ptime.now ();
+            }
+        else
+          Error
+            (Fmt.str "Clone '%s' does not match group primary '%s'" clone_name
+               (fst group.primary))
+    | None -> Error (Fmt.str "Clone name '%s' is not a valid format" clone_name)
 
+  (** [check_group_average group key now rusage] calculates the average CPU
+      usage across all instances in the [group] (primary and clones). Since
+      stats arrive for a single VM at a time (identified by [key]), we: 1.
+      Calculate the current CPU usage for the VM [key] using the new [rusage].
+      2. Use the last cached CPU usage for all other VMs in the group. 3. Update
+      the state of VM [key] with the new measurements. 4. Return the computed
+      average, the updated VM state, and the updated group. *)
   let check_group_average group key now rusage =
     let all_instances = group.primary :: group.clones in
-    let current_vm_state = ref None in
-    let total_usage =
-      List.fold_left
-        (fun acc (name, vm) ->
-          if String.equal name key then begin
-            let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
-            let new_monitor = Cpu_monitor.create now rusage in
-            vm.monitor <- new_monitor;
-            vm.last_cpu_usage <- current_vm_usage;
-            vm.last_stats_received <- now;
-            current_vm_state := Some vm;
-            acc +. current_vm_usage
-          end
-          else acc +. vm.last_cpu_usage)
-        0.0 all_instances
-    in
-    match !current_vm_state with
+    match List.assoc_opt key all_instances with
     | None -> Error "Current VM not found in group during average check"
-    | Some state ->
+    | Some vm ->
+        let current_vm_usage = Cpu_monitor.measure vm.monitor now rusage in
+        let state =
+          {
+            monitor = Cpu_monitor.create now rusage;
+            last_cpu_usage = current_vm_usage;
+            last_stats_received = now;
+          }
+        in
+        let total_usage =
+          List.fold_left
+            (fun acc (name, v) ->
+              if String.equal name key then acc +. current_vm_usage
+              else acc +. v.last_cpu_usage)
+            0.0 all_instances
+        in
         let average_usage =
           total_usage /. float_of_int (List.length all_instances)
         in
-        Ok (average_usage, state)
+        (* Construct the new updated group state *)
+        let updated_group =
+          if String.equal key (fst group.primary) then
+            { group with primary = (key, state) }
+          else
+            let new_clones =
+              List.map
+                (fun (n, v) ->
+                  if String.equal n key then (n, state) else (n, v))
+                group.clones
+            in
+            { group with clones = new_clones }
+        in
+        Ok (average_usage, state, updated_group)
 
+  (** [check_group_status group key now rusage] evaluates the scaling status of
+      the [group] when new stats [rusage] at time [now] arrive for the VM [key].
+      It updates the average load of the group, ticks the consecutive high/low
+      counters, and determines if a scaling action (spawn or prune) is
+      triggered. *)
   let check_group_status group key now rusage =
     match check_group_average group key now rusage with
     | Error e -> Error e
-    | Ok (average_usage, current_vm_state) ->
-        let is_cooldown = in_cooldown now group in
+    | Ok (average_usage, current_vm_state, updated_group) ->
+        let is_cooldown = in_cooldown now updated_group in
         let is_high = average_usage > scale_up_threshold_percent in
         let is_low =
-          average_usage < scale_down_threshold_percent && group.clones <> []
+          average_usage < scale_down_threshold_percent
+          && updated_group.clones <> []
         in
-        if should_tick now group then begin
-          group.last_tick_update <- Some now;
-          group.consecutive_high_ticks <-
-            (if is_high && not is_cooldown then group.consecutive_high_ticks + 1
-             else 0);
-          group.consecutive_low_ticks <-
-            (if is_low && not is_cooldown then group.consecutive_low_ticks + 1
-             else 0)
-        end;
-        let trigger state =
-          group.consecutive_high_ticks <- 0;
-          group.consecutive_low_ticks <- 0;
-          group.last_scale_action <- Some now;
-          Ok state
+        let updated_group =
+          if should_tick now updated_group then
+            {
+              updated_group with
+              last_tick_update = now;
+              consecutive_high_ticks =
+                (if is_high && not is_cooldown then
+                   updated_group.consecutive_high_ticks + 1
+                 else 0);
+              consecutive_low_ticks =
+                (if is_low && not is_cooldown then
+                   updated_group.consecutive_low_ticks + 1
+                 else 0);
+            }
+          else updated_group
         in
-        if is_cooldown then Ok (Cooldown current_vm_state)
-        else if group.consecutive_high_ticks >= scale_up_trigger_ticks then
-          trigger (Overloaded current_vm_state)
-        else if group.consecutive_low_ticks >= scale_down_trigger_ticks then
-          let clone_to_kill = fst (List.hd group.clones) in
-          trigger (Underloaded (clone_to_kill, current_vm_state))
+        let trigger state updated_group =
+          let final_group =
+            {
+              updated_group with
+              consecutive_high_ticks = 0;
+              consecutive_low_ticks = 0;
+              last_scale_action = now;
+            }
+          in
+          Ok (state, final_group)
+        in
+        if is_cooldown then Ok (Cooldown current_vm_state, updated_group)
+        else if updated_group.consecutive_high_ticks >= scale_up_trigger_ticks
+        then trigger (Overloaded current_vm_state) updated_group
+        else if updated_group.consecutive_low_ticks >= scale_down_trigger_ticks
+        then
+          let clone_to_kill = fst (List.hd updated_group.clones) in
+          trigger (Underloaded (clone_to_kill, current_vm_state)) updated_group
         else if is_high then
-          Ok (Pending (`Spawn, group.consecutive_high_ticks, current_vm_state))
+          Ok
+            ( Pending
+                (`Spawn, updated_group.consecutive_high_ticks, current_vm_state),
+              updated_group )
         else if is_low then
-          Ok (Pending (`Prune, group.consecutive_low_ticks, current_vm_state))
-        else Ok (Normal current_vm_state)
+          Ok
+            ( Pending
+                (`Prune, updated_group.consecutive_low_ticks, current_vm_state),
+              updated_group )
+        else Ok (Normal current_vm_state, updated_group)
 
-  let is_dead now (vm : t) =
-    Ptime.Span.to_float_s (Ptime.diff now vm.last_stats_received)
-    > death_timeout
-
-  let prune_dead_clusters now =
-    let dead_keys =
-      Hashtbl.fold
-        (fun primary_name group acc ->
-          if is_dead now (snd group.primary) then primary_name :: acc
-          else begin
-            let alive_clones, dead_clones =
-              List.partition (fun (_, vm) -> not (is_dead now vm)) group.clones
-            in
-            match dead_clones with
-            | [] -> acc
-            | _ ->
-                Logs.debug ~src:a_logs (fun m ->
-                    m "[Cluster Manager] Pruning %d dead clones"
-                      (List.length dead_clones));
-                group.clones <- alive_clones;
-                acc
-          end)
-        clusters []
-    in
-    List.iter
-      (fun key ->
-        Logs.debug ~src:a_logs (fun m ->
-            m "[Cluster Manager] Pruning dead cluster: %s" key);
-        Hashtbl.remove clusters key)
-      dead_keys
+  (** [sync_group group active_vm_names] checks if the primary is still alive
+      and prunes any clones that are no longer present in [active_vm_names].
+      Returns the updated group, or Error `Primary_dead if the primary VM has
+      died. *)
+  let sync_group group active_vm_names =
+    let primary_name = fst group.primary in
+    if not (List.mem primary_name active_vm_names) then Error `Primary_dead
+    else
+      let new_clones =
+        List.filter
+          (fun (name, _) -> List.mem name active_vm_names)
+          group.clones
+      in
+      let next_id = update_next_id new_clones in
+      Ok { group with clones = new_clones; next_id }
 end

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -4,8 +4,7 @@ let a_logs = Logs.Src.create "autoscaling-logs"
 let poll_interval = Duration.of_min 5
 
 (** A span representation of [poll_interval]. *)
-let poll_interval_span =
-  Ptime.Span.of_int_s (Int64.to_int (Duration.to_sec poll_interval))
+let poll_interval_span = Ptime.Span.of_int_s (Duration.to_sec poll_interval)
 
 (** number of times a cluster is checked before deciding if it's overloaded. *)
 let scale_up_trigger_ticks = 3


### PR DESCRIPTION
This module implements the logic for monitoring CPU usage of the currently running unikernels and decides when to scale up or scale down.

## Configuration

* **`poll_interval`**: How frequently the system expects to evaluate the unikernel stats.
* **`scale_up_threshold_percent`**: The CPU load threshold that triggers a scale up.
* **`scale_up_trigger_ticks`**: How many consecutive stats reports must exceed the scale up threshold before a clone is created.
* **`scale_down_threshold_percent`**: The CPU load threshold that triggers a scale down event.
* **`scale_down_trigger_ticks`**: How many consecutive stats reports must fall below the scale down threshold before a clone is destroyed.
* **`cooldown_period`**: The grace period after any scaling action where the system pauses scaling to prevent rapid creation/destruction of clones.
* **`death_timeout`**: The maximum time to wait for stats from a VM before it is considered dead.

## Modules

### `Cpu_monitor`

Converts raw `rusage` stats from Albatross into a CPU utilization percentage (0-100%).

### `Cluster_manager`

Tracks and evaluates load metrics for groups containing a primary unikernel and all of its clones.

* **`in_cooldown`**: Checks if the group recently had a scale operation and should ignore load changes.
* **`extract_name_and_clone_id`**: Parses a clone's name to separate the primary name from the clone ID.
* **`create_group`**: Initializes a new scaling group state with the primary VM.
* **`next_clone_name`**: Generates a unique name for the next clone based on the group's `next_id`.
* **`register_clone`**: Adds a newly created clone to the group.
* **`remove_clone`**: Removes a clone from the group and updates the next clone ID.
* **`update_vm_metrics`**: Calculates and updates CPU usage metrics for a specific VM (primary or clone) in the group.
* **`evaluate_scaling`**: Calculates the group-wide average CPU load, updates consecutive tick counters, and returns the scaling status.
* **`sync_group`**: Synchronizes the group state against active VMs, pruning dead clones and reporting if the primary has died.
