### PR TITLE
Restart unikernels with modified arguments

### DIFF
--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -409,3 +409,39 @@ let config_to_json (cfg : Vmm_core.Unikernel.config) =
           ~some:(fun s -> `String s)
           cfg.linux_boot_partition );
     ]
+
+let unikernel_info_to_arguments_json info =
+  `Assoc
+    [
+      ("typ", `String (typ info.Vmm_core.Unikernel.typ));
+      ("fail_behaviour", fail_behaviour info.fail_behaviour);
+      ("startup", `Int (Option.fold ~none:50 ~some:Fun.id info.startup));
+      (* add_name is not found in Vmm_core.Unikernel.info *)
+      ("add_name", `Bool false);
+      ("cpuids", cpuids info.cpuids);
+      ("memory", memory info.memory);
+      ("block_devices", block_devices info.block_devices);
+      ("bridges", bridges info.bridges);
+      ("arguments", argv info.argv);
+      ("numcpus", `Int info.numcpus);
+      ( "linux_boot_partition",
+        `String (Option.fold ~none:"" ~some:Fun.id info.linux_boot_partition) );
+    ]
+
+let arguments_of_json str =
+  match config_of_json str with
+  | Ok config ->
+      Ok
+        {
+          Vmm_core.Unikernel.fail_behaviour = config.fail_behaviour;
+          add_name = config.add_name;
+          startup = config.startup;
+          cpuids = config.cpuids;
+          memory = config.memory;
+          block_devices = config.block_devices;
+          bridges = config.bridges;
+          argv = config.argv;
+          numcpus = config.numcpus;
+          linux_boot_partition = config.linux_boot_partition;
+        }
+  | Error err -> Error err

--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -17,32 +17,31 @@ let memory m = `Int m
 let argv args =
   `List (List.map (fun a -> `String a) (Option.value ~default:[] args))
 
-let unikernel_info (unikernel_name, info) =
-  let block_devices bs =
-    let block
-        { Vmm_core.Unikernel.unikernel_device; host_device; sector_size; size }
-        =
-      `Assoc
-        [
-          ("name", `String unikernel_device);
-          ("host_device", `String host_device);
-          ("sector_size", `Int sector_size);
-          ("size", `Int size);
-        ]
-    in
-    `List (List.map block bs)
-  and bridges bs =
-    let bridge
-        ({ Vmm_core.Unikernel.unikernel_device; host_device; _ } :
-          Vmm_core.Unikernel.net_info) =
-      `Assoc
-        [
-          ("name", `String unikernel_device);
-          ("host_device", `String host_device);
-        ]
-    in
-    `List (List.map bridge bs)
+let block_devices bs =
+  let block
+      { Vmm_core.Unikernel.unikernel_device; host_device; sector_size; size } =
+    `Assoc
+      [
+        ("name", `String unikernel_device);
+        ("host_device", `String host_device);
+        ("sector_size", `Int sector_size);
+        ("size", `Int size);
+      ]
   in
+  `List (List.map block bs)
+
+let bridges bs =
+  let bridge
+      ({ Vmm_core.Unikernel.unikernel_device; host_device; _ } :
+        Vmm_core.Unikernel.net_info) =
+    `Assoc
+      [
+        ("name", `String unikernel_device); ("host_device", `String host_device);
+      ]
+  in
+  `List (List.map bridge bs)
+
+let unikernel_info (unikernel_name, info) =
   `Assoc
     [
       ( "name",
@@ -358,6 +357,8 @@ let config_of_json str =
       linux_boot_partition;
     }
 
+let typ typ = match typ with `Solo5 -> "solo5" | `BHyve -> "bhyve"
+
 let config_to_json (cfg : Vmm_core.Unikernel.config) =
   let block_devices bs =
     let block (name, host_device, sector_size) =
@@ -392,10 +393,9 @@ let config_to_json (cfg : Vmm_core.Unikernel.config) =
     in
     `List (List.map bridge bs)
   in
-  let typ = match cfg.typ with `Solo5 -> "solo5" | `BHyve -> "bhyve" in
   `Assoc
     [
-      ("typ", `String typ);
+      ("typ", `String (typ cfg.typ));
       ("compressed", `Bool cfg.compressed);
       ("fail_behaviour", fail_behaviour cfg.fail_behaviour);
       ("cpuids", cpuids cfg.cpuids);

--- a/albatross_json.ml
+++ b/albatross_json.ml
@@ -357,7 +357,7 @@ let config_of_json str =
       linux_boot_partition;
     }
 
-let typ typ = match typ with `Solo5 -> "solo5" | `BHyve -> "bhyve"
+let typ = function `Solo5 -> "solo5" | `BHyve -> "bhyve"
 
 let config_to_json (cfg : Vmm_core.Unikernel.config) =
   let block_devices bs =
@@ -417,7 +417,7 @@ let unikernel_info_to_arguments_json info =
       ("fail_behaviour", fail_behaviour info.fail_behaviour);
       ("startup", `Int (Option.fold ~none:50 ~some:Fun.id info.startup));
       (* add_name is not found in Vmm_core.Unikernel.info *)
-      ("add_name", `Bool false);
+      ("add_name", `Bool true);
       ("cpuids", cpuids info.cpuids);
       ("memory", memory info.memory);
       ("block_devices", block_devices info.block_devices);

--- a/assets/main.js
+++ b/assets/main.js
@@ -1370,3 +1370,18 @@ window.mapFields = function (field_id, detail, options) {
 	}
 	return reqs.map(n => ({ title: n, selected: '' }));
 };
+
+function parseXhrResponse(xhr) {
+	let res = {};
+	try {
+		res = JSON.parse(xhr.responseText);
+		if (res.success) {
+			postAlert("bg-primary-300", "Succesful");
+			setTimeout(() => window.location.reload(), 1000);
+		} else {
+			postAlert("bg-secondary-300", res.data);
+		}
+	} catch (error) {
+		postAlert("bg-secondary-300", error);
+	}
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -533,29 +533,6 @@ async function deployUnikernel(albatross_instance) {
 	}
 }
 
-async function restartUnikernel(unikernel_name, instance_name) {
-	try {
-		const molly_csrf = document.getElementById("molly-csrf").value;
-		const response = await fetch(`/api/unikernel/restart`, {
-			method: 'POST',
-			body: JSON.stringify({ "name": unikernel_name, "molly_csrf": molly_csrf, "albatross_instance": instance_name }),
-			headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }
-		})
-
-		const data = await response.json();
-		if (data.status === 200) {
-			postAlert("bg-primary-300", `Successful: ${data.data}`);
-			setTimeout(function () {
-				window.location.href = "/dashboard";
-			}, 2000);
-		} else {
-			postAlert("bg-secondary-300", `Error. Restarting ${name} returned ${data.data}.`);
-		}
-	} catch (error) {
-		postAlert("bg-secondary-300", error);
-	}
-}
-
 async function destroyUnikernel(unikernel_name, instance_name) {
 	try {
 		const molly_csrf = document.getElementById("molly-csrf").value;

--- a/header_layout.ml
+++ b/header_layout.ml
@@ -25,6 +25,8 @@ let header ?(page_title = "Mollymawk") ~icon () =
               a_crossorigin `Anonymous;
             ]
           (txt "");
+        (* add an htmx extension which lets us submit json from forms, so we can maintain using application/json that should work for the UI and for the API system *)
+        script ~a:[ a_src "https://unpkg.com/htmx-ext-form-json" ] (txt "");
         (* by default htmx doesn't swap on error responses. 
         this allows it to swap for any error code. 
         we need this to display errors to the user

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2053,59 +2053,35 @@ struct
         Middleware.http_response reqd
           ~data:(`String "Couldn't find unikernel name in json") `Bad_request
 
-  let unikernel_restart stack albatross_instances (user : User_model.user)
-      json_dict reqd =
+  let unikernel_restart stack albatross unikernel (user : User_model.user)
+      multipart_body reqd =
     (* TODO use uuid in the future *)
-    match
-      Utils.Json.(get "name" json_dict, get "albatross_instance" json_dict)
-    with
-    | Some (`String unikernel_name), Some (`String instance_name) -> (
-        match
-          ( Configuration.name_of_str instance_name,
-            Configuration.name_of_str unikernel_name )
-        with
-        | Ok instance_name, Ok unikernel_name -> (
-            match
-              Albatross_state.find_instance_by_name albatross_instances
-                instance_name
-            with
-            | Ok albatross -> (
-                Albatross_state.query stack albatross ~domain:user.name
-                  ~name:unikernel_name
-                  (`Unikernel_cmd (`Unikernel_restart None))
-                >>= function
-                | Error msg ->
-                    Middleware.http_response reqd
-                      ~data:(`String ("Error querying albatross: " ^ msg))
-                      `Internal_server_error
-                | Ok (_hdr, res) -> (
-                    Albatross.set_online albatross;
-                    match Albatross_json.res res with
-                    | Ok res -> Middleware.http_response reqd ~data:res `OK
-                    | Error (`String err) ->
-                        Middleware.http_response reqd ~data:(`String err)
-                          `Internal_server_error))
-            | _ ->
-                Logs.err (fun m ->
-                    m "Error finding albatross instance %s"
-                      (Configuration.name_to_str instance_name));
-                Middleware.http_response reqd
-                  ~data:
-                    (`String
-                       ("Error finding albatross instance: "
-                       ^ Configuration.name_to_str instance_name))
-                  `Not_found)
-        | Error (`Msg err), _ ->
+    match Map.find_opt "arguments" multipart_body with
+    | Some (_, arguments_str) -> (
+        match Albatross_json.arguments_of_json arguments_str with
+        | Error (`Msg err) ->
             Middleware.http_response reqd
-              ~data:(`String ("Error converting instance name: " ^ err))
+              ~data:(`String ("Error parsing arguments: " ^ err))
               `Bad_request
-        | _, Error (`Msg err) ->
-            Middleware.http_response reqd
-              ~data:(`String ("Error converting unikernel name: " ^ err))
-              `Bad_request)
+        | Ok arguments -> (
+            Albatross_state.query stack albatross ~domain:user.name
+              ~name:unikernel
+              (`Unikernel_cmd (`Unikernel_restart (Some arguments)))
+            >>= function
+            | Error msg ->
+                Middleware.http_response reqd
+                  ~data:(`String ("Error querying albatross: " ^ msg))
+                  `Internal_server_error
+            | Ok (_hdr, res) -> (
+                Albatross.set_online albatross;
+                match Albatross_json.res res with
+                | Ok res -> Middleware.http_response reqd ~data:res `OK
+                | Error (`String err) ->
+                    Middleware.http_response reqd ~data:(`String err)
+                      `Internal_server_error)))
     | _ ->
         Middleware.http_response reqd
-          ~data:(`String "Couldn't find unikernel name in json") `Bad_request
+          ~data:(`String "Couldn't find arguments in request body") `Bad_request
 
   let unikernel_create stack albatross_instances http_client token_or_cookie
       (user : User_model.user) reqd =
@@ -3580,8 +3556,10 @@ struct
         | "/api/unikernel/restart" ->
             check_meth `POST (fun () ->
                 authenticate ~check_token:true ~api_meth:true store reqd
-                  (extract_json_csrf_token
-                     (unikernel_restart stack !albatross_instances)))
+                  (albatross_instance req.H1.Request.target (fun albatross ->
+                       unikernel (fun unikernel_name ->
+                           extract_multipart_csrf_token
+                             (unikernel_restart stack albatross unikernel_name)))))
         | "/api/unikernel/console" ->
             check_meth `GET (fun () ->
                 authenticate store reqd ~check_token:true ~api_meth:true

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2056,6 +2056,22 @@ struct
   let unikernel_restart stack albatross unikernel (user : User_model.user)
       multipart_body reqd =
     (* TODO use uuid in the future *)
+    let restart ?arguments () =
+      Albatross_state.query stack albatross ~domain:user.name ~name:unikernel
+        (`Unikernel_cmd (`Unikernel_restart arguments))
+      >>= function
+      | Error msg ->
+          Middleware.http_response reqd
+            ~data:(`String ("Error querying albatross: " ^ msg))
+            `Internal_server_error
+      | Ok (_hdr, res) -> (
+          Albatross.set_online albatross;
+          match Albatross_json.res res with
+          | Ok res -> Middleware.http_response reqd ~data:res `OK
+          | Error (`String err) ->
+              Middleware.http_response reqd ~data:(`String err)
+                `Internal_server_error)
+    in
     match Map.find_opt "arguments" multipart_body with
     | Some (_, arguments_str) -> (
         match Albatross_json.arguments_of_json arguments_str with
@@ -2063,25 +2079,8 @@ struct
             Middleware.http_response reqd
               ~data:(`String ("Error parsing arguments: " ^ err))
               `Bad_request
-        | Ok arguments -> (
-            Albatross_state.query stack albatross ~domain:user.name
-              ~name:unikernel
-              (`Unikernel_cmd (`Unikernel_restart (Some arguments)))
-            >>= function
-            | Error msg ->
-                Middleware.http_response reqd
-                  ~data:(`String ("Error querying albatross: " ^ msg))
-                  `Internal_server_error
-            | Ok (_hdr, res) -> (
-                Albatross.set_online albatross;
-                match Albatross_json.res res with
-                | Ok res -> Middleware.http_response reqd ~data:res `OK
-                | Error (`String err) ->
-                    Middleware.http_response reqd ~data:(`String err)
-                      `Internal_server_error)))
-    | _ ->
-        Middleware.http_response reqd
-          ~data:(`String "Couldn't find arguments in request body") `Bad_request
+        | Ok arguments -> restart ~arguments ())
+    | None -> restart ()
 
   let unikernel_create stack albatross_instances http_client token_or_cookie
       (user : User_model.user) reqd =

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -2054,7 +2054,7 @@ struct
           ~data:(`String "Couldn't find unikernel name in json") `Bad_request
 
   let unikernel_restart stack albatross unikernel (user : User_model.user)
-      multipart_body reqd =
+      json_dict reqd =
     (* TODO use uuid in the future *)
     let restart ?arguments () =
       Albatross_state.query stack albatross ~domain:user.name ~name:unikernel
@@ -2072,14 +2072,17 @@ struct
               Middleware.http_response reqd ~data:(`String err)
                 `Internal_server_error)
     in
-    match Map.find_opt "arguments" multipart_body with
-    | Some (_, arguments_str) -> (
-        match Albatross_json.arguments_of_json arguments_str with
+    match Utils.Json.get "arguments" json_dict with
+    | Some (`String arguments) -> (
+        match Albatross_json.arguments_of_json arguments with
         | Error (`Msg err) ->
             Middleware.http_response reqd
               ~data:(`String ("Error parsing arguments: " ^ err))
               `Bad_request
         | Ok arguments -> restart ~arguments ())
+    | Some _ ->
+        Middleware.http_response reqd
+          ~data:(`String "Arguments is expected to be a string") `Bad_request
     | None -> restart ()
 
   let unikernel_create stack albatross_instances http_client token_or_cookie
@@ -3557,7 +3560,7 @@ struct
                 authenticate ~check_token:true ~api_meth:true store reqd
                   (albatross_instance req.H1.Request.target (fun albatross ->
                        unikernel (fun unikernel_name ->
-                           extract_multipart_csrf_token
+                           extract_json_csrf_token
                              (unikernel_restart stack albatross unikernel_name)))))
         | "/api/unikernel/console" ->
             check_meth `GET (fun () ->

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -1,3 +1,47 @@
+let restart_unikernel_dialog ~unikernel_name ~instance_name info =
+  Tyxml_html.(
+    div
+      ~a:[ a_class [ "p-4" ]; a_id "restart-container" ]
+      [
+        form
+          ~a:
+            [
+              a_enctype "multipart/form-data";
+              Unsafe.string_attrib "hx-post"
+                (Fmt.str "/api/unikernel/restart?instance=%s&unikernel=%s"
+                   (Configuration.name_to_str instance_name)
+                   (Configuration.name_to_str unikernel_name));
+              Unsafe.string_attrib "hx-include" "#molly-csrf";
+              Unsafe.string_attrib "hx-target" "#restart-container";
+              Unsafe.string_attrib "hx-swap" "innerHTML";
+            ]
+          [
+            Utils.switch_button ~switch_id:"restart-dialog"
+              ~switch_label:"Modify unikernel arguments"
+              (textarea
+                 ~a:
+                   [
+                     a_rows 25;
+                     a_cols 80;
+                     a_required ();
+                     a_name "arguments";
+                     a_id "unikernel-arguments";
+                     a_class
+                       [
+                         "px-3 py-3 rounded-xl border focus:outline-none \
+                          font-mono";
+                       ];
+                   ]
+                 (txt
+                    (Albatross_json.unikernel_info_to_arguments_json info
+                    |> Yojson.Basic.pretty_to_string)));
+            Utils.button_component ~btn_type:`Primary_outlined
+              ~content:(txt "Restart")
+              ~attribs:[ a_button_type `Submit; a_id "restart-button" ]
+              ();
+          ];
+      ])
+
 let unikernel_single_layout ~unikernel_name ~instance_name
     ?(last_update_time = None) ~current_time ~max_allowed unikernel
     scaling_policy =
@@ -121,17 +165,14 @@ let unikernel_single_layout ~unikernel_name ~instance_name
                       [
                         div
                           [
-                            Utils.button_component
-                              ~attribs:
-                                [
-                                  a_onclick
-                                    ("restartUnikernel('" ^ unikernel_name_str
-                                   ^ "', '"
-                                    ^ Configuration.name_to_str instance_name
-                                    ^ "')");
-                                ]
-                              ~content:(txt "Restart")
-                              ~btn_type:`Primary_outlined ();
+                            Modal_dialog.modal_dialog
+                              ~modal_title:"Restart Unikernel"
+                              ~button_type:`Primary_outlined
+                              ~button_content:(txt "Restart")
+                              ~content:
+                                (restart_unikernel_dialog ~unikernel_name
+                                   ~instance_name data)
+                              ();
                           ];
                         div
                           [

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -6,11 +6,11 @@ let restart_unikernel_dialog ~unikernel_name ~instance_name info =
         form
           ~a:
             [
-              a_enctype "multipart/form-data";
               Unsafe.string_attrib "hx-post"
                 (Fmt.str "/api/unikernel/restart?instance=%s&unikernel=%s"
                    (Configuration.name_to_str instance_name)
                    (Configuration.name_to_str unikernel_name));
+              Unsafe.string_attrib "hx-ext" "form-json";
               Unsafe.string_attrib "hx-include" "#molly-csrf";
               Unsafe.string_attrib "hx-target" "#restart-container";
               Unsafe.string_attrib "hx-swap" "none";

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -13,7 +13,9 @@ let restart_unikernel_dialog ~unikernel_name ~instance_name info =
                    (Configuration.name_to_str unikernel_name));
               Unsafe.string_attrib "hx-include" "#molly-csrf";
               Unsafe.string_attrib "hx-target" "#restart-container";
-              Unsafe.string_attrib "hx-swap" "innerHTML";
+              Unsafe.string_attrib "hx-swap" "none";
+              Unsafe.string_attrib "hx-on::after-request"
+                "window.parseXhrResponse(event.detail.xhr)";
             ]
           [
             Utils.switch_button ~switch_id:"restart-dialog"

--- a/unikernel_single.ml
+++ b/unikernel_single.ml
@@ -16,6 +16,9 @@ let restart_unikernel_dialog ~unikernel_name ~instance_name info =
               Unsafe.string_attrib "hx-swap" "none";
               Unsafe.string_attrib "hx-on::after-request"
                 "window.parseXhrResponse(event.detail.xhr)";
+              Unsafe.string_attrib "hx-on::config-request"
+                "if (!document.getElementById('restart-dialog').checked) \
+                 delete event.detail.parameters['arguments'];";
             ]
           [
             Utils.switch_button ~switch_id:"restart-dialog"


### PR DESCRIPTION
We can restart a unikernel and modify it's json arguments. 
In the future, we can have a UI builder which takes such a json and renders UI elements similar to what the deploy form looks like (see https://github.com/robur-coop/mollymawk/issues/258)


Currently, the memory value gets ignored during the restart: see https://github.com/robur-coop/albatross/issues/275

Closes https://github.com/robur-coop/mollymawk/issues/35