### PR TITLE
Spawn a new clone

### DIFF
--- a/albatross.ml
+++ b/albatross.ml
@@ -365,6 +365,23 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     in
     continue_reading name dec d tls_flow
 
+  let get_unikernel_binary name f tls_flow d =
+    let dec = function
+      | Error s ->
+          Logs.err (fun m ->
+              m "albatross stop reading unikernel binary %a: error %s"
+                Vmm_core.Name.pp name s);
+          Error ()
+      | Ok (hdr, `Success (`Unikernel_image (_compressed, data))) -> f data
+      | Ok w ->
+          Logs.warn (fun m ->
+              m "albatross unexpected reply, need unikernel binary, got %a"
+                (Vmm_commands.pp_wire ~verbose:false)
+                w);
+          Ok ()
+    in
+    continue_reading name dec d tls_flow
+
   let raw_query (stack : S.t) t ?(name = Vmm_core.Name.root) certificates cmd
       ?push f =
     let open Lwt.Infix in
@@ -613,6 +630,14 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     | Ok (vmm_name, certificates) ->
         raw_query stack t ~name:vmm_name certificates cmd
           (block_data vmm_name f)
+
+  let query_unikernel_binary stack t ~domain ~name f =
+    let cmd = `Unikernel_cmd (`Unikernel_get 4) in
+    match certs t domain name cmd with
+    | Error str -> Lwt.return (Error str)
+    | Ok (vmm_name, certificates) ->
+        raw_query stack t ~name:vmm_name certificates cmd
+          (get_unikernel_binary vmm_name f)
 
   let query_stats stack t f =
     let cmd = `Stats_cmd `Stats_subscribe in

--- a/albatross.ml
+++ b/albatross.ml
@@ -263,19 +263,31 @@ module Make (S : Tcpip.Stack.V4V6) = struct
               m "albatross buffer too small: %u bytes, requires %u bytes"
                 (String.length data - 4 - off)
                 len);
-          acc)
-      else if String.length data = off then acc
+          (acc, None))
+      else if String.length data = off then (acc, None)
       else (
         Logs.warn (fun m ->
             m "albatross buffer too small: %u bytes leftover"
               (String.length data - off));
-        acc)
+        (acc, None))
     in
-    split [] data 0 |> List.rev
+    split [] data 0 |> fun (acc, left) -> (List.rev acc, left)
 
-  let rec continue_reading name f d flow =
+  let split_many_with_leftover data =
+    let rec split acc data off =
+      if String.length data - off >= 4 then
+        let len = Int32.to_int (String.get_int32_be data off) in
+        if String.length data - off >= 4 + len then
+          split (String.sub data (4 + off) len :: acc) data (off + len + 4)
+        else (acc, Some (String.sub data off (String.length data - off)))
+      else if String.length data = off then (acc, None)
+      else (acc, Some (String.sub data off (String.length data - off)))
+    in
+    split [] data 0
+
+  let rec continue_reading name f ?(split = split_many) d flow =
     let open Lwt.Infix in
-    let bufs = split_many d in
+    let bufs, left_over = split d in
     let r =
       List.fold_left
         (fun acc d ->
@@ -287,7 +299,13 @@ module Make (S : Tcpip.Stack.V4V6) = struct
     | Ok () -> (
         TLS.read flow >>= fun r ->
         match r with
-        | Ok (`Data d) -> continue_reading name f (Cstruct.to_string d) flow
+        | Ok (`Data d) -> (
+            match left_over with
+            | None -> continue_reading name f (Cstruct.to_string d) flow
+            | Some left_over_string ->
+                continue_reading name f ~split:split_many_with_leftover
+                  (left_over_string ^ Cstruct.to_string d)
+                  flow)
         | Ok `Eof ->
             Logs.info (fun m ->
                 m "albatross received eof while reading stream %a"
@@ -372,7 +390,9 @@ module Make (S : Tcpip.Stack.V4V6) = struct
               m "albatross stop reading unikernel binary %a: error %s"
                 Vmm_core.Name.pp name s);
           Error ()
-      | Ok (hdr, `Success (`Unikernel_image (_compressed, data))) -> f data
+      | Ok (hdr, `Success (`Unikernel_image (_compressed, data))) ->
+          let _ = f data in
+          Error ()
       | Ok w ->
           Logs.warn (fun m ->
               m "albatross unexpected reply, need unikernel binary, got %a"
@@ -380,7 +400,7 @@ module Make (S : Tcpip.Stack.V4V6) = struct
                 w);
           Ok ()
     in
-    continue_reading name dec d tls_flow
+    continue_reading ~split:split_many_with_leftover name dec d tls_flow
 
   let raw_query (stack : S.t) t ?(name = Vmm_core.Name.root) certificates cmd
       ?push f =

--- a/albatross.ml
+++ b/albatross.ml
@@ -626,43 +626,6 @@ module Make (S : Tcpip.Stack.V4V6) = struct
         raw_query stack t ~name:vmm_name certificates cmd
           (stats_data vmm_name f)
 
-  let unikernel_get_data name f tls_flow d =
-    let open Lwt.Infix in
-    let rec read_loop acc =
-      if String.length acc >= 4 then
-        let len = Int32.to_int (String.get_int32_be acc 0) in
-        if String.length acc >= 4 + len then (
-          match decode_reply acc with
-          | Error msg -> Lwt.return_error msg
-          | Ok (_, `Success (`Unikernel_image (compressed, binary))) ->
-              f (compressed, binary)
-          | Ok w ->
-              Logs.warn (fun m ->
-                  m "albatross unexpected reply %a"
-                    (Vmm_commands.pp_wire ~verbose:false)
-                    w);
-              Lwt.return_error "Unexpected reply for Unikernel_get")
-        else
-          TLS.read tls_flow >>= function
-          | Ok (`Data d) -> read_loop (acc ^ Cstruct.to_string d)
-          | Ok `Eof -> Lwt.return_error "EOF while reading unikernel image"
-          | Error _ -> Lwt.return_error "TLS error"
-      else
-        TLS.read tls_flow >>= function
-        | Ok (`Data d) -> read_loop (acc ^ Cstruct.to_string d)
-        | Ok `Eof -> Lwt.return_error "EOF while reading unikernel image header"
-        | Error _ -> Lwt.return_error "TLS error"
-    in
-    read_loop d
-
-  let query_unikernel_get stack t ~domain ~name f =
-    let cmd = `Unikernel_cmd (`Unikernel_get 0) in
-    match certs t domain name cmd with
-    | Error str -> Lwt.return (Error str)
-    | Ok (vmm_name, certificates) ->
-        raw_query stack t ~name:vmm_name certificates cmd
-          (unikernel_get_data vmm_name f)
-
   let set_policy stack t ~domain policy =
     let open Lwt.Infix in
     let old_policies = t.policies in

--- a/albatross.ml
+++ b/albatross.ml
@@ -626,6 +626,43 @@ module Make (S : Tcpip.Stack.V4V6) = struct
         raw_query stack t ~name:vmm_name certificates cmd
           (stats_data vmm_name f)
 
+  let unikernel_get_data name f tls_flow d =
+    let open Lwt.Infix in
+    let rec read_loop acc =
+      if String.length acc >= 4 then
+        let len = Int32.to_int (String.get_int32_be acc 0) in
+        if String.length acc >= 4 + len then (
+          match decode_reply acc with
+          | Error msg -> Lwt.return_error msg
+          | Ok (_, `Success (`Unikernel_image (compressed, binary))) ->
+              f (compressed, binary)
+          | Ok w ->
+              Logs.warn (fun m ->
+                  m "albatross unexpected reply %a"
+                    (Vmm_commands.pp_wire ~verbose:false)
+                    w);
+              Lwt.return_error "Unexpected reply for Unikernel_get")
+        else
+          TLS.read tls_flow >>= function
+          | Ok (`Data d) -> read_loop (acc ^ Cstruct.to_string d)
+          | Ok `Eof -> Lwt.return_error "EOF while reading unikernel image"
+          | Error _ -> Lwt.return_error "TLS error"
+      else
+        TLS.read tls_flow >>= function
+        | Ok (`Data d) -> read_loop (acc ^ Cstruct.to_string d)
+        | Ok `Eof -> Lwt.return_error "EOF while reading unikernel image header"
+        | Error _ -> Lwt.return_error "TLS error"
+    in
+    read_loop d
+
+  let query_unikernel_get stack t ~domain ~name f =
+    let cmd = `Unikernel_cmd (`Unikernel_get 0) in
+    match certs t domain name cmd with
+    | Error str -> Lwt.return (Error str)
+    | Ok (vmm_name, certificates) ->
+        raw_query stack t ~name:vmm_name certificates cmd
+          (unikernel_get_data vmm_name f)
+
   let set_policy stack t ~domain policy =
     let open Lwt.Infix in
     let old_policies = t.policies in

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -156,6 +156,9 @@ module Cluster_manager = struct
     else g
 
   let register_clone group clone =
+    (* TODO: add a validation rule during unikernel creation so users 
+            can't name any vm with the suffix "-clone-INT". 
+            What about unikernels deployed directly on albatross? *)
     let name = fst clone in
     match extract_name_and_clone_id name with
     | Some (primary_name, clone_id) ->

--- a/autoscaler.ml
+++ b/autoscaler.ml
@@ -205,6 +205,8 @@ module Cluster_manager = struct
           (Fmt.str "Clone name '%s' is not a valid format"
              (Configuration.name_to_str clone_name))
 
+  let remove_cooldown group = { group with last_scale_action = Ptime.epoch }
+
   (** [update_vm_metrics group key now rusage] calculates the CPU usage for the
       VM [key] using [rusage] at time [now]. It updates the cached state of VM
       [key] in the [group] (either primary or one of the clones). Returns the

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3019,6 +3019,21 @@ struct
 
   module Log = (val Logs.src_log Autoscaler.a_logs : Logs.LOG)
 
+  let least_used_cpuid stack albatross user_name =
+    user_unikernels_by_instance stack albatross user_name >|= fun unikernels ->
+    match Albatross_state.policy ~domain:user_name albatross with
+    | Error err -> Error err
+    | Ok None -> Error "No policy found for user"
+    | Ok (Some p) -> (
+        let cpu_usage_count = Utils.cpu_usage_count p unikernels in
+        let sorted_cpus =
+          cpu_usage_count
+          |> List.sort (fun (_, c1) (_, c2) -> Int.compare c1 c2)
+        in
+        match sorted_cpus with
+        | (id, _) :: _ -> Ok id
+        | [] -> Error "No cpuids available in user policy")
+
   let put_group ~(user_name : Vmm_core.Name.Label.t)
       ~(unikernel_name : Vmm_core.Name.Label.t) group =
     let unikernel_map =
@@ -3030,81 +3045,86 @@ struct
         (Label_map.add unikernel_name group unikernel_map)
         !scaling_groups
 
-  let spawn_clone stack albatross ~unikernel_name ~clone_name ~user_name =
-    user_unikernel stack albatross ~user_name ~unikernel_name >>= function
-    | Error err ->
-        Lwt.return_error
-          (Fmt.str "An error occured trying to fetch %s from albatross: %s"
-             (Configuration.name_to_str unikernel_name)
-             err)
-    | Ok (_, unikernel) -> (
-        if unikernel.block_devices <> [] then begin
-          Log.info (fun m ->
-              m
-                "spawn_clone: Aborting clone of %s because it has block \
-                 devices."
-                (Configuration.name_to_str unikernel_name));
-          Lwt.return_error
-            "Unikernels with block devices cannot be safely cloned"
-        end
-        else
-          let bridges =
-            List.map
-              (fun { Vmm_core.Unikernel.unikernel_device; host_device; _ } ->
-                (unikernel_device, Some host_device, None))
-              unikernel.bridges
-          in
-          let argv =
-            match unikernel.argv with
-            | None -> None
-            | Some args ->
-                Log.info (fun m ->
-                    m "Cloning %s: original argv: %s"
-                      (Configuration.name_to_str unikernel_name)
-                      (String.concat "," args));
-                Some (Utils.filter_ip_args args)
-          in
-          least_used_cpuid stack albatross user_name >>= function
-          | Error err -> Lwt.return_error err
-          | Ok cpuid -> (
-              let config : Vmm_core.Unikernel.config =
-                {
-                  typ = unikernel.typ;
-                  fail_behaviour = unikernel.fail_behaviour;
-                  startup = unikernel.startup;
-                  memory = unikernel.memory;
-                  block_devices = [];
-                  add_name = false;
-                  bridges;
-                  argv;
-                  numcpus = unikernel.numcpus;
-                  linux_boot_partition = unikernel.linux_boot_partition;
-                  compressed = false;
-                  image = "";
-                  cpuids = Vmm_core.IS.singleton cpuid;
-                }
+  let spawn_clone stack store albatross ~unikernel_name ~clone_name ~user_name =
+    match Store.find_by_name store user_name with
+    | None -> Lwt.return_error "User not found"
+    | Some user -> (
+        user_unikernel stack albatross ~user_name ~unikernel_name >>= function
+        | Error err ->
+            Lwt.return_error
+              (Fmt.str "An error occured trying to fetch %s from albatross: %s"
+                 (Configuration.name_to_str unikernel_name)
+                 err)
+        | Ok (_, unikernel) -> (
+            if
+              (* unikernels with block devices can't be reliably scaled because block devices can't be shared by multiple unikernels *)
+              unikernel.block_devices <> []
+            then begin
+              Log.info (fun m ->
+                  m
+                    "spawn_clone: Aborting clone of %s because it has block \
+                     devices."
+                    (Configuration.name_to_str unikernel_name));
+              Lwt.return_error
+                "Unikernels with block devices cannot be safely cloned"
+            end
+            else
+              let bridges =
+                List.map
+                  (fun { Vmm_core.Unikernel.unikernel_device; host_device; _ }
+                     -> (unikernel_device, Some host_device, None))
+                  unikernel.bridges
               in
-              Albatross_state.query_unikernel_get stack albatross
-                ~domain:user_name ~name:unikernel_name
-                (fun (compressed, binary_string) ->
-                  let config = { config with compressed } in
-                  let data_stream, push_chunks = Lwt_stream.create () in
-                  let push () = Lwt_stream.get data_stream in
-                  push_chunks (Some binary_string);
-                  push_chunks None;
-                  force_create_unikernel stack albatross
-                    ~unikernel_name:clone_name ~push config user
+              let argv =
+                let name_arg =
+                  "--name=" ^ Configuration.name_to_str unikernel_name
+                in
+                match unikernel.argv with
+                | None -> Some [ name_arg ]
+                | Some args -> Some (name_arg :: args)
+              in
+              least_used_cpuid stack albatross user_name >>= function
+              | Error err -> Lwt.return_error err
+              | Ok cpuid -> (
+                  let config : Vmm_core.Unikernel.config =
+                    {
+                      typ = unikernel.typ;
+                      fail_behaviour = unikernel.fail_behaviour;
+                      startup = unikernel.startup;
+                      memory = unikernel.memory;
+                      block_devices = [];
+                      add_name = true;
+                      bridges;
+                      (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
+                      argv;
+                      numcpus = unikernel.numcpus;
+                      linux_boot_partition = unikernel.linux_boot_partition;
+                      compressed = false;
+                      image = "";
+                      cpuids = Vmm_core.IS.singleton cpuid;
+                    }
+                  in
+                  Albatross_state.query_unikernel_get stack albatross
+                    ~domain:user_name ~name:unikernel_name
+                    (fun (compressed, binary_string) ->
+                      let config = { config with compressed } in
+                      let data_stream, push_chunks = Lwt_stream.create () in
+                      let push () = Lwt_stream.get data_stream in
+                      push_chunks (Some binary_string);
+                      push_chunks None;
+                      force_create_unikernel stack albatross
+                        ~unikernel_name:clone_name ~push config user
+                      >>= function
+                      | Error (`Msg err, _status) -> Lwt.return_error err
+                      | Ok () -> Lwt.return_ok ())
                   >>= function
-                  | Error (`Msg err, _status) -> Lwt.return_error err
-                  | Ok () -> Lwt.return_ok ())
-              >>= function
-              | Error err ->
-                  Log.err (fun m ->
-                      m "spawn_clone: Error getting binary for %s: %s"
-                        (Configuration.name_to_str unikernel_name)
-                        err);
-                  Lwt.return_error err
-              | Ok () -> Lwt.return_ok ()))
+                  | Error err ->
+                      Log.err (fun m ->
+                          m "spawn_clone: Error getting binary for %s: %s"
+                            (Configuration.name_to_str unikernel_name)
+                            err);
+                      Lwt.return_error err
+                  | Ok () -> Lwt.return_ok ())))
 
   let prune_clone stack albatross group ~unikernel_name ~clone_to_kill
       ~user_name =
@@ -3152,7 +3172,8 @@ struct
                   err);
             Lwt.return_error err)
 
-  let evaluate_scaling stack albatross group now ~user_name ~unikernel_name =
+  let evaluate_scaling stack store albatross group now user_name unikernel_name
+      =
     match Autoscaler.Cluster_manager.evaluate_scaling group now with
     | Error err ->
         Lwt.return_error
@@ -3211,7 +3232,7 @@ struct
                           (Configuration.name_to_str unikernel_name)
                           scaler.last_cpu_usage
                           (Configuration.name_to_str next_name));
-                    spawn_clone stack albatross ~unikernel_name:unikernel_key
+                    spawn_clone stack store albatross ~unikernel_name
                       ~clone_name:next_name ~user_name))
         | Autoscaler.Underloaded (clone_to_kill, scaler) ->
             Log.info (fun m ->
@@ -3311,8 +3332,8 @@ struct
                         ~unikernel_name:primary_name updated_group;
                       if Vmm_core.Name.Label.equal unikernel_name primary_name
                       then
-                        evaluate_scaling stack state updated_group now
-                          ~user_name:user.name ~unikernel_name:primary_name
+                        evaluate_scaling stack store state updated_group now
+                          user.name primary_name
                       else Lwt.return_ok ())
                 else Lwt.return (Ok ()))
         | _ ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3126,17 +3126,7 @@ struct
                         ~unikernel_name:clone_name ~push config user
                       >>= function
                       | Error (`Msg err, _status) -> Lwt.return_error err
-                      | Ok () -> (
-                          Lwt.return_ok () >>= function
-                          | Error err ->
-                              Log.err (fun m ->
-                                  m
-                                    "spawn_clone: Error getting binary for %s: \
-                                     %s"
-                                    (Configuration.name_to_str unikernel_name)
-                                    err);
-                              Lwt.return_error err
-                          | Ok () -> Lwt.return_ok ()))
+                      | Ok () -> Lwt.return_ok ())
                   | Ok w ->
                       Logs.err (fun m ->
                           m "albatross returned: %a"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3086,28 +3086,38 @@ struct
               least_used_cpuid stack albatross user_name >>= function
               | Error err -> Lwt.return_error err
               | Ok cpuid -> (
-                  let config : Vmm_core.Unikernel.config =
-                    {
-                      typ = unikernel.typ;
-                      fail_behaviour = unikernel.fail_behaviour;
-                      startup = unikernel.startup;
-                      memory = unikernel.memory;
-                      block_devices = [];
-                      add_name = true;
-                      bridges;
-                      (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
-                      argv;
-                      numcpus = unikernel.numcpus;
-                      linux_boot_partition = unikernel.linux_boot_partition;
-                      compressed = false;
-                      image = "";
-                      cpuids = Vmm_core.IS.singleton cpuid;
-                    }
-                  in
-                  Albatross_state.query_unikernel_get stack albatross
-                    ~domain:user_name ~name:unikernel_name
-                    (fun (compressed, binary_string) ->
-                      let config = { config with compressed } in
+                  Albatross_state.query stack albatross ~domain:user_name
+                    ~name:unikernel_name
+                    (`Unikernel_cmd (`Unikernel_get 4))
+                  >>= function
+                  | Error err ->
+                      Log.err (fun m ->
+                          m "Error getting binary for %s: %s"
+                            (Configuration.name_to_str unikernel_name)
+                            err);
+                      Lwt.return_error err
+                  | Ok
+                      ( _hdr,
+                        `Success (`Unikernel_image (compressed, binary_string))
+                      ) -> (
+                      let config : Vmm_core.Unikernel.config =
+                        {
+                          typ = unikernel.typ;
+                          fail_behaviour = unikernel.fail_behaviour;
+                          startup = unikernel.startup;
+                          memory = unikernel.memory;
+                          block_devices = [];
+                          add_name = true;
+                          bridges;
+                          (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
+                          argv;
+                          numcpus = unikernel.numcpus;
+                          linux_boot_partition = unikernel.linux_boot_partition;
+                          compressed;
+                          image = binary_string;
+                          cpuids = Vmm_core.IS.singleton cpuid;
+                        }
+                      in
                       let data_stream, push_chunks = Lwt_stream.create () in
                       let push () = Lwt_stream.get data_stream in
                       push_chunks (Some binary_string);
@@ -3116,15 +3126,26 @@ struct
                         ~unikernel_name:clone_name ~push config user
                       >>= function
                       | Error (`Msg err, _status) -> Lwt.return_error err
-                      | Ok () -> Lwt.return_ok ())
-                  >>= function
-                  | Error err ->
-                      Log.err (fun m ->
-                          m "spawn_clone: Error getting binary for %s: %s"
-                            (Configuration.name_to_str unikernel_name)
-                            err);
-                      Lwt.return_error err
-                  | Ok () -> Lwt.return_ok ())))
+                      | Ok () -> (
+                          Lwt.return_ok () >>= function
+                          | Error err ->
+                              Log.err (fun m ->
+                                  m
+                                    "spawn_clone: Error getting binary for %s: \
+                                     %s"
+                                    (Configuration.name_to_str unikernel_name)
+                                    err);
+                              Lwt.return_error err
+                          | Ok () -> Lwt.return_ok ()))
+                  | Ok w ->
+                      Logs.err (fun m ->
+                          m "albatross returned: %a"
+                            (Vmm_commands.pp_wire ~verbose:true)
+                            w);
+                      Lwt.return_error
+                        (Fmt.str "Expected unikernel binary, but got %a"
+                           (Vmm_commands.pp_wire ~verbose:false)
+                           w))))
 
   let prune_clone stack albatross group ~unikernel_name ~clone_to_kill
       ~user_name =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3080,14 +3080,17 @@ struct
               | Error err -> Lwt.return_error err
               | Ok cpuid -> (
                   let argv =
-                    Option.fold unikernel.argv ~none:None ~some:(fun arg ->
-                        Some
-                          (List.fold_left
-                             (fun acc arg ->
-                               if String.starts_with ~prefix:"--name=" arg then
-                                 acc
-                               else arg :: acc)
-                             [] arg))
+                    Option.map
+                      (fun args ->
+                        List.map
+                          (fun arg ->
+                            String.split_on_char ' ' arg
+                            |> List.filter (fun s ->
+                                   not (String.starts_with ~prefix:"--name=" s))
+                            |> String.concat " ")
+                          args
+                        |> List.filter (fun s -> s <> ""))
+                      unikernel.argv
                   in
                   let config : Vmm_core.Unikernel.config =
                     {

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3030,6 +3030,82 @@ struct
         (Label_map.add unikernel_name group unikernel_map)
         !scaling_groups
 
+  let spawn_clone stack albatross ~unikernel_name ~clone_name ~user_name =
+    user_unikernel stack albatross ~user_name ~unikernel_name >>= function
+    | Error err ->
+        Lwt.return_error
+          (Fmt.str "An error occured trying to fetch %s from albatross: %s"
+             (Configuration.name_to_str unikernel_name)
+             err)
+    | Ok (_, unikernel) -> (
+        if unikernel.block_devices <> [] then begin
+          Log.info (fun m ->
+              m
+                "spawn_clone: Aborting clone of %s because it has block \
+                 devices."
+                (Configuration.name_to_str unikernel_name));
+          Lwt.return_error
+            "Unikernels with block devices cannot be safely cloned"
+        end
+        else
+          let bridges =
+            List.map
+              (fun { Vmm_core.Unikernel.unikernel_device; host_device; _ } ->
+                (unikernel_device, Some host_device, None))
+              unikernel.bridges
+          in
+          let argv =
+            match unikernel.argv with
+            | None -> None
+            | Some args ->
+                Log.info (fun m ->
+                    m "Cloning %s: original argv: %s"
+                      (Configuration.name_to_str unikernel_name)
+                      (String.concat "," args));
+                Some (Utils.filter_ip_args args)
+          in
+          least_used_cpuid stack albatross user_name >>= function
+          | Error err -> Lwt.return_error err
+          | Ok cpuid -> (
+              let config : Vmm_core.Unikernel.config =
+                {
+                  typ = unikernel.typ;
+                  fail_behaviour = unikernel.fail_behaviour;
+                  startup = unikernel.startup;
+                  memory = unikernel.memory;
+                  block_devices = [];
+                  add_name = false;
+                  bridges;
+                  argv;
+                  numcpus = unikernel.numcpus;
+                  linux_boot_partition = unikernel.linux_boot_partition;
+                  compressed = false;
+                  image = "";
+                  cpuids = Vmm_core.IS.singleton cpuid;
+                }
+              in
+              Albatross_state.query_unikernel_get stack albatross
+                ~domain:user_name ~name:unikernel_name
+                (fun (compressed, binary_string) ->
+                  let config = { config with compressed } in
+                  let data_stream, push_chunks = Lwt_stream.create () in
+                  let push () = Lwt_stream.get data_stream in
+                  push_chunks (Some binary_string);
+                  push_chunks None;
+                  force_create_unikernel stack albatross
+                    ~unikernel_name:clone_name ~push config user
+                  >>= function
+                  | Error (`Msg err, _status) -> Lwt.return_error err
+                  | Ok () -> Lwt.return_ok ())
+              >>= function
+              | Error err ->
+                  Log.err (fun m ->
+                      m "spawn_clone: Error getting binary for %s: %s"
+                        (Configuration.name_to_str unikernel_name)
+                        err);
+                  Lwt.return_error err
+              | Ok () -> Lwt.return_ok ()))
+
   let prune_clone stack albatross group ~unikernel_name ~clone_to_kill
       ~user_name =
     Albatross_state.query stack albatross ~domain:user_name ~name:clone_to_kill
@@ -3135,7 +3211,8 @@ struct
                           (Configuration.name_to_str unikernel_name)
                           scaler.last_cpu_usage
                           (Configuration.name_to_str next_name));
-                    Lwt.return_ok ()))
+                    spawn_clone stack albatross ~unikernel_name:unikernel_key
+                      ~clone_name:next_name ~user_name))
         | Autoscaler.Underloaded (clone_to_kill, scaler) ->
             Log.info (fun m ->
                 m "[%s/%s]: underloaded (%d%%), pruning: %s"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3045,7 +3045,8 @@ struct
         (Label_map.add unikernel_name group unikernel_map)
         !scaling_groups
 
-  let spawn_clone stack store albatross ~unikernel_name ~clone_name ~user_name =
+  let spawn_clone stack store albatross ~unikernel_name ~clone_name ~user_name
+      group scaler =
     match Store.find_by_name store user_name with
     | None -> Lwt.return_error "User not found"
     | Some user -> (
@@ -3083,6 +3084,8 @@ struct
                     (`Unikernel_cmd (`Unikernel_get 4))
                   >>= function
                   | Error err ->
+                      put_group ~user_name ~unikernel_name
+                        (Autoscaler.Cluster_manager.remove_cooldown group);
                       Log.err (fun m ->
                           m "Error getting binary for %s: %s"
                             (Configuration.name_to_str unikernel_name)
@@ -3117,8 +3120,26 @@ struct
                       force_create_unikernel stack albatross
                         ~unikernel_name:clone_name ~push config user
                       >>= function
-                      | Error (`Msg err, _status) -> Lwt.return_error err
-                      | Ok () -> Lwt.return_ok ())
+                      | Error (`Msg err, _status) ->
+                          put_group ~user_name ~unikernel_name
+                            (Autoscaler.Cluster_manager.remove_cooldown group);
+                          Lwt.return_error err
+                      | Ok () -> (
+                          match
+                            Autoscaler.Cluster_manager.register_clone group
+                              (clone_name, scaler)
+                          with
+                          | Error e ->
+                              (* this is fine because on the next cycle, when stats are received with the clone name, 
+                            it will correct itself and be added to the group. we should cancel the cooldown here.*)
+                              Lwt.return_error
+                                (Fmt.str "Error registering clone %s: %s"
+                                   (Configuration.name_to_str clone_name)
+                                   e)
+                          | Ok spawn_group ->
+                              (* TODO Add new clone to load balancer pool *)
+                              put_group ~user_name ~unikernel_name spawn_group;
+                              Lwt.return_ok ()))
                   | Ok w ->
                       Logs.err (fun m ->
                           m "albatross returned: %a"
@@ -3135,6 +3156,7 @@ struct
       (`Unikernel_cmd `Unikernel_destroy)
     >>= function
     | Error err ->
+        (* TODO: remove cooldown if destroying the clone fails. *)
         Log.err (fun m ->
             m "Error pruning unikernel %s: %s"
               (Configuration.name_to_str clone_to_kill)
@@ -3160,7 +3182,7 @@ struct
                     m "Succesfully pruned %s"
                       (Configuration.name_to_str clone_to_kill));
 
-                (* TODO: remove clone's ip address from load balancer *)
+                (* TODO: remove clone's ip address from load balancer. *)
 
                 (* calling put_group here with post_prune_group means we pass back 
                    the groups state when prune_clone was called even though new metrics
@@ -3213,30 +3235,15 @@ struct
         | Autoscaler.Overloaded scaler -> (
             match Autoscaler.Cluster_manager.next_clone_name group with
             | Error (`Msg e) -> Lwt.return_error (Fmt.str "Error: %s" e)
-            | Ok next_name -> (
-                match
-                  Autoscaler.Cluster_manager.register_clone group
-                    (next_name, scaler)
-                with
-                | Error e ->
-                    Lwt.return_error
-                      (Fmt.str "Error registering clone %s: %s"
-                         (Configuration.name_to_str next_name)
-                         e)
-                | Ok spawn_group ->
-                    put_group ~user_name ~unikernel_name spawn_group;
-                    (* TODO
-                       1) Deploy new clone with name next_name
-                       2) Add new clone to load balancer pool
-                    *)
-                    Log.info (fun m ->
-                        m "%s/%s: overloaded (%d%%), spawning new clone: %s"
-                          (Configuration.name_to_str user_name)
-                          (Configuration.name_to_str unikernel_name)
-                          scaler.last_cpu_usage
-                          (Configuration.name_to_str next_name));
-                    spawn_clone stack store albatross ~unikernel_name
-                      ~clone_name:next_name ~user_name))
+            | Ok next_name ->
+                Log.info (fun m ->
+                    m "%s/%s: overloaded (%d%%), spawning new clone: %s"
+                      (Configuration.name_to_str user_name)
+                      (Configuration.name_to_str unikernel_name)
+                      scaler.last_cpu_usage
+                      (Configuration.name_to_str next_name));
+                spawn_clone stack store albatross ~unikernel_name
+                  ~clone_name:next_name ~user_name group scaler)
         | Autoscaler.Underloaded (clone_to_kill, scaler) ->
             Log.info (fun m ->
                 m "[%s/%s]: underloaded (%d%%), pruning: %s"

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3075,14 +3075,6 @@ struct
                      -> (unikernel_device, Some host_device, None))
                   unikernel.bridges
               in
-              let argv =
-                let name_arg =
-                  "--name=" ^ Configuration.name_to_str unikernel_name
-                in
-                match unikernel.argv with
-                | None -> Some [ name_arg ]
-                | Some args -> Some (name_arg :: args)
-              in
               least_used_cpuid stack albatross user_name >>= function
               | Error err -> Lwt.return_error err
               | Ok cpuid -> (
@@ -3110,7 +3102,7 @@ struct
                           add_name = true;
                           bridges;
                           (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
-                          argv;
+                          argv = unikernel.argv;
                           numcpus = unikernel.numcpus;
                           linux_boot_partition = unikernel.linux_boot_partition;
                           compressed;

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3101,7 +3101,9 @@ struct
                   let push () = Lwt_stream.get data_stream in
                   Albatross_state.query_unikernel_binary stack albatross
                     ~domain:user_name ~name:unikernel_name (fun binary_string ->
-                      Ok (push_chunks (Some binary_string)))
+                      push_chunks (Some binary_string);
+                      push_chunks None;
+                      Ok ())
                   >>= function
                   | Error err ->
                       put_group ~user_name ~unikernel_name
@@ -3127,11 +3129,19 @@ struct
                           | Error e ->
                               (* this is fine because on the next cycle, when stats are received with the clone name, 
                             it will correct itself and be added to the group. we should cancel the cooldown here.*)
+                              Log.err (fun m ->
+                                  m "Error registering clone %s: %s"
+                                    (Configuration.name_to_str clone_name)
+                                    e);
                               Lwt.return_error
                                 (Fmt.str "Error registering clone %s: %s"
                                    (Configuration.name_to_str clone_name)
                                    e)
                           | Ok spawn_group ->
+                              Log.debug (fun m ->
+                                  m "Successfully cloned %s to %s"
+                                    (Configuration.name_to_str unikernel_name)
+                                    (Configuration.name_to_str clone_name));
                               (* TODO Add new clone to load balancer pool *)
                               put_group ~user_name ~unikernel_name spawn_group;
                               Lwt.return_ok ())))))

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3079,9 +3079,29 @@ struct
               least_used_cpuid stack albatross user_name >>= function
               | Error err -> Lwt.return_error err
               | Ok cpuid -> (
-                  Albatross_state.query stack albatross ~domain:user_name
-                    ~name:unikernel_name
-                    (`Unikernel_cmd (`Unikernel_get 4))
+                  let config : Vmm_core.Unikernel.config =
+                    {
+                      typ = unikernel.typ;
+                      fail_behaviour = unikernel.fail_behaviour;
+                      startup = unikernel.startup;
+                      memory = unikernel.memory;
+                      block_devices = [];
+                      add_name = true;
+                      bridges;
+                      (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
+                      argv = unikernel.argv;
+                      numcpus = unikernel.numcpus;
+                      linux_boot_partition = unikernel.linux_boot_partition;
+                      compressed = true;
+                      image = "";
+                      cpuids = Vmm_core.IS.singleton cpuid;
+                    }
+                  in
+                  let data_stream, push_chunks = Lwt_stream.create () in
+                  let push () = Lwt_stream.get data_stream in
+                  Albatross_state.query_unikernel_binary stack albatross
+                    ~domain:user_name ~name:unikernel_name (fun binary_string ->
+                      Ok (push_chunks (Some binary_string)))
                   >>= function
                   | Error err ->
                       put_group ~user_name ~unikernel_name
@@ -3091,32 +3111,7 @@ struct
                             (Configuration.name_to_str unikernel_name)
                             err);
                       Lwt.return_error err
-                  | Ok
-                      ( _hdr,
-                        `Success (`Unikernel_image (compressed, binary_string))
-                      ) -> (
-                      let config : Vmm_core.Unikernel.config =
-                        {
-                          typ = unikernel.typ;
-                          fail_behaviour = unikernel.fail_behaviour;
-                          startup = unikernel.startup;
-                          memory = unikernel.memory;
-                          block_devices = [];
-                          add_name = true;
-                          bridges;
-                          (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
-                          argv = unikernel.argv;
-                          numcpus = unikernel.numcpus;
-                          linux_boot_partition = unikernel.linux_boot_partition;
-                          compressed;
-                          image = binary_string;
-                          cpuids = Vmm_core.IS.singleton cpuid;
-                        }
-                      in
-                      let data_stream, push_chunks = Lwt_stream.create () in
-                      let push () = Lwt_stream.get data_stream in
-                      push_chunks (Some binary_string);
-                      push_chunks None;
+                  | Ok () -> (
                       force_create_unikernel stack albatross
                         ~unikernel_name:clone_name ~push config user
                       >>= function
@@ -3139,16 +3134,7 @@ struct
                           | Ok spawn_group ->
                               (* TODO Add new clone to load balancer pool *)
                               put_group ~user_name ~unikernel_name spawn_group;
-                              Lwt.return_ok ()))
-                  | Ok w ->
-                      Logs.err (fun m ->
-                          m "albatross returned: %a"
-                            (Vmm_commands.pp_wire ~verbose:true)
-                            w);
-                      Lwt.return_error
-                        (Fmt.str "Expected unikernel binary, but got %a"
-                           (Vmm_commands.pp_wire ~verbose:false)
-                           w))))
+                              Lwt.return_ok ())))))
 
   let prune_clone stack albatross group ~unikernel_name ~clone_to_kill
       ~user_name =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3086,7 +3086,7 @@ struct
                           (fun arg ->
                             String.split_on_char ' ' arg
                             |> List.filter (fun s ->
-                                   not (String.starts_with ~prefix:"--name=" s))
+                                not (String.starts_with ~prefix:"--name=" s))
                             |> String.concat " ")
                           args
                         |> List.filter (fun s -> s <> ""))

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -3079,6 +3079,16 @@ struct
               least_used_cpuid stack albatross user_name >>= function
               | Error err -> Lwt.return_error err
               | Ok cpuid -> (
+                  let argv =
+                    Option.fold unikernel.argv ~none:None ~some:(fun arg ->
+                        Some
+                          (List.fold_left
+                             (fun acc arg ->
+                               if String.starts_with ~prefix:"--name=" arg then
+                                 acc
+                               else arg :: acc)
+                             [] arg))
+                  in
                   let config : Vmm_core.Unikernel.config =
                     {
                       typ = unikernel.typ;
@@ -3089,7 +3099,7 @@ struct
                       add_name = true;
                       bridges;
                       (* we assume for unikernels which are scaled, their ip is configured via DNSvizor *)
-                      argv = unikernel.argv;
+                      argv;
                       numcpus = unikernel.numcpus;
                       linux_boot_partition = unikernel.linux_boot_partition;
                       compressed = true;


### PR DESCRIPTION
In this PR, when it has been determined by the autoscaling module that a vm is overloaded, we spawn a new clone. 
- We first get the configuration of the primary vm,
- Then we check if it has any block devices. At the moment we can't scale vms which have a block device, as block devices can't be shared by multiple unikernels.
- If the unikernel has no block device, then we construct a config for the new clone:
     - we remove the mac addresses of the bridges, so the clone is issued new mac addresses
     - we assume we have DNSvizor running on any network interfaces so IP's get assigned
     - we add to the arguments, `--name=<primary_name> so DNSvizor knows to register the ip correctly